### PR TITLE
fix: adjust y-axis label position to align with tick marks

### DIFF
--- a/src/rendering/axes.js
+++ b/src/rendering/axes.js
@@ -77,7 +77,7 @@ export function drawTimeAxis(instance) {
     // Label (in the left margin)
     const label = createSVGText(
       margins.left - 8,
-      yPos + 4, // Slight offset for better alignment
+      yPos - 5, // Align with tick mark position
       timeValue.toFixed(1) + 's',
       'gram-frame-axis-label',
       'end'


### PR DESCRIPTION
Fixes #36