### PR TITLE
feat: increase decimal precision for frequency and harmonic rate displays

### DIFF
--- a/src/components/HarmonicPanel.js
+++ b/src/components/HarmonicPanel.js
@@ -79,7 +79,7 @@ function updateHarmonicRow(row, harmonicSet, instance) {
   // Update spacing cell if changed
   const spacingCell = row.cells[1]
   if (spacingCell) {
-    const newSpacing = harmonicSet.spacing.toFixed(1)
+    const newSpacing = harmonicSet.spacing.toFixed(2)
     if (spacingCell.textContent !== newSpacing) {
       spacingCell.textContent = newSpacing
     }
@@ -90,9 +90,9 @@ function updateHarmonicRow(row, harmonicSet, instance) {
   if (rateCell) {
     let rate
     if (instance.state.cursorPosition && instance.state.cursorPosition.freq > 0) {
-      rate = (instance.state.cursorPosition.freq / harmonicSet.spacing).toFixed(2)
+      rate = (instance.state.cursorPosition.freq / harmonicSet.spacing).toFixed(3)
     } else {
-      rate = '5.00' // Representative rate for 5th harmonic
+      rate = '5.000' // Representative rate for 5th harmonic
     }
     
     if (rateCell.textContent !== rate) {
@@ -149,7 +149,7 @@ function createHarmonicRow(harmonicSet, instance, index) {
   // Spacing cell
   const spacingCell = document.createElement('td')
   spacingCell.className = 'gram-frame-harmonic-spacing'
-  spacingCell.textContent = harmonicSet.spacing.toFixed(1)
+  spacingCell.textContent = harmonicSet.spacing.toFixed(2)
   row.appendChild(spacingCell)
   
   // Rate cell
@@ -157,9 +157,9 @@ function createHarmonicRow(harmonicSet, instance, index) {
   rateCell.className = 'gram-frame-harmonic-rate'
   let rate
   if (instance.state.cursorPosition && instance.state.cursorPosition.freq > 0) {
-    rate = (instance.state.cursorPosition.freq / harmonicSet.spacing).toFixed(2)
+    rate = (instance.state.cursorPosition.freq / harmonicSet.spacing).toFixed(3)
   } else {
-    rate = '5.00'
+    rate = '5.000'
   }
   rateCell.textContent = rate
   row.appendChild(rateCell)

--- a/src/main.js
+++ b/src/main.js
@@ -375,7 +375,7 @@ export class GramFrame {
     if (this.freqLED) {
       const freqValue = this.freqLED.querySelector('.gram-frame-led-value')
       if (freqValue) {
-        freqValue.textContent = dataCoords.freq.toFixed(1)
+        freqValue.textContent = dataCoords.freq.toFixed(2)
       }
     }
   }

--- a/src/modes/analysis/AnalysisMode.js
+++ b/src/modes/analysis/AnalysisMode.js
@@ -505,7 +505,7 @@ export class AnalysisMode extends BaseMode {
     // Update frequency cell (third cell)
     const freqCell = row.cells[2]
     if (freqCell) {
-      const newFreq = marker.freq.toFixed(1)
+      const newFreq = marker.freq.toFixed(2)
       if (freqCell.textContent !== newFreq) {
         freqCell.textContent = newFreq
       }
@@ -568,7 +568,7 @@ export class AnalysisMode extends BaseMode {
       
       // Frequency cell
       const freqCell = document.createElement('td')
-      freqCell.textContent = marker.freq.toFixed(1)
+      freqCell.textContent = marker.freq.toFixed(2)
       row.appendChild(freqCell)
       
       // Delete button cell


### PR DESCRIPTION
## Summary

Increases decimal precision for frequency and harmonic rate displays to provide more accurate measurements in the spectrogram analysis tool.

## Changes Made

- **Frequency Display:** Increased frequency precision to 2 decimal places (`toFixed(2)`) in main cursor display
- **Harmonic Spacing:** Set harmonic spacing display to 2 decimal places for consistency
- **Harmonic Rate:** Increased harmonic rate precision to 3 decimal places (`toFixed(3)`) for more detailed ratios
- **Analysis Markers:** Updated marker frequency display to 2 decimal places in analysis mode

## Test Plan

- [x] Frequency values display with 2 decimal places in LED display
- [x] Harmonic spacing shows 2 decimal places in harmonic panel
- [x] Harmonic rates show 3 decimal places for precise ratio calculations
- [x] Analysis mode markers display frequencies with 2 decimal places
- [x] All existing functionality preserved

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>