### PR TITLE
fix: reduce minimum harmonic spacing to 0.1Hz (closes #123)

### DIFF
--- a/src/modes/harmonics/HarmonicsMode.js
+++ b/src/modes/harmonics/HarmonicsMode.js
@@ -492,7 +492,7 @@ export class HarmonicsMode extends BaseMode {
     }
     
     // Ensure minimum spacing
-    initialSpacing = Math.max(initialSpacing, 1.0)
+    initialSpacing = Math.max(initialSpacing, 0.1)
     
     // Create the harmonic set immediately
     const harmonicSet = this.addHarmonicSet(dataCoords.time, initialSpacing)
@@ -561,7 +561,7 @@ export class HarmonicsMode extends BaseMode {
     newSpacing = currentPos.freq / clickedHarmonicNumber
     
     // Ensure minimum spacing
-    newSpacing = Math.max(newSpacing, 1.0)
+    newSpacing = Math.max(newSpacing, 0.1)
     
     // Allow vertical movement for both new creation and existing drags
     const deltaTime = currentPos.time - startPos.time

--- a/src/modes/harmonics/ManualHarmonicModal.js
+++ b/src/modes/harmonics/ManualHarmonicModal.js
@@ -21,9 +21,9 @@ export function showManualHarmonicModal(state, addHarmonicSet) {
     </div>
     <div class="gram-frame-modal-body">
       <label for="harmonic-spacing-input">Harmonic spacing (Hz):</label>
-      <input type="number" id="harmonic-spacing-input" min="1.0" step="0.1" placeholder="Enter spacing in Hz">
+      <input type="number" id="harmonic-spacing-input" min="0.1" step="0.1" placeholder="Enter spacing in Hz">
       <div class="gram-frame-modal-error" id="spacing-error" style="display: none; color: red; font-size: 12px; margin-top: 5px;">
-        Please enter a number ≥ 1.0
+        Please enter a number ≥ 0.1
       </div>
     </div>
     <div class="gram-frame-modal-footer">
@@ -44,7 +44,7 @@ export function showManualHarmonicModal(state, addHarmonicSet) {
   // Input validation
   const validateInput = () => {
     const value = parseFloat(spacingInput.value)
-    const isValid = !isNaN(value) && value >= 1.0
+    const isValid = !isNaN(value) && value >= 0.1
 
     if (spacingInput.value.trim() === '') {
       // Empty input - hide error, disable button
@@ -79,7 +79,7 @@ export function showManualHarmonicModal(state, addHarmonicSet) {
   // Add harmonic function
   function addHarmonic() {
     const spacing = parseFloat(spacingInput.value)
-    if (!isNaN(spacing) && spacing >= 1.0) {
+    if (!isNaN(spacing) && spacing >= 0.1) {
       // Determine anchor time: use cursor position if available, otherwise midpoint
       let anchorTime
       if (state.cursorPosition) {

--- a/src/utils/version.js
+++ b/src/utils/version.js
@@ -4,7 +4,7 @@
  */
 
 // This value is replaced automatically by the generation script.
-export const VERSION = '0.1.2'
+export const VERSION = '0.1.4'
 
 /**
  * Get the current version of GramFrame


### PR DESCRIPTION
## Summary
- Reduced minimum harmonic spacing from 1.0Hz to 0.1Hz to allow finer harmonic adjustments
- Updated both manual input modal and drag interaction handlers
- All existing tests pass without modification

## Changes
- Updated `ManualHarmonicModal.js` to accept minimum spacing of 0.1Hz
- Modified `HarmonicsMode.js` drag handlers to enforce 0.1Hz minimum instead of 1.0Hz
- Updated validation messages to reflect new minimum value

## Test plan
- [x] Manual testing with harmonics mode
- [x] Verified spacing can be set to 0.1Hz via manual input
- [x] Verified drag interactions respect 0.1Hz minimum
- [x] All automated tests pass (`yarn test`)

Fixes #123