### PR TITLE
fix: allow harmonic set deletion from table in any mode

### DIFF
--- a/src/components/HarmonicPanel.js
+++ b/src/components/HarmonicPanel.js
@@ -193,9 +193,7 @@ function createHarmonicRow(harmonicSet, instance, index) {
   deleteButton.addEventListener('click', (e) => {
     e.preventDefault()
     e.stopPropagation()
-    if (instance.currentMode && instance.currentMode.removeHarmonicSet) {
-      instance.currentMode.removeHarmonicSet(harmonicSet.id)
-    }
+    instance.removeHarmonicSet(harmonicSet.id)
   })
   
   return row

--- a/src/core/initialization/EventBindings.js
+++ b/src/core/initialization/EventBindings.js
@@ -9,7 +9,7 @@
 /// <reference path="../../types.js" />
 
 import { setupEventListeners, setupResizeObserver } from '../events.js'
-import { initializeKeyboardControl, setSelection, clearSelection, updateSelectionVisuals } from '../keyboardControl.js'
+import { initializeKeyboardControl, setSelection, clearSelection, updateSelectionVisuals, removeHarmonicSet } from '../keyboardControl.js'
 import { getGlobalStateListeners } from '../state.js'
 
 /**
@@ -30,6 +30,7 @@ export function setupAllEventListeners(instance) {
   instance.setSelection = (type, id, index) => setSelection(instance, type, id, index)
   instance.clearSelection = () => clearSelection(instance)
   instance.updateSelectionVisuals = () => updateSelectionVisuals(instance)
+  instance.removeHarmonicSet = (id) => removeHarmonicSet(instance, id)
 }
 
 /**

--- a/src/core/keyboardControl.js
+++ b/src/core/keyboardControl.js
@@ -8,6 +8,7 @@
 /// <reference path="../types.js" />
 
 import { notifyStateListeners } from './state.js'
+import { updateHarmonicPanelContent } from '../components/HarmonicPanel.js'
 
 /**
  * Movement increments in pixels
@@ -345,6 +346,36 @@ export function clearSelection(instance) {
   updateSelectionVisuals(instance)
   
   notifyStateListeners(instance.state, instance.stateListeners)
+}
+
+/**
+ * Remove a harmonic set by ID
+ * @param {GramFrame} instance - GramFrame instance
+ * @param {string} id - Harmonic set ID to remove
+ */
+export function removeHarmonicSet(instance, id) {
+  const setIndex = instance.state.harmonics.harmonicSets.findIndex(set => set.id === id)
+  if (setIndex !== -1) {
+    // Clear selection if removing the selected harmonic set
+    if (instance.state.selection.selectedType === 'harmonicSet' && 
+        instance.state.selection.selectedId === id) {
+      clearSelection(instance)
+    }
+    
+    instance.state.harmonics.harmonicSets.splice(setIndex, 1)
+    
+    // Update visual elements
+    if (instance.harmonicPanel) {
+      updateHarmonicPanelContent(instance.harmonicPanel, instance)
+    }
+    
+    // Trigger re-render of persistent features to remove the harmonic set
+    if (instance.featureRenderer) {
+      instance.featureRenderer.renderAllPersistentFeatures()
+    }
+    
+    notifyStateListeners(instance.state, instance.stateListeners)
+  }
 }
 
 

--- a/src/types.js
+++ b/src/types.js
@@ -283,6 +283,7 @@
  * @property {function(string, string, number): void} [setSelection] - Set selection
  * @property {function(): void} [clearSelection] - Clear selection  
  * @property {function(): void} [updateSelectionVisuals] - Update selection visuals
+ * @property {function(string): void} [removeHarmonicSet] - Remove harmonic set by ID
  * @property {function(): void} [createUnifiedLayout] - Create unified layout
  */
 


### PR DESCRIPTION
## Summary
- Move removeHarmonicSet functionality from HarmonicsMode to core instance method
- Allow harmonic sets to be deleted from the harmonics table regardless of current mode
- Maintain consistency with analysis markers which can be deleted in any mode

## Changes
- Added `removeHarmonicSet` function to `src/core/keyboardControl.js` 
- Export and assign as instance method via `EventBindings.js`
- Update `HarmonicPanel.js` to call instance method directly
- Add TypeScript type definition for the new method

## Test plan
- [x] All existing tests pass
- [x] TypeScript type checking passes
- [x] Manually tested deleting harmonics in Analysis, Harmonics, and Doppler modes
- [x] Verified harmonic panel updates correctly after deletion
- [x] Confirmed persistent features re-render properly

Fixes #125