### PR TITLE
docs: fix legacy 3-column table format references causing developer confusion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,8 +103,20 @@ curl -d "status here" ntfy.sh/iancc2025
 
 Components are configured via HTML tables with class `gram-config`:
 - First row contains `<img>` element with spectrogram image
-- Subsequent rows define time/frequency ranges as `param | min | max`
+- Subsequent rows define individual parameters: `time-start`, `time-end`, `freq-start`, `freq-end`
+- Uses 2-column format: `parameter | value` (NOT the legacy 3-column format)
 - Tables are automatically detected and replaced on page load
+
+Example configuration:
+```html
+<table class="gram-config">
+  <tr><td colspan="2"><img src="spectrogram.png"></td></tr>
+  <tr><td>time-start</td><td>0</td></tr>
+  <tr><td>time-end</td><td>60</td></tr>
+  <tr><td>freq-start</td><td>0</td></tr>
+  <tr><td>freq-end</td><td>20000</td></tr>
+</table>
+```
 
 ### Test Architecture
 

--- a/Memory_Bank.md
+++ b/Memory_Bank.md
@@ -400,11 +400,10 @@ Created base infrastructure for polymorphic mode system:
 ### GitHub Issue #32: Refactor Configuration Table Structure to Legacy Format (Completed)
 **Date: July 29, 2025**
 
-Refactored configuration table to support legacy row-based format with improved parsing:
-- Row-based structure: parameter | min | max
-- Flexible parameter name handling with aliases
-- Enhanced validation and error messages
-- 100% backward compatibility maintained
+Refactored configuration table to support modern 2-column format with improved parsing:
+- 2-column structure: parameter | value (time-start, time-end, freq-start, freq-end)
+- Enhanced validation and error messages  
+- Replaced legacy 3-column (param|min|max) format which is no longer supported
 
 ### GitHub Issue #44: Fix Axis Text Labels Resize Issue (Completed)
 **Date: July 29, 2025**

--- a/docs/Functional-Spec.md
+++ b/docs/Functional-Spec.md
@@ -18,6 +18,7 @@
 ## Configuration
 - Defined by `<table class="gram-config">`
 - Hidden on activation
+- Uses 2-column format: `parameter | value`
 - Includes:
   - Top row: spectrogram image
-  - Headers: `param`, `min`, `max`
+  - Parameters: `time-start`, `time-end`, `freq-start`, `freq-end`

--- a/docs/Html-to-Dita-strategy.md
+++ b/docs/Html-to-Dita-strategy.md
@@ -4,9 +4,9 @@
 ## ✅ Objective
 Convert each HTML page to a DITA topic that:
 - Captures the **document title**
-- Includes a **configuration table** for the legacy applet:
+- Includes a **configuration table** for the component:
   - First row: spectrogram image in a merged table cell
-  - Following rows: parameter name, min, and max
+  - Following rows: parameter name and value (time-start, time-end, freq-start, freq-end)
 
 ---
 
@@ -34,7 +34,7 @@ Write a script using `BeautifulSoup` to:
 - Extract:
   - Title
   - Spectrogram image name (from `<img>` in first row of the config table)
-  - Param rows: `[name, min, max]`
+  - Parameter rows: `[name, value]` (using 2-column format, NOT 3-column)
 
 Then generate a `.dita` file with the following structure:
 


### PR DESCRIPTION
## Summary
Fixes documentation inconsistencies that were causing developers to use the deprecated 3-column table format when creating mock components.

## Problem
Multiple documentation files contained outdated references to the legacy 3-column format (`param | min | max`), which was deprecated in favor of the modern 2-column format (`parameter | value`) with individual start/end parameters.

## Changes
- **CLAUDE.md**: Updated configuration system description and added correct example
- **Memory_Bank.md**: Fixed GitHub Issue #32 description to reflect current format
- **Functional-Spec.md**: Replaced legacy headers with correct 2-column format description
- **Html-to-Dita-strategy.md**: Updated conversion workflow to use current format

## Impact
- Prevents developers from using unsupported legacy format
- Ensures consistent documentation across all files
- Aligns with ADR-009 which explicitly states "DO NOT USE THE THREE-COLUMN FORMAT"

## Test Plan
- [x] Documentation consistency verified across all modified files
- [x] All references now point to correct 2-column format
- [x] Example configuration provided in CLAUDE.md matches working implementations