### PR TITLE
fix: implement placeholder version strategy for local development

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,22 @@ jobs:
           echo "🔍 Running type checking..."
           yarn typecheck
 
+      - name: Update version for release
+        run: |
+          echo "🏷️ Updating version.js with actual version from package.json..."
+          yarn generate-version
+          
+          # Verify version was updated correctly
+          VERSION_IN_FILE=$(grep "export const VERSION" src/utils/version.js | cut -d"'" -f2)
+          PACKAGE_VERSION="${{ steps.validate-tag.outputs.version }}"
+          
+          if [ "$VERSION_IN_FILE" != "$PACKAGE_VERSION" ]; then
+            echo "❌ Version mismatch: version.js has '$VERSION_IN_FILE', expected '$PACKAGE_VERSION'"
+            exit 1
+          fi
+          
+          echo "✅ Version updated successfully to $PACKAGE_VERSION"
+
       - name: Build standalone version
         run: |
           echo "🏗️ Building standalone version for file:// protocol compatibility..."

--- a/Memory_Bank.md
+++ b/Memory_Bank.md
@@ -5,6 +5,84 @@ GramFrame is a component for displaying and interacting with spectrograms. It pr
 
 ## Implementation Progress
 
+---
+**Agent:** Implementation Agent
+**Task Reference:** GitHub Issue #126 - Version.js Server-Only Update Implementation
+
+**Summary:**
+Implemented placeholder version strategy to prevent local builds from modifying version.js, requiring commits after version bumps. Version updates now occur only during release pipeline.
+
+**Details:**
+1. **Modified version.js placeholder strategy:**
+   - Changed VERSION constant from '0.1.4' to 'DEV' placeholder
+   - Updated comments to explain development vs release versioning
+   - Maintained identical API structure for compatibility
+
+2. **Updated package.json build scripts:**
+   - Removed `npm run generate-version &&` from `dev`, `build`, and `build:standalone` commands  
+   - Kept `generate-version` script intact for release pipeline usage
+   - Local builds now run directly with Vite, avoiding version file modifications
+
+3. **Enhanced release workflow (.github/workflows/release.yml):**
+   - Added "Update version for release" step after type checking, before building
+   - Step runs `yarn generate-version` to update version.js with actual package.json version
+   - Includes verification that version was updated correctly with error handling
+   - Ensures release builds contain correct version information
+
+4. **Verification testing:**
+   - Confirmed `yarn dev`, `yarn build`, and `yarn build:standalone` work without modifying version.js
+   - Tested `yarn generate-version` script functions correctly when called manually
+   - Verified git status shows no unwanted changes after local builds
+
+**Output/Result:**
+```javascript
+// src/utils/version.js - Key changes
+/**
+ * Version constants for GramFrame
+ * Uses placeholder during development, updated to actual version during releases
+ */
+
+// Placeholder version for development - updated automatically during release builds
+export const VERSION = 'DEV'
+```
+
+```json
+// package.json - Script modifications
+"scripts": {
+  "generate-version": "node scripts/generate-version.js",
+  "dev": "vite",
+  "build": "vite build", 
+  "build:standalone": "BUILD_STANDALONE=true vite build"
+}
+```
+
+```yaml
+# .github/workflows/release.yml - New step added
+- name: Update version for release
+  run: |
+    echo "🏷️ Updating version.js with actual version from package.json..."
+    yarn generate-version
+    
+    # Verify version was updated correctly
+    VERSION_IN_FILE=$(grep "export const VERSION" src/utils/version.js | cut -d"'" -f2)
+    PACKAGE_VERSION="${{ steps.validate-tag.outputs.version }}"
+    
+    if [ "$VERSION_IN_FILE" != "$PACKAGE_VERSION" ]; then
+      echo "❌ Version mismatch: version.js has '$VERSION_IN_FILE', expected '$PACKAGE_VERSION'"
+      exit 1
+    fi
+    
+    echo "✅ Version updated successfully to $PACKAGE_VERSION"
+```
+
+**Status:** Completed
+
+**Issues/Blockers:**
+None
+
+**Next Steps:**
+Ready for pull request creation. Implementation successfully addresses GitHub Issue #126 by eliminating the need to commit version.js changes after local development builds.
+
 ## Issue #88 Phase A-B - Refactor Large Files and Improve Module Boundaries - 2025-01-06
 
 **Task Reference:** GitHub Issue #88 - Refactor Large Files and Improve Module Boundaries

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "type": "module",
   "scripts": {
     "generate-version": "node scripts/generate-version.js",
-    "dev": "npm run generate-version && vite",
-    "build": "npm run generate-version && vite build",
-    "build:standalone": "npm run generate-version && BUILD_STANDALONE=true vite build",
+    "dev": "vite",
+    "build": "vite build",
+    "build:standalone": "BUILD_STANDALONE=true vite build",
     "test": "playwright test",
     "typecheck": "tsc --noEmit"
   },

--- a/prompts/tasks/Task_Issue_126.md
+++ b/prompts/tasks/Task_Issue_126.md
@@ -1,0 +1,80 @@
+# APM Task Assignment: Version.js Server-Only Update Implementation
+
+## 1. Agent Role & APM Context
+
+You are activated as an Implementation Agent within the Agentic Project Management (APM) framework for the GramFrame project. Your role is to execute assigned tasks diligently and log work meticulously to maintain project continuity and knowledge preservation.
+
+## 2. Task Assignment
+
+**Reference GitHub Issue:** This assignment addresses GitHub Issue #126 - "Only update `version.js` on server"
+
+**Issue Context:** Currently, the `version.js` file gets updated during local builds via the `generate-version` script, causing it to appear as a changed file that needs to be committed after each version bump. This creates unnecessary version control noise and developer friction.
+
+**Objective:** Implement a placeholder version strategy where:
+- Local development uses a placeholder version in `version.js`
+- The release pipeline updates `version.js` with the actual version from `package.json` before building
+- Developers no longer need to commit `version.js` changes after version bumps
+
+**Detailed Action Steps:**
+
+1. **Modify version.js to use placeholder version:**
+   - Change the VERSION constant in `src/utils/version.js` from the current version to a placeholder value `'DEV'`
+   - Ensure the file structure and exports remain identical for API compatibility
+   - Add a comment explaining this is a placeholder updated during releases
+
+2. **Update package.json scripts to remove local version generation:**
+   - Remove `npm run generate-version &&` from the `dev`, `build`, and `build:standalone` scripts
+   - Keep the `generate-version` script itself (needed for release pipeline)
+   - Ensure local builds work with placeholder version
+
+3. **Modify release.yml workflow to update version before building:**
+   - Add a new step after "Install dependencies" and before "Build standalone version"
+   - Use the existing `scripts/generate-version.js` to update version.js with actual package.json version
+   - Ensure this happens before the build step so the release contains the correct version
+
+4. **Verify the implementation:**
+   - Test that local `yarn dev` works without changing version.js
+   - Test that local `yarn build` works with placeholder version
+   - Confirm that the generate-version script still functions correctly when called manually
+
+**Provide Necessary Context/Assets:**
+
+- Current `src/utils/version.js` exports VERSION constant and getVersion() function
+- `scripts/generate-version.js` reads package.json and updates version.js using regex replacement
+- Build scripts in package.json currently run generate-version before Vite
+- Release workflow in `.github/workflows/release.yml` handles CI/CD builds
+- The VERSION constant is used throughout the codebase for version display
+
+## 3. Expected Output & Deliverables
+
+**Define Success:** 
+- Local builds (`yarn dev`, `yarn build`) no longer modify `version.js`
+- `version.js` contains placeholder `'DEV'` version in repository
+- Release workflow successfully updates version before building
+- All existing version-related functionality continues to work unchanged
+
+**Specify Deliverables:**
+1. Modified `src/utils/version.js` with placeholder version and explanatory comment
+2. Updated `package.json` with scripts that don't run generate-version locally
+3. Enhanced `.github/workflows/release.yml` with version update step
+4. Verification that local builds work without file changes
+
+**Format:** Standard code file modifications with clear, minimal changes to existing structure.
+
+## 4. Memory Bank Logging Instructions
+
+Upon successful completion of this task, you **must** log your work comprehensively to the project's [Memory_Bank.md](../../Memory_Bank.md) file.
+
+Adhere strictly to the established logging format. Ensure your log includes:
+- A reference to GitHub Issue #126 and the placeholder version strategy
+- A clear description of the files modified and changes made
+- Code snippets showing the key changes (placeholder version, script modifications, workflow step)
+- Any key decisions made during implementation
+- Confirmation of successful testing (local builds, version script functionality)
+
+## 5. Clarification Instruction
+
+If any part of this task assignment is unclear, please state your specific questions before proceeding. Pay particular attention to:
+- The exact placeholder value to use (suggested: 'DEV')
+- The placement of the version update step in the release workflow
+- Any concerns about API compatibility or breaking changes

--- a/src/utils/version.js
+++ b/src/utils/version.js
@@ -1,10 +1,10 @@
 /**
- * Generated version constants
- * Auto-generated from package.json - do not edit manually
+ * Version constants for GramFrame
+ * Uses placeholder during development, updated to actual version during releases
  */
 
-// This value is replaced automatically by the generation script.
-export const VERSION = '0.1.4'
+// Placeholder version for development - updated automatically during release builds
+export const VERSION = 'DEV'
 
 /**
  * Get the current version of GramFrame


### PR DESCRIPTION
## Summary
- Use 'DEV' placeholder in version.js during development
- Remove version generation from local build scripts (dev, build, build:standalone)
- Add version update step in release workflow before building
- Prevent unnecessary commits of version.js changes after local builds

## Test plan
- [x] Local `yarn dev` works without modifying version.js
- [x] Local `yarn build` works without modifying version.js  
- [x] Local `yarn build:standalone` works without modifying version.js
- [x] `yarn generate-version` script functions correctly when called manually
- [x] TypeScript validation passes
- [x] Release workflow includes version update step with verification

Resolves #126