### PR TITLE
Add debug-trainer.html to PR preview workflow

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -38,6 +38,7 @@ jobs:
           cp -r sample _site/
           cp index.html _site/
           cp debug.html _site/
+          cp debug-trainer.html _site/
           cp debug-multiple.html _site/
           cp test-release.html _site/
           # Standalone demo pages


### PR DESCRIPTION
## Summary
This change adds the `debug-trainer.html` file to the list of files copied during the PR preview build process, ensuring it is available in the preview deployment.

## Key Changes
- Added `cp debug-trainer.html _site/` to the GitHub Actions workflow that prepares files for PR previews

## Details
The PR preview workflow copies various HTML files to the `_site/` directory for deployment. This change includes the `debug-trainer.html` file alongside other debug and demo pages, making it accessible in PR preview environments.

https://claude.ai/code/session_01JSEM6AKpipvdhekYWTmfvC