### PR TITLE
Spec: Expand image toggle (#171)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,8 @@ Example configuration:
 - Markdown documentation (no code changes) + N/A (documentation-only feature) (154-enrich-docs)
 - JavaScript (ES2020+, JSDoc-typed, no compilation) + None (zero runtime dependencies, Vite for build) (155-browser-storage)
 - Browser Web Storage API (localStorage / sessionStorage) (155-browser-storage)
+- JavaScript (ES2020+), JSDoc-typed, no compilation + None at runtime (zero runtime deps); Vite for build (156-expand-image-toggle)
+- N/A — expand state is in-memory only (explicitly NOT browser storage) (156-expand-image-toggle)
 
 ## Recent Changes
 - 154-enrich-docs: Added Markdown documentation (no code changes) + N/A (documentation-only feature)

--- a/specs/156-expand-image-toggle/contracts/expand-toggle-ui.md
+++ b/specs/156-expand-image-toggle/contracts/expand-toggle-ui.md
@@ -1,0 +1,48 @@
+# UI Contract: Expand Toggle Control
+
+The contract the demonstrator and Playwright tests rely on. Class names are proposed and
+may be refined in implementation, but the *behavioural* contract is fixed.
+
+## Presence / gating
+
+- The toggle MUST be rendered **only** when `imageDetails.naturalWidth > naturalHeight`
+  (landscape). For portrait or square images it MUST NOT be present in the DOM.
+- One toggle per GramFrame instance. Multiple instances on a page each have their own.
+
+## DOM / structure
+
+- A `<button>` element with a stable class (e.g. `gram-frame-expand-toggle`) appended to
+  the instance's `.gram-frame-main-panel` (which is `position: relative`).
+- Positioned absolutely at the **top-left of the image region**, offset so it does NOT
+  overlap the left (time) axis labels.
+- MUST expose its state for testing/assistive tech, e.g. `aria-pressed="true|false"` and
+  an `aria-label` ("Expand image" / "Collapse image"). Distinct expand (⤢) vs collapse
+  (⤡) affordance.
+- Semi-transparent so it does not obscure the spectrogram.
+
+## Behaviour
+
+| Trigger | Precondition | Effect |
+|---------|--------------|--------|
+| Click toggle | `imageExpanded === false` | Compute available width/height; set `renderWidth/Height`; relayout; set `imageExpanded = true`; re-render features; update button to collapse state (`aria-pressed="true"`). |
+| Click toggle | `imageExpanded === true` | Restore `renderWidth/Height` to natural; relayout; set `imageExpanded = false`; re-render features; update button to expand state (`aria-pressed="false"`). |
+| Window/container resize | `imageExpanded === true` | Recompute available width/height; relayout to keep the image filling the space. |
+| Window/container resize | `imageExpanded === false` | No expand-specific behaviour (existing reflow only). |
+
+## Invariants the tests assert (maps to Success Criteria)
+
+- **SC-001**: when expanded, rendered image width == component inner image-region width ±2px.
+- **SC-002**: when expanded, rendered image height == computed `availableHeight` ±2px.
+- **SC-003**: axis tick-label font size identical before vs after expand.
+- **SC-004**: a known data point reports the same freq/time before expand and after expand
+  (coordinate fidelity), including with zoom applied.
+- **SC-005**: toggle absent for portrait image; present for landscape image.
+- **SC-006**: after collapse, rendered image width/height == original natural dimensions exactly.
+- **SC-007**: a feature placed before expanding sits at its original screen position and
+  reports its original data coordinates after expand→collapse.
+
+## Out of scope (explicit)
+
+- No persistence of `imageExpanded` (not stored in localStorage/sessionStorage).
+- No change to the `gram-config` HTML configuration contract.
+- No aspect-ratio locking.

--- a/specs/156-expand-image-toggle/contracts/state-shape.md
+++ b/specs/156-expand-image-toggle/contracts/state-shape.md
@@ -1,0 +1,49 @@
+# State Contract: Expand Image Toggle
+
+Additive changes to GramFrame instance state. No existing field is removed or repurposed.
+
+## Added fields
+
+```js
+// src/core/state.js — imageDetails (extended)
+imageDetails: {
+  naturalWidth: 0,    // existing — unchanged; data-mapping reference + landscape test
+  naturalHeight: 0,   // existing — unchanged
+  renderWidth: 0,     // NEW — base render width (defaults to naturalWidth on load)
+  renderHeight: 0     // NEW — base render height (defaults to naturalHeight on load)
+}
+
+// src/core/state.js — instance state (new flag)
+imageExpanded: false  // NEW — in-memory only, default false, never persisted
+```
+
+## Contract rules
+
+1. On image load, `renderWidth/renderHeight` MUST be initialised equal to
+   `naturalWidth/naturalHeight`.
+2. `imageExpanded` defaults to `false` and is NOT written to or read from any browser
+   storage (independent of feature 155).
+3. When `imageExpanded` is `true`, `renderWidth/renderHeight` hold the computed
+   available-space dimensions; when `false`, they equal `naturalWidth/naturalHeight`.
+4. All consumers computing data↔pixel ratios MUST read `renderWidth/renderHeight`:
+   - `updateSVGLayout` (viewBox, image element, clip rects)
+   - `renderAxes` (axis span)
+   - `imageToDataCoordinates` (divisor)
+   - `cursors.js` data→pixel placement
+   - `events.js` screen→data zoom normalization (base = render size)
+5. `state.zoom.level` continues to multiply the rendered size; expand and zoom compose
+   and remain independent.
+6. State broadcast: existing deep-copy-before-listener behaviour is preserved; the new
+   fields are plain numbers/boolean and serialize trivially. External listeners may read
+   `imageExpanded` and `imageDetails.renderWidth/Height`.
+
+## Optional API surface (nice-to-have, not required for MVP)
+
+If exposed via `src/api/`:
+
+| Method | Behaviour |
+|--------|-----------|
+| `getExpandState()` | returns current `imageExpanded` boolean |
+| `setExpandState(bool)` | programmatically expand/collapse (no-op for portrait images) |
+
+These mirror the toggle button and are gated by the same landscape rule.

--- a/specs/156-expand-image-toggle/data-model.md
+++ b/specs/156-expand-image-toggle/data-model.md
@@ -1,0 +1,69 @@
+# Phase 1 Data Model: Expand Image Toggle
+
+This feature is UI/layout state, not persisted data. The "model" is the in-memory state
+added to a GramFrame instance and the derived layout values computed at toggle/resize.
+
+## Entities
+
+### ImageDetails (extended)
+
+Existing object at `state.imageDetails` (`src/core/state.js:46-50`), extended with
+rendered dimensions.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `naturalWidth` | number | 0 | Load-time (capped) image width. **Data-mapping reference + landscape test.** Unchanged by expand. |
+| `naturalHeight` | number | 0 | Load-time (capped) image height. Unchanged by expand. |
+| `renderWidth` | number | = `naturalWidth` | Width at which the image/axes/overlay are currently drawn (base, before zoom). Set to fill-width when expanded. |
+| `renderHeight` | number | = `naturalHeight` | Height at which the image/axes/overlay are currently drawn (base, before zoom). Set to fill-height when expanded. |
+
+**Validation / invariants**:
+- `renderWidth`/`renderHeight` default to the natural values and MUST be restored to them
+  exactly on collapse (SC-006).
+- All data↔pixel transforms use `renderWidth`/`renderHeight`; only the landscape test and
+  load-time scaling use `naturalWidth`/`naturalHeight`.
+- `isLandscape` is derived, not stored: `naturalWidth > naturalHeight`.
+
+### Expand state
+
+New per-instance flag. Lives on `state` (in-memory; NOT written to browser storage).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `imageExpanded` | boolean | `false` | Whether the image is currently expanded. |
+
+**State transitions**:
+
+```text
+            click toggle (landscape only)
+ collapsed ───────────────────────────────▶ expanded
+   ▲                                            │
+   │            click toggle                     │
+   └────────────────────────────────────────────┘
+
+ collapsed: renderWidth/Height = naturalWidth/Height
+ expanded:  renderWidth = availableWidth, renderHeight = availableHeight (recomputed on resize)
+```
+
+- No transition is offered for portrait/square images (toggle absent).
+- `imageExpanded` is never persisted and resets to `false` on reload.
+
+## Derived (computed, not stored)
+
+Recomputed at toggle time and on every resize while expanded:
+
+| Value | Formula | Source |
+|-------|---------|--------|
+| `isLandscape` | `naturalWidth > naturalHeight` | `imageDetails` |
+| `availableWidth` | GramFrame inner image-region width (component width minus left+right axis margins) | main-panel/container bounds |
+| `availableHeight` | `viewportBottom − imageRegionTop − bottomGap` (gap ≈ 16px) | `getBoundingClientRect()` + `window.innerHeight` |
+
+## Relationships to existing state
+
+- **`state.zoom.level`** (`state.js:67-70`): multiplies the base render size. Expand sets
+  the base (`renderWidth`/`renderHeight`); zoom applies `level` on top. They compose
+  multiplicatively and remain independent (FR-012).
+- **`state.config`** (`freqMin/Max`, `timeMin/Max`): unchanged by expand. The data range
+  maps across whatever render size is active — this is what preserves coordinate fidelity.
+- **Persistent features** (markers/harmonics/doppler): store data coordinates; re-rendered
+  through `FeatureRenderer` after a toggle so they re-resolve against the new render size.

--- a/specs/156-expand-image-toggle/plan.md
+++ b/specs/156-expand-image-toggle/plan.md
@@ -1,0 +1,92 @@
+# Implementation Plan: Expand Image Toggle
+
+**Branch**: `156-expand-image-toggle` (developing on `claude/affectionate-euler-1a44hu`) | **Date**: 2026-06-25 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/156-expand-image-toggle/spec.md`
+
+## Summary
+
+Add a per-instance toggle that lets an analyst expand a **landscape** spectrogram so
+the image fills the GramFrame component's width and grows downward to consume most of
+the available viewport height, while navigation, title, and the control panel stay
+visible. The core technical approach is to **decouple the rendered image size from the
+image's natural size**: a new `renderWidth`/`renderHeight` drives `updateSVGLayout`,
+axis rendering, and the coordinate transforms, so cursors and persistent features stay
+locked to their data coordinates at any rendered size. Aspect ratio is not locked; only
+the image region grows (axis-label text and the control panel keep their normal size).
+State is in-memory, default off, not persisted. Portrait `verniers` get no toggle.
+
+## Technical Context
+
+**Language/Version**: JavaScript (ES2020+), JSDoc-typed, no compilation
+**Primary Dependencies**: None at runtime (zero runtime deps); Vite for build
+**Storage**: N/A — expand state is in-memory only (explicitly NOT browser storage)
+**Testing**: Playwright e2e (`yarn test`); `GramFramePage` helper class
+**Target Platform**: Modern browsers (SVG + ResizeObserver), embedded in DITA-OT/Oxygen WebHelp pages
+**Project Type**: Single-project browser component (library)
+**Performance Goals**: Toggle + re-layout visually instant (<1 frame perceptible); no regression to 60fps drag interactions
+**Constraints**: Must preserve coordinate fidelity across render-size changes; only the image expands (axis text unchanged); reuse existing ResizeObserver
+**Scale/Scope**: One contained feature — ~1 state field, `updateSVGLayout` + 2 coordinate divisors, 1 toggle control, 1 landscape guard; multiple instances per page supported
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Assessment |
+|-----------|------------|
+| **I. SVG-First Rendering** | PASS. Image, axes, cursors, and all features continue to render as SVG and flow through `src/utils/coordinates.js`. The render-size decoupling is applied *inside* the existing coordinate system (transforms switch divisor from natural to rendered dims) — it does not bypass it. The expand **toggle is a UI control, not a data overlay**; like the existing `ModeButtons` and `ColorPicker` it is an HTML control, positioned in the `position: relative` main-panel cell. Principle I governs data overlays (cursors/axes/markers/harmonics/doppler), which remain SVG. No Canvas; no absolutely-positioned DOM rendering of *data*. |
+| **II. Test-First (NON-NEGOTIABLE)** | PASS. New Playwright coverage for all seven success criteria (SC-001..007) added via `GramFramePage` helpers before/with implementation. `yarn typecheck`, `yarn test`, `yarn build` are the merge gates. |
+| **III. Modular Mode Architecture** | PASS. Expand is a cross-mode layout concern, not a mode. It lives in core rendering/layout (`table.js`/`updateSVGLayout`, `coordinates.js`, a small UI control) and is coordinated through the existing render path; it does NOT modify any mode and does NOT add a mode. Feature re-render on toggle goes through `FeatureRenderer`, not mode-to-mode calls. |
+| **IV. Declarative HTML Configuration** | PASS. No config-table contract change. The toggle is a runtime control discovered per instance; the landscape guard reads the already-parsed `imageDetails`. Multiple independent instances per page remain supported (each computes its own available space). |
+
+**Result**: PASS — no violations. Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/156-expand-image-toggle/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (state + UI-control contracts)
+│   ├── state-shape.md
+│   └── expand-toggle-ui.md
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── core/
+│   └── state.js                 # add expand flag + renderWidth/renderHeight to imageDetails
+├── components/
+│   ├── table.js                 # updateSVGLayout: compute render dims; axes span render dims
+│   └── ExpandToggle.js          # NEW: floating expand/collapse control (landscape-only)
+├── utils/
+│   └── coordinates.js           # imageToDataCoordinates / inverse: divide by render dims
+├── rendering/
+│   └── (cursors.js, axes.js)    # follow render dims via updated transforms (no logic rewrite)
+├── api/                         # optional: expose getExpandState/setExpandState on the API
+└── gramframe.css                # toggle styling + expanded main-panel/container rules
+
+sample/
+└── pub10-gram1.html             # NEW: demonstrator rebuilt from published Pub-10 shell
+                                 #      (+ mirrored oxygen-webhelp CSS/JS assets, local bundle)
+
+tests/
+├── expand-image.spec.ts         # NEW: SC-001..007 acceptance tests
+└── helpers/                     # extend GramFramePage with expand helpers
+```
+
+**Structure Decision**: Single-project browser component (Option 1). The feature
+touches core layout (`table.js`/`updateSVGLayout`), the coordinate utilities
+(`coordinates.js`), state (`state.js`), one new UI control component
+(`ExpandToggle.js`), CSS, a new `sample/` demonstrator, and Playwright tests. No new
+top-level structure is introduced.
+
+## Complexity Tracking
+
+> No constitution violations — section intentionally empty.

--- a/specs/156-expand-image-toggle/quickstart.md
+++ b/specs/156-expand-image-toggle/quickstart.md
@@ -1,0 +1,62 @@
+# Quickstart: Expand Image Toggle
+
+How to build, run, and verify the feature locally.
+
+## Prerequisites
+
+- `yarn install`
+- Mirrored Pub-10 demonstrator assets (CSS/JS + `gram-1.png`) imported into the repo
+  under `sample/` (see Decision 7 in `research.md`).
+
+## Build & run
+
+```bash
+yarn dev          # dev server with HMR
+yarn typecheck    # JSDoc type checking — must be clean
+yarn build        # production build (unminified)
+yarn test         # full Playwright suite
+```
+
+Run just this feature's tests:
+
+```bash
+npx playwright test tests/expand-image.spec.ts
+```
+
+## Manual verification (landscape gram)
+
+1. Open the demonstrator (`sample/pub10-gram1.html`, landscape `gram-1.png` 902×237).
+2. Confirm an expand toggle (⤢) is floating at the **top-left of the image**, clear of the
+   time-axis labels.
+3. Click it:
+   - The image fills the GramFrame component width (black area to the right is consumed).
+   - The frame grows downward into the white space; nav bar, title, and control panel stay
+     visible without scrolling up.
+   - Axis tick **labels stay the same size** — only the image grew.
+4. Before expanding, place an Analysis marker at a known point (e.g. ~180 Hz / 00:20) and
+   note the LED readout. Expand, then collapse: the marker is back on the same feature and
+   reports the same data values.
+5. Hover the same image feature while expanded: the TIME/FREQ LEDs report the correct
+   values (coordinate fidelity).
+6. Zoom in/out and pan while expanded: they operate on the expanded image; coordinates stay
+   correct.
+7. Click the toggle again: the image returns to its exact original size.
+
+## Manual verification (portrait vernier)
+
+1. Open a page whose gram image is taller than wide.
+2. Confirm **no** expand toggle is present.
+
+## Acceptance criteria → tests
+
+| Criterion | Check |
+|-----------|-------|
+| SC-001 | Expanded width == component inner image-region width ±2px |
+| SC-002 | Expanded height == computed available height ±2px |
+| SC-003 | Axis label font size unchanged before/after expand |
+| SC-004 | Known data point reports same freq/time before/after expand (and with zoom) |
+| SC-005 | No toggle for portrait; toggle present for landscape |
+| SC-006 | Collapse restores exact natural dimensions |
+| SC-007 | Pre-placed feature returns to original position/data after expand→collapse |
+
+All run at a fixed Playwright viewport against `sample/pub10-gram1.html`.

--- a/specs/156-expand-image-toggle/research.md
+++ b/specs/156-expand-image-toggle/research.md
@@ -1,0 +1,115 @@
+# Phase 0 Research: Expand Image Toggle
+
+All open questions from the spec were resolved during the design discussion with the
+stakeholder (issue #171). This document records the resulting decisions and the
+codebase facts that constrain implementation. There are **no remaining NEEDS
+CLARIFICATION** items.
+
+## Decision 1 — Decouple rendered image size from natural size
+
+**Decision**: Introduce `renderWidth`/`renderHeight` in `state.imageDetails` (default =
+`naturalWidth`/`naturalHeight`). When expanded, these hold the computed fill dimensions.
+All layout and coordinate math that currently divides/multiplies by `naturalWidth`/
+`naturalHeight` to map data ↔ image pixels switches to the **rendered** dimensions.
+
+**Rationale**: The data range (`freqMin..freqMax`, `timeMin..timeMax`) maps across the
+*displayed* image, whatever its pixel size. Keying transforms off the rendered size
+preserves coordinate fidelity (SC-004) while letting the image grow. `naturalWidth`/
+`naturalHeight` are retained as the load-time reference and the landscape test only.
+
+**Codebase facts** (the exact lines that must change):
+- `src/components/table.js:177-178` — `axesWidth/axesHeight` set from natural; must use render dims.
+- `src/components/table.js:198-214` — image + clip rects sized from natural; use render dims.
+- `src/components/table.js:292-306` — `renderAxes` spans natural dims; use render dims.
+- `src/utils/coordinates.js:53,56-63` — `imageToDataCoordinates` divides by natural; use render dims.
+- `src/rendering/cursors.js:66-69` — data→pixel uses `naturalWidth`; use render dims.
+- `src/core/events.js:25-59` — screen→data path (normalizes zoom, subtracts margins) must
+  normalize against the base **render** size, not natural.
+
+**Alternatives considered**:
+- *`preserveAspectRatio="none"` on the whole SVG + a bigger CSS box*: trivial, zero
+  coordinate changes, but stretches the **axis-label text** too — violates "only the
+  image expands" (FR-006/SC-003). Rejected.
+- *Overload `naturalWidth`/`naturalHeight` with the expanded values*: loses the
+  data-mapping reference and the landscape test, and corrupts collapse-restore. Rejected
+  in favour of a separate render field.
+
+## Decision 2 — Composition with the existing zoom/pan transform
+
+**Decision**: Expand sets the **base** render size; zoom multiplies it. The existing
+zoom path is the model to follow and must be made render-size aware rather than
+natural-size aware.
+
+**Rationale**: The stakeholder requires zoom/pan to remain independent and to act on the
+current image size (original or expanded). The code already renders the image element at
+non-natural sizes under zoom (`table.js:254-272`, `zoomedWidth = naturalWidth * level`)
+and already recomputes the visible range from the *actual element* dimensions
+(`table.js:334-335`). Expand reuses that decoupling: base size becomes `renderWidth`
+instead of `naturalWidth`, and zoom applies `level` on top.
+
+**Risk / validation**: The screen→data normalization in `events.js` divides out
+`zoom.level` to recover image-pixel coordinates. After this change it must divide by the
+**base render** size, then map to data via render dims — so expand × zoom composes
+multiplicatively without double-counting. This is the single highest-risk interaction
+and is covered by SC-004 (coordinate fidelity) plus an explicit expand-then-zoom test.
+
+## Decision 3 — Available-space computation
+
+**Decision**: At toggle time and on resize, compute:
+- **Width** = the GramFrame component's inner image-region width (image fills the black
+  area to its right, between the 60px left and 15px right axis margins).
+- **Height** = `viewportBottom − imageRegionTop − bottomGap` (gap ≈ 16px), i.e. fill down
+  to near the viewport bottom from the image region's current top.
+
+**Rationale**: Growing downward keeps the control panel (above the image) and nav/title
+on screen (FR-004). Pub-10 pages are typically taller than the viewport, so expanding a
+lower gram simply pushes following content down (normal flow) — no inter-instance
+coordination needed.
+
+**Alternatives considered**: Locking aspect ratio (rejected per stakeholder — width and
+height computed independently); a minimum-extra-space threshold before allowing expand
+(rejected — always allow for landscape).
+
+## Decision 4 — Reuse existing resize machinery
+
+**Decision**: Reuse the existing `ResizeObserver` (`src/core/events.js:129-140`) and
+window `resize` handler, which already call `updateSVGLayout` → `renderAxes`. When
+expanded, the layout function recomputes available space so the fill is maintained
+(FR-010). No new observers.
+
+**Rationale**: The reflow path already exists; expand only changes the dimensions it
+computes from.
+
+## Decision 5 — Feature re-render on toggle
+
+**Decision**: On expand/collapse, after recomputing layout, call
+`FeatureRenderer.renderAllPersistentFeatures()` (`src/core/FeatureRenderer.js:23`) so
+markers, harmonics, and doppler re-resolve through the (now render-size-aware) transforms
+and stay locked to their data coordinates (FR-008/SC-007).
+
+**Rationale**: Constitution III — cross-mode feature coordination goes through
+`FeatureRenderer`, not mode-to-mode calls. The features store data coordinates, so a
+re-render at the new size repositions them correctly with no per-mode change.
+
+## Decision 6 — Toggle control: HTML control, landscape-gated, in-memory
+
+**Decision**: A small `<button>` floating at the image region's top-left (inside the
+`position: relative` `.gram-frame-main-panel`), shown only when
+`naturalWidth > naturalHeight`. Expand state is a per-instance in-memory boolean, default
+off, not persisted.
+
+**Rationale**: Consistent with existing HTML controls (`ModeButtons`, `ColorPicker`);
+Principle I governs *data* overlays (which stay SVG), not UI controls. Landscape gate and
+non-persistence are explicit requirements (FR-002, FR-011). Square images are treated as
+non-landscape.
+
+## Decision 7 — Demonstrator-based acceptance testing
+
+**Decision**: Add `sample/pub10-gram1.html`, rebuilt from the published Pub-10 page
+`out/pub-10/Grams/gram1.html`, reusing its CSS/JS shell but loading the locally built
+GramFrame bundle, with the landscape `gram-1.png` (902×237, time 0–40, freq 100–300).
+Playwright runs SC-001..007 against it at a fixed viewport.
+
+**Rationale**: Exercises the feature in the real published layout (nav above, content
+below, sidebar beside — the conditions FR-004 and the multi-gram edge case depend on)
+without requiring OxygenXML. Assets were mirrored during research and are ready to import.

--- a/specs/156-expand-image-toggle/spec.md
+++ b/specs/156-expand-image-toggle/spec.md
@@ -1,0 +1,231 @@
+# Feature Specification: Expand Image Toggle
+
+**Feature Branch**: `156-expand-image-toggle`
+**Created**: 2026-06-25
+**Status**: Draft
+**Input**: User description: "Add toggle for expand image" (GitHub Issue #171)
+
+> We should introduce a toggle that allows a user to expand the image to fill the
+> available screen area. We should only offer this for images that are wider than
+> they are tall (landscape). Portrait images are termed a `verniers` and should
+> not be resizable, since the visible features may become unrecognisable.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Expand a Landscape Gram to Fill Available Space (Priority: P1)
+
+An analyst is studying a landscape spectrogram on a published Pub-10 page. The
+gram image only occupies part of the GramFrame component, leaving black space to
+its right and white space on the page below it. The analyst clicks a small toggle
+floating at the top-left of the image. The image immediately grows: it fills the
+full width of the GramFrame component and grows downward to consume most of the
+remaining vertical space in the current viewport, while the navigation bar, page
+title, and the GramFrame control panel (LEDs, mode buttons, tables) all remain
+visible. Clicking the toggle again restores the image to its original size.
+
+**Why this priority**: This is the entire feature. A larger image lets analysts
+see fine spectral detail that is hard to read at the default size. It is the
+minimum viable slice — a single toggle that grows and restores the image.
+
+**Independent Test**: Load a page with a landscape gram, click the expand toggle,
+and verify the image grows to fill the GramFrame width and the available viewport
+height while nav and control panel stay on screen. Click again and verify it
+returns to the original dimensions.
+
+**Acceptance Scenarios**:
+
+1. **Given** a landscape gram at its default size, **When** the analyst clicks the
+   expand toggle, **Then** the image region grows to fill the GramFrame component's
+   inner width (consuming the black area to its right).
+2. **Given** a landscape gram at its default size, **When** the analyst clicks the
+   expand toggle, **Then** the image region grows in height to consume most of the
+   vertical space available in the current viewport below the image's top edge.
+3. **Given** an expanded gram, **When** the analyst clicks the toggle again, **Then**
+   the image returns exactly to its original (natural) rendered dimensions.
+4. **Given** an expanded gram, **When** the page is laid out, **Then** the top
+   navigation bar, page title, and the GramFrame control panel remain visible
+   without the user needing to scroll up.
+5. **Given** the image is expanded, **When** the analyst reads the axis tick labels,
+   **Then** the label text is rendered at its normal (unchanged) size — only the
+   image area has grown.
+
+---
+
+### User Story 2 - Existing Annotations Stay Locked to Their Data Points (Priority: P2)
+
+An analyst has already placed analysis markers, harmonics, and/or a doppler curve
+on the gram. They toggle expand on and off. Every annotation stays pinned to the
+same time/frequency data coordinate it was created at — the markers visually move
+and scale together with the stretched image rather than drifting or detaching.
+
+**Why this priority**: Expanding is useless, even harmful, if it corrupts work the
+analyst has already done. Correct re-rendering of features against the new image
+size is what makes the feature trustworthy. It depends on Story 1 existing.
+
+**Independent Test**: Place a marker at a known data point (e.g. 180 Hz / 00:20),
+record its data readout, toggle expand on, toggle expand off, and verify the marker
+still reports the same data coordinates and sits on the same image feature.
+
+**Acceptance Scenarios**:
+
+1. **Given** an analysis marker at a known time/frequency, **When** the analyst
+   expands the image, **Then** the marker remains on the same data coordinate and
+   moves/scales with the image.
+2. **Given** a harmonic set on the gram, **When** the analyst expands then collapses
+   the image, **Then** the harmonics return to exactly their original positions.
+3. **Given** a doppler curve on the gram, **When** the analyst expands the image,
+   **Then** the curve continues to track the same data points.
+4. **Given** an expanded image, **When** the analyst hovers a pixel and reads the
+   time/frequency LEDs, **Then** the reported values match the data coordinate at
+   that point (coordinate fidelity is preserved across the render-size change).
+
+---
+
+### User Story 3 - Portrait Verniers Are Not Expandable (Priority: P3)
+
+An analyst views a portrait spectrogram (a `vernier`). No expand toggle is offered
+on the image at all, so there is no way to distort the narrow features by scaling.
+
+**Why this priority**: A guard rail that prevents misuse. Low priority because it is
+an absence of UI rather than a new capability, but it directly reflects the issue's
+explicit constraint.
+
+**Independent Test**: Load a page whose gram image is taller than it is wide and
+verify no expand toggle is rendered.
+
+**Acceptance Scenarios**:
+
+1. **Given** a gram whose image is taller than it is wide, **When** the page loads,
+   **Then** no expand toggle is present on that gram.
+2. **Given** a gram whose image is wider than it is tall, **When** the page loads,
+   **Then** the expand toggle is present on that gram.
+
+---
+
+### Edge Cases
+
+- **Multiple grams on one page**: Pub-10 pages are frequently taller than the
+  viewport. Each gram computes its available space relative to the current viewport.
+  Expanding a lower gram grows it into the current viewport and pushes the grams
+  and content below it further down the page (normal document flow). No coordination
+  between instances is required for this experiment.
+- **Window resize while expanded**: When an expanded gram's container resizes (window
+  resize / ResizeObserver), the available width and height are recomputed so the
+  image continues to fill the available space.
+- **Zoom and Pan**: Zoom and Pan are independent of expand. They continue to operate
+  on whatever the current rendered image size is (original or expanded). Expand
+  changes the size of the rendered image box; zoom/pan change the data window shown
+  within it. The two compose without interfering.
+- **Already-large landscape image**: The toggle is always offered for landscape
+  images, even when little extra space is available. No minimum-extra-space threshold
+  is applied.
+- **Collapse returns to natural size**: Collapsing always restores the original
+  natural rendered dimensions, regardless of intervening resizes.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST render an expand/collapse toggle floating at the
+  top-left corner of the image region, positioned so it does not obscure the left
+  (time) axis labels.
+- **FR-002**: The system MUST render the toggle ONLY for images that are landscape
+  (natural width greater than natural height). Portrait/square images MUST receive
+  no toggle.
+- **FR-003**: When expanded, the system MUST render the image to fill the inner
+  width of the GramFrame component (the image area between the left and right axis
+  margins spans the component's available width).
+- **FR-004**: When expanded, the system MUST render the image to grow in height to
+  consume most of the vertical space available within the current viewport below the
+  image region's top edge, leaving a small bottom gap, such that the navigation bar,
+  page title, and GramFrame control panel remain visible without scrolling up.
+- **FR-005**: The system MUST NOT lock the image's aspect ratio when expanding; the
+  expanded width and height are computed independently from the available space.
+- **FR-006**: The system MUST expand only the image region. Axis margins and axis
+  label text MUST retain their normal size; the GramFrame control panel (LEDs, mode
+  buttons, markers/harmonics tables) MUST be unaffected in size.
+- **FR-007**: The system MUST maintain a rendered image size that is decoupled from
+  the image's natural size, and all coordinate transforms (screen ↔ image ↔ data)
+  and feature rendering MUST use the rendered size so that data-coordinate fidelity
+  is preserved at any rendered size.
+- **FR-008**: On toggling expand or collapse, the system MUST re-render all persistent
+  features (analysis markers, harmonics, doppler) so they remain locked to their
+  original data coordinates.
+- **FR-009**: When collapsed, the system MUST restore the image to its original
+  natural rendered dimensions exactly.
+- **FR-010**: When an expanded gram's container resizes, the system MUST recompute
+  the available width and height and re-render so the image continues to fill the
+  available space.
+- **FR-011**: The expand state MUST be held in memory per GramFrame instance, default
+  OFF, and MUST NOT be persisted to browser storage.
+- **FR-012**: Zoom and Pan MUST remain available and functional in both expanded and
+  collapsed states, operating on the current rendered image size.
+
+### Key Entities
+
+- **Rendered image dimensions**: The width/height at which the spectrogram image,
+  axes span, and feature overlay are currently drawn. Defaults to the natural
+  (load-time, capped) dimensions; set to computed fill dimensions when expanded.
+  Distinct from the natural dimensions, which are retained as the data-mapping
+  reference and the landscape test.
+- **Expand state**: A per-instance, in-memory boolean (expanded / collapsed),
+  default collapsed, not persisted.
+- **Available space**: The width of the GramFrame component's image region and the
+  vertical space from the image region's top edge to the viewport bottom (minus a
+  small gap), recomputed at toggle time and on resize.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: When expanded at a fixed viewport, the rendered image width equals the
+  GramFrame component's inner image-region width within ±2px.
+- **SC-002**: When expanded at a fixed viewport, the rendered image height equals the
+  computed available height within ±2px.
+- **SC-003**: Axis tick-label text size is identical before and after expanding
+  (proving only the image expands).
+- **SC-004**: For a known pixel/data point, hovering before expand and hovering the
+  corresponding point after expand report the same frequency/time values (coordinate
+  fidelity preserved across the render-size change).
+- **SC-005**: No expand toggle is present for a portrait/`vernier` image; the toggle
+  is present for a landscape image.
+- **SC-006**: Collapsing restores the image to its exact original natural dimensions.
+- **SC-007**: After expand and collapse, an annotation placed before expanding sits
+  at its original screen position and reports its original data coordinates.
+
+## Acceptance Testing Approach
+
+To exercise the feature in a realistic published-document context without running
+OxygenXML, a self-contained demonstrator page is reconstructed from the published
+Pub-10 page `out/pub-10/Grams/gram1.html`:
+
+- The published page's shell is reproduced verbatim — the "COMMERCIAL IN CONFIDENCE"
+  banner, top navigation bar, page title, the `gram-config` table, the right-hand
+  "Related information" sidebar, and the Question/Theory table beneath the gram —
+  using copies of its upstream CSS/JS assets (`commons.css`, `topic.css`,
+  `oxygen.css`, `f13ldman.css`, `notes.css`, and the oxygen-webhelp scripts).
+- The published `gramframe.bundle.js` is replaced with the locally built GramFrame
+  bundle so tests exercise the current source.
+- The demonstrator uses the published landscape spectrogram (`gram-1.png`, 902 × 237,
+  time 0–40, freq 100–300), giving a layout with navigation above and content below —
+  the conditions FR-004 and the multiple-gram edge case depend on.
+
+Playwright acceptance tests run against this demonstrator at a fixed viewport to
+assert SC-001 through SC-007.
+
+## Assumptions
+
+- "Fill the available width" means the width of the GramFrame component itself (the
+  image consumes the black area currently to its right), not the full browser
+  viewport width or the page's right sidebar.
+- "Consume most of" the available vertical space means filling the space from the
+  image region's top edge down to the viewport bottom, less a small gap (~16px), so
+  the expanded frame is not flush against the window edge.
+- Landscape is defined strictly as natural width greater than natural height; square
+  images are treated as non-landscape and receive no toggle.
+- The toggle is an early experiment to gather user feedback; its visual styling can be
+  minimal (a small semi-transparent button with an expand/collapse icon).
+- The existing ResizeObserver and window resize handling are reused to drive
+  recomputation; no new observers are required.
+- Persistence (browser storage, feature 155) is intentionally out of scope for the
+  expand state.

--- a/specs/156-expand-image-toggle/tasks.md
+++ b/specs/156-expand-image-toggle/tasks.md
@@ -1,0 +1,211 @@
+---
+description: "Task list for feature 156 — Expand Image Toggle"
+---
+
+# Tasks: Expand Image Toggle
+
+**Input**: Design documents from `/specs/156-expand-image-toggle/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: INCLUDED. Per the project constitution (Principle II — Test-First, NON-NEGOTIABLE)
+and the spec's acceptance-testing approach, every user story has Playwright tests written
+before its implementation.
+
+**Organization**: Tasks are grouped by user story (P1→P3) for independent implementation
+and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1 / US2 / US3 (maps to spec.md user stories)
+- Exact file paths included in each task
+
+## Path Conventions
+
+Single-project browser component: source in `src/`, tests in `tests/`, demonstrator in
+`sample/`. Mirrored Pub-10 assets staged in scratchpad during research need importing.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Stage the demonstrator assets and test scaffolding shared by all stories.
+
+- [ ] T001 Import mirrored Pub-10 demonstrator assets into the repo under `sample/pub10-assets/` (the oxygen-webhelp CSS/JS shell + `gram-1.png`, 902×237) from the research mirror, keeping relative paths intact
+- [ ] T002 Create demonstrator page `sample/pub10-gram1.html` reproducing the published Pub-10 shell (COMMERCIAL IN CONFIDENCE banner, nav bar, title, `gram-config` table with time 0–40 / freq 100–300, Related-information sidebar, Question/Theory table), loading the locally built GramFrame bundle instead of the published bundle
+- [ ] T003 [P] Add a portrait test fixture image (taller than wide) under `sample/pub10-assets/` for the US3 vernier case, plus a minimal portrait `gram-config` demonstrator `sample/pub10-vernier.html`
+
+**Checkpoint**: Demonstrator pages load the local bundle and render the existing gram.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Decouple rendered image size from natural size as a **no-op refactor**
+(render dims default to natural, so rendering is unchanged) and extend the test helper.
+This blocks all user stories.
+
+**⚠️ CRITICAL**: No user-story work begins until this phase is complete and the existing
+suite is still green.
+
+- [ ] T004 Add `renderWidth` and `renderHeight` to `imageDetails` and add `imageExpanded: false` to instance state in `src/core/state.js` (per contracts/state-shape.md), with JSDoc types updated in `src/types.js`
+- [ ] T005 Initialise `renderWidth`/`renderHeight` to `naturalWidth`/`naturalHeight` on image load in `src/components/table.js` (image `onload`, near lines 148-149)
+- [ ] T006 Refactor `updateSVGLayout` in `src/components/table.js` to compute viewBox, image element, and clip rects from `renderWidth`/`renderHeight` instead of `naturalWidth`/`naturalHeight` (lines ~177-214)
+- [ ] T007 Refactor `renderAxes`/visible-range calc in `src/components/table.js` to span `renderWidth`/`renderHeight` (lines ~292-342), keeping axis-label rendering size independent of image size
+- [ ] T008 Refactor `imageToDataCoordinates` in `src/utils/coordinates.js` to divide by render dims (lines 53-63); update the `ImageDetails` JSDoc to document `renderWidth`/`renderHeight`
+- [ ] T009 Refactor data→pixel placement in `src/rendering/cursors.js` to use render dims (lines 66-69)
+- [ ] T010 Refactor the screen→data zoom normalization in `src/core/events.js` (lines 25-59) so zoom `level` is applied on top of the **base render** size, ensuring expand × zoom composes (research.md Decision 2)
+- [ ] T011 [P] Extend the `GramFramePage` helper in `tests/helpers/` with expand utilities: `getRenderedImageSize()`, `getAxisLabelFontSize()`, `clickExpandToggle()`, `isExpandToggleVisible()`, `readDataAtPixel(x,y)`
+- [ ] T012 Run `yarn typecheck` and `yarn test` to confirm the refactor is a no-op (existing tests green, image renders identically at default size)
+
+**Checkpoint**: Render-size decoupling in place and proven inert; transforms are render-aware.
+
+---
+
+## Phase 3: User Story 1 - Expand a Landscape Gram to Fill Available Space (Priority: P1) 🎯 MVP
+
+**Goal**: A landscape gram gains a top-left toggle that expands the image to fill the
+component width and available viewport height (only the image grows), and restores it.
+
+**Independent Test**: On `sample/pub10-gram1.html`, click the toggle and assert the image
+fills the component width and available height with nav/title/panel still visible and axis
+text unchanged; click again to restore exactly.
+
+### Tests for User Story 1 ⚠️ (write first, must fail before implementation)
+
+- [ ] T013 [P] [US1] Test SC-001/SC-002 in `tests/expand-image.spec.ts`: at a fixed viewport, expanded image width == component inner image-region width ±2px and height == computed available height ±2px
+- [ ] T014 [P] [US1] Test SC-003 in `tests/expand-image.spec.ts`: axis tick-label font size identical before and after expand
+- [ ] T015 [P] [US1] Test SC-006 in `tests/expand-image.spec.ts`: collapse restores exact original natural image dimensions
+
+### Implementation for User Story 1
+
+- [ ] T016 [US1] Add available-space computation in `src/components/table.js` (or a small helper): `availableWidth` = component inner image-region width; `availableHeight` = `viewportBottom − imageRegionTop − ~16px`, using `getBoundingClientRect()` + `window.innerHeight`
+- [ ] T017 [US1] Create `src/components/ExpandToggle.js`: a landscape-gated (`naturalWidth > naturalHeight`) `<button class="gram-frame-expand-toggle">` appended to `.gram-frame-main-panel`, absolutely positioned top-left clear of the time-axis labels, with `aria-pressed`/`aria-label` and ⤢/⤡ affordance (per contracts/expand-toggle-ui.md)
+- [ ] T018 [US1] Implement the toggle click handler: set `imageExpanded`, compute render dims (expand → available space; collapse → natural), call `updateSVGLayout` + `renderAxes`, and update button state/aria
+- [ ] T019 [US1] Wire the existing `ResizeObserver`/window-resize path in `src/core/events.js` to recompute available space and relayout while `imageExpanded === true` (no new observer)
+- [ ] T020 [P] [US1] Add CSS in `src/gramframe.css` for `.gram-frame-expand-toggle` (semi-transparent, top-left, z-index above SVG) and any expanded main-panel/container rules
+- [ ] T021 [US1] Mount the toggle during instance construction (wherever `ModeButtons`/main UI are wired) so each landscape instance gets one; run T013–T015 to green
+
+**Checkpoint**: MVP — landscape grams expand/collapse correctly; US1 tests pass.
+
+---
+
+## Phase 4: User Story 2 - Existing Annotations Stay Locked to Their Data Points (Priority: P2)
+
+**Goal**: Markers, harmonics, and doppler stay pinned to their data coordinates across
+expand/collapse, with coordinate fidelity preserved (including under zoom).
+
+**Independent Test**: Place a feature at a known data point, toggle expand on/off, and
+assert it returns to the same screen position and reports the same data values.
+
+### Tests for User Story 2 ⚠️ (write first, must fail before implementation)
+
+- [ ] T022 [P] [US2] Test SC-004 in `tests/expand-image.spec.ts`: a known pixel reports the same freq/time before and after expand, and again with a zoom level applied (expand × zoom composition)
+- [ ] T023 [P] [US2] Test SC-007 in `tests/expand-image.spec.ts`: an Analysis marker placed before expanding returns to its original screen position and data coordinates after expand→collapse
+
+### Implementation for User Story 2
+
+- [ ] T024 [US2] In the toggle handler (`src/components/ExpandToggle.js`), after relayout call `FeatureRenderer.renderAllPersistentFeatures()` (`src/core/FeatureRenderer.js`) so all persistent features re-resolve through the render-aware transforms
+- [ ] T025 [US2] Validate and, if needed, fix the expand × zoom composition in `src/core/events.js` so coordinate fidelity holds when both are active (the research-flagged risk); make T022 pass
+- [ ] T026 [US2] Run T022–T023 to green; verify harmonics and doppler (not just analysis markers) reposition correctly via a manual quickstart pass
+
+**Checkpoint**: US1 + US2 both work; annotations are trustworthy across expand.
+
+---
+
+## Phase 5: User Story 3 - Portrait Verniers Are Not Expandable (Priority: P3)
+
+**Goal**: Portrait (and square) images get no toggle at all.
+
+**Independent Test**: Load the portrait demonstrator and assert no toggle exists; load the
+landscape one and assert it does.
+
+### Tests for User Story 3 ⚠️ (write first, must fail before implementation)
+
+- [ ] T027 [P] [US3] Test SC-005 in `tests/expand-image.spec.ts`: no `.gram-frame-expand-toggle` present on `sample/pub10-vernier.html` (portrait); present on `sample/pub10-gram1.html` (landscape)
+
+### Implementation for User Story 3
+
+- [ ] T028 [US3] Confirm/strengthen the landscape guard in `src/components/ExpandToggle.js` so the toggle is only created when `naturalWidth > naturalHeight` (square treated as non-landscape); make T027 pass
+
+**Checkpoint**: All three stories independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Quality gates and optional surface area.
+
+- [ ] T029 [P] [Polish] (Optional) Expose `getExpandState()` / `setExpandState(bool)` on the external API in `src/api/` (landscape-gated), per contracts/state-shape.md
+- [ ] T030 [P] [Polish] Update `debug.html` and docs to mention the expand toggle and the demonstrator
+- [ ] T031 [Polish] Run `yarn typecheck`, `yarn test`, and `yarn build` — all must be clean (Quality Gates)
+- [ ] T032 [Polish] Execute `specs/156-expand-image-toggle/quickstart.md` manual verification end-to-end on both demonstrators
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies — start immediately.
+- **Foundational (Phase 2)**: depends on Setup — **BLOCKS all user stories**. The refactor must be proven inert (T012) before any story.
+- **User Story 1 (Phase 3)**: depends on Foundational. Delivers the MVP.
+- **User Story 2 (Phase 4)**: depends on Foundational; builds on US1's toggle handler (adds the feature re-render call). Independently testable.
+- **User Story 3 (Phase 5)**: depends on US1's toggle component existing (it guards that control). Independently testable.
+- **Polish (Phase 6)**: depends on all desired stories complete.
+
+### Within Each User Story
+
+- Tests written first and FAIL before implementation.
+- Available-space + state before the toggle component; toggle component before its handler; handler before resize wiring.
+- Story complete and green before moving to the next priority.
+
+### Parallel Opportunities
+
+- Setup: T003 [P] alongside T001/T002.
+- Foundational: T011 [P] (helper) alongside the source refactors; T004–T010 mostly touch different files but T006/T007 share `table.js` (sequential).
+- US1 tests T013/T014/T015 [P] together; T020 [P] (CSS) alongside component work.
+- US2 tests T022/T023 [P] together.
+- Different stories can proceed in parallel once Foundational is done (US3 needs US1's component).
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Write all US1 tests together (they must fail first):
+Task: "T013 SC-001/002 expand fill dimensions in tests/expand-image.spec.ts"
+Task: "T014 SC-003 axis label size unchanged in tests/expand-image.spec.ts"
+Task: "T015 SC-006 collapse restores natural dims in tests/expand-image.spec.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Phase 1: Setup (demonstrator).
+2. Phase 2: Foundational (render-size decoupling, proven inert).
+3. Phase 3: User Story 1 (toggle + expand/collapse).
+4. **STOP and VALIDATE**: US1 tests + quickstart on the landscape demonstrator.
+5. Demo for stakeholder feedback (this is an experiment).
+
+### Incremental Delivery
+
+1. Setup + Foundational → render-size decoupling ready (no behaviour change).
+2. US1 → expand/collapse works → demo (MVP).
+3. US2 → annotations stay locked → demo.
+4. US3 → portrait guard → demo.
+
+---
+
+## Notes
+
+- The Foundational refactor (T004–T012) is the heart of the feature; keeping render dims
+  defaulted to natural means it ships as a no-op and is verified by the existing suite
+  before any visible change.
+- The single highest-risk task is T025 (expand × zoom coordinate composition) — guarded by
+  T022.
+- `imageExpanded` is in-memory only; do NOT route it through the feature-155 storage layer.
+- Commit after each task or logical group; keep `yarn typecheck` clean throughout.


### PR DESCRIPTION
## Summary

Adds the feature specification for **#171 — Add toggle for expand image** at `specs/156-expand-image-toggle/spec.md`. This is spec-only; no component code changes yet.

The toggle lets an analyst expand a **landscape** gram's image to fill the GramFrame component width and consume most of the available viewport height, while the navigation, page title, and control panel stay visible. Portrait `verniers` get no toggle.

## Key decisions captured

- **Rendered size decoupled from natural size** — all coordinate transforms and persistent features (markers/harmonics/doppler) use the rendered size, so annotations stay locked to their data coordinates across expand/collapse.
- **Aspect ratio is not locked** — expanded width and height are computed independently from available space.
- **Only the image expands** — axis margins/label text and the control panel keep their normal size.
- **Viewport-aware height** — fills from the image's top edge to near the viewport bottom; expanding a lower gram pushes content below it down (normal flow).
- **In-memory, per-instance, default off** — not persisted to browser storage.
- **Zoom/Pan independent** — continue to operate on the current rendered size.
- Toggle floats top-left of the image; offered only when natural width > natural height.

## Acceptance testing

Documents a self-contained demonstrator rebuilt from the published Pub-10 page (`out/pub-10/Grams/gram1.html`) — published shell/CSS/JS reused, published bundle swapped for the local build, landscape `gram-1.png` (902×237) — so Playwright can verify the 7 success criteria at a fixed viewport without running OxygenXML.

## Next steps (not in this PR)

- Build the demonstrator under `sample/` + Playwright fixture
- Optional speckit `plan.md` / `tasks.md`
- Implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qyAAJ2oJo8uF5EaV3H3gd

---
_Generated by [Claude Code](https://claude.ai/code/session_017qyAAJ2oJo8uF5EaV3H3gd)_