### PR TITLE
Restore annotations to control-panel tables on reload

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -165,6 +165,14 @@ export class GramFrame {
     // Restore saved annotations before first render
     this._restoreAnnotations()
 
+    // Reflect restored annotations in the persistent control panels (markers
+    // and harmonics tables) and in the SVG overlays. Without this, reloaded
+    // annotations render over the spectrogram but leave the panel tables empty.
+    updatePersistentPanels(this)
+    if (this.featureRenderer) {
+      this.featureRenderer.renderAllPersistentFeatures()
+    }
+
     // Register storage save listener
     this._setupStorageSaveListener()
 

--- a/tests/storage.spec.js
+++ b/tests/storage.spec.js
@@ -170,6 +170,54 @@ test.describe('US1: Trainer annotations persist across reloads', () => {
     }
   })
 
+  // Regression: restored annotations must repopulate the control-panel tables,
+  // not just the SVG overlays and in-memory state.
+  test('restored markers repopulate the markers table on reload', async ({ page }) => {
+    const gfp = await gotoFixture(page, '/tests/fixtures/trainer-page.html')
+
+    await addAnalysisMarker(gfp, 200, 150)
+
+    // Markers table should have a row before reload
+    const rowsBefore = await page
+      .locator('.gram-frame-markers-persistent-container .gram-frame-table tbody tr')
+      .count()
+    expect(rowsBefore).toBeGreaterThan(0)
+
+    await page.reload()
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+    await page.waitForTimeout(500)
+
+    // After reload, the markers table must be repopulated (not just the SVG/state)
+    const rowsAfter = await page
+      .locator('.gram-frame-markers-persistent-container .gram-frame-table tbody tr')
+      .count()
+    expect(rowsAfter).toBe(rowsBefore)
+  })
+
+  // Regression: restored harmonic sets must repopulate the harmonics panel table.
+  test('restored harmonic sets repopulate the harmonics panel on reload', async ({ page }) => {
+    const gfp = await gotoFixture(page, '/tests/fixtures/trainer-page.html')
+
+    await addHarmonicSet(gfp, 200, 150, 300, 100)
+
+    const stateBefore = await getStateFromPage(page)
+    expect(stateBefore.harmonics.harmonicSets.length).toBeGreaterThan(0)
+
+    const rowsBefore = await page
+      .locator('.gram-frame-harmonics-persistent-container .gram-frame-table tbody tr')
+      .count()
+    expect(rowsBefore).toBeGreaterThan(0)
+
+    await page.reload()
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+    await page.waitForTimeout(500)
+
+    const rowsAfter = await page
+      .locator('.gram-frame-harmonics-persistent-container .gram-frame-table tbody tr')
+      .count()
+    expect(rowsAfter).toBe(rowsBefore)
+  })
+
   // T010
   test('annotations are restored silently without prompt', async ({ page }) => {
     const gfp = await gotoFixture(page, '/tests/fixtures/trainer-page.html')


### PR DESCRIPTION
## Problem

On the trainer page, persisted annotations are restored after a page refresh and rendered over the spectrogram (SVG overlays) — but the **MARKERS** and **HARMONICS** control-panel tables stay empty. The data is in state, but the panels never reflect it.

## Cause

`_restoreAnnotations()` in `src/main.js` writes the restored markers / harmonic sets / doppler data into component state, but it does not refresh the persistent control panels. Those tables are normally populated by `updatePersistentPanels()`, which only runs during a mode switch (`_switchMode`) — never during initial construction after a restore.

## Fix

Immediately after `_restoreAnnotations()` in the constructor, call `updatePersistentPanels(this)` and re-render the persistent SVG features so the markers and harmonics tables reflect the restored data on load.

## Tests

Added two regression tests in `tests/storage.spec.js` that assert the markers table and harmonics panel are repopulated (DOM rows present) after a page reload. Both fail without the fix and pass with it. The full `storage.spec.js` suite (14 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGetPC1kCwgQ9xdv53MQAS)_