### PR TITLE
Document persistence model and add gf-persistent flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,36 @@ This component provides an interactive overlay for sonar spectrogram images, ena
 - [Rendering Troubleshooting](docs/Rendering-Troubleshooting.md) — Debugging rendering and coordinate issues
 - [Architecture Decision Records](docs/ADRs/) — Design decisions and rationale
 
+## Annotation Persistence
+
+Annotations (analysis markers, harmonic sets, and Doppler curves) are saved to
+browser storage automatically. The storage backend depends on whether the page
+is detected as a **trainer** or **student** context:
+
+| Context   | Storage          | Lifetime                                      |
+|-----------|------------------|-----------------------------------------------|
+| Trainer   | `localStorage`   | Permanent — survives browser restarts         |
+| Student   | `sessionStorage` | Cleared when the browser tab/session closes   |
+
+### How the context is detected
+
+A page is treated as a **trainer** page if **either** of the following is true:
+
+1. The page contains an element with `id="gf-persistent"` (anywhere in the DOM), or
+2. The page contains an anchor (`<a>`) element whose exact trimmed text is `ANALYSIS`.
+
+If neither is present, the page is treated as a **student** page.
+
+To opt a page into permanent (trainer) persistence, add a marker element, e.g.:
+
+```html
+<span id="gf-persistent" hidden></span>
+```
+
+The detection is re-evaluated on every save/load, and the storage key is
+namespaced per page path (`gramframe::<pathname>`) — only the storage backend
+(local vs. session) differs between contexts.
+
 ## Target Audience
 
 Trainees or students using sonar training manuals in HTML format.

--- a/src/core/storage.js
+++ b/src/core/storage.js
@@ -5,8 +5,9 @@
  * in browser storage. Trainers get localStorage (permanent); students get
  * sessionStorage (cleared on browser close).
  *
- * Context detection: pages with an anchor containing exact text "ANALYSIS"
- * are trainer pages; all others are student pages.
+ * Context detection: a page is treated as a trainer page if EITHER an anchor
+ * with exact text "ANALYSIS" is present, OR an element with id "gf-persistent"
+ * exists anywhere on the page. All other pages are student pages.
  */
 
 /// <reference path="../types.js" />
@@ -19,10 +20,18 @@ const KEY_PREFIX = 'gramframe::'
 
 /**
  * Detect whether the current page is a trainer or student context.
- * Trainer pages contain an anchor element with exact text "ANALYSIS".
+ * A page is treated as trainer context if EITHER condition holds:
+ *   - an anchor element with exact text "ANALYSIS" is present, OR
+ *   - an element with id "gf-persistent" exists anywhere on the page.
+ * All other pages are student context.
  * @returns {'trainer' | 'student'}
  */
 export function detectUserContext() {
+  // Explicit persistence flag: an element with id "gf-persistent"
+  if (document.getElementById('gf-persistent')) {
+    return 'trainer'
+  }
+  // Legacy detection: an anchor whose exact text is "ANALYSIS"
   const anchors = document.querySelectorAll('a')
   for (let i = 0; i < anchors.length; i++) {
     if (anchors[i].textContent && anchors[i].textContent.trim() === 'ANALYSIS') {

--- a/tests/fixtures/persistent-flag-page.html
+++ b/tests/fixtures/persistent-flag-page.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Persistent Flag Page - Storage Test</title>
+  <link rel="stylesheet" href="../../src/gramframe.css" />
+  <script type="module" src="../../src/main.js"></script>
+</head>
+<body>
+  <h1>Persistent Flag Page</h1>
+  <!-- No ANALYSIS link, but the gf-persistent flag forces trainer persistence -->
+  <span id="gf-persistent" hidden></span>
+
+  <div class="component-container">
+    <table class="gram-config">
+      <tr>
+        <td colspan="2">
+          <img src="../../sample/mock-gram.png" alt="Sample Spectrogram">
+        </td>
+      </tr>
+      <tr><td>time-start</td><td>0</td></tr>
+      <tr><td>time-end</td><td>60</td></tr>
+      <tr><td>freq-start</td><td>0</td></tr>
+      <tr><td>freq-end</td><td>100</td></tr>
+    </table>
+  </div>
+
+  <div class="diagnostics-panel" style="display:none;">
+    <pre id="state-display">Loading...</pre>
+  </div>
+</body>
+</html>

--- a/tests/storage.spec.js
+++ b/tests/storage.spec.js
@@ -296,6 +296,50 @@ test.describe('US2: Student annotations persist within session', () => {
 })
 
 // ──────────────────────────────────────────────────────────────
+// gf-persistent flag — opts a page into trainer (localStorage) persistence
+// ──────────────────────────────────────────────────────────────
+
+test.describe('gf-persistent flag forces trainer persistence', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/tests/fixtures/persistent-flag-page.html')
+    await page.evaluate(() => {
+      localStorage.clear()
+      sessionStorage.clear()
+    })
+  })
+
+  test('page with #gf-persistent uses localStorage (not sessionStorage)', async ({ page }) => {
+    const gfp = await gotoFixture(page, '/tests/fixtures/persistent-flag-page.html')
+
+    await addAnalysisMarker(gfp, 200, 150)
+    await page.waitForTimeout(300)
+
+    // Annotations should be written to localStorage (trainer behaviour)
+    const localKeys = await gfp.getStorageKeys('local')
+    expect(localKeys.length).toBeGreaterThan(0)
+
+    // ...and NOT to sessionStorage (student behaviour)
+    const sessionKeys = await gfp.getStorageKeys('session')
+    expect(sessionKeys.length).toBe(0)
+  })
+
+  test('annotations persist across reload via the gf-persistent flag', async ({ page }) => {
+    const gfp = await gotoFixture(page, '/tests/fixtures/persistent-flag-page.html')
+
+    await addAnalysisMarker(gfp, 200, 150)
+    const stateBefore = await getStateFromPage(page)
+    expect(stateBefore.analysis.markers.length).toBeGreaterThan(0)
+
+    await page.reload()
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+    await page.waitForTimeout(500)
+
+    const stateAfter = await getStateFromPage(page)
+    expect(stateAfter.analysis.markers.length).toBe(stateBefore.analysis.markers.length)
+  })
+})
+
+// ──────────────────────────────────────────────────────────────
 // User Story 3 — Trainer Clears Stored Annotations
 // ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Annotations are persisted to browser storage with two different models depending on context: **trainer** pages use `localStorage` (permanent), **student** pages use `sessionStorage` (cleared on session close). Until now the only way to select trainer persistence was an `<a>` anchor with exact text `ANALYSIS`, and this behaviour was completely undocumented.

This PR:

- **Adds a second, explicit trigger** — an element with `id="gf-persistent"` anywhere on the page now also selects trainer (`localStorage`) persistence, alongside the existing ANALYSIS-anchor detection. This gives integrators a clear, intentional opt-in that doesn't depend on incidental link text.
- **Documents** both detection criteria and the trainer/student storage model in the README (new "Annotation Persistence" section).
- **Adds tests** — a new `persistent-flag-page.html` fixture plus two tests verifying that a page carrying `#gf-persistent` writes to `localStorage` (not `sessionStorage`) and that annotations survive a reload.

## Detection logic (`src/core/storage.js`)

A page is treated as **trainer** context if **either**:
1. An element with `id="gf-persistent"` exists, **or**
2. An anchor whose exact trimmed text is `ANALYSIS` exists.

Otherwise it is **student** context. The `#gf-persistent` check runs first; existing behaviour is unchanged.

## Testing

All 16 tests in `tests/storage.spec.js` pass, including the 2 new `gf-persistent` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0183n3qwA6ssJ8m6UJVUwhid)_