### PR TITLE
chore: release v0.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spectro-component",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "type": "module",
   "scripts": {
     "generate-version": "node scripts/generate-version.js",


### PR DESCRIPTION
## 🔖 Release v0.1.10

Bumps `package.json` from `0.1.9` → `0.1.10`. Once this lands on `main`, push the `v0.1.10` tag to trigger the automated release workflow (`.github/workflows/release.yml`).

> ⚠️ I was unable to push the `v0.1.10` tag from this environment — tag-ref pushes are blocked by the session's egress policy (HTTP 403). A maintainer needs to create/push the tag:
> ```bash
> git checkout main && git pull
> git tag v0.1.10 && git push origin v0.1.10
> ```

## 📋 Release Notes — v0.1.10

### ✨ Features
- Add expand-image toggle for landscape grams, decoupling rendered size from natural size (#171)
- Implement browser storage for user annotations, with persistence model and `gf-persistent` flag (#159, #174, #175)
- Restore annotations to control-panel tables on reload

### 📚 Documentation
- Enrich repository with comprehensive developer documentation and fix file-reference accuracy
- Add Product Overview and Technology Overview documents
- Add speckit artifacts and project documentation/task templates

### 🛠️ Tooling / Infrastructure
- Add GitHub Actions workflow for PR preview deployments
- Deploy main site and student/trainer demo pages to GitHub Pages alongside PR previews
- Add `debug-trainer.html` to GH Pages deployment
- Add additional Bash commands for prerequisite checks and setup scripts

### 🔗 Full Changelog
[`v0.1.9...v0.1.10`](https://github.com/DeepBlueCLtd/GramFrame/compare/v0.1.9...v0.1.10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0123mQgJRPLynUJwDyTqtwa2)_