### PR TITLE
Detect trainer context via class/data-attribute (DITA-friendly)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  playwright:
+    name: Playwright tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: yarn test

--- a/docs/HTML-Integration-Guide.md
+++ b/docs/HTML-Integration-Guide.md
@@ -114,6 +114,64 @@ GramFrame.removeStateListener(listener)
 
 State is deep-copied before being passed to listeners, so you cannot accidentally mutate internal state.
 
+## Annotation Persistence (Trainer vs. Student)
+
+GramFrame can persist annotations (analysis markers, harmonic sets, doppler
+curves) in browser storage. The storage backend depends on whether the page is
+detected as a **trainer** page or a **student** page:
+
+- **Trainer pages** use `localStorage` — annotations persist permanently, so an
+  instructor can author them once and have them survive browser restarts.
+- **Student pages** use `sessionStorage` — annotations are ephemeral and cleared
+  when the browser tab/session closes.
+
+A page is treated as a trainer page if **any** of the following explicit flags is
+present anywhere in the page, in order of preference:
+
+| Form | Example | Notes |
+|------|---------|-------|
+| Class | `<span class="gf-persistent"></span>` | **Recommended** — DITA-friendly |
+| Data attribute | `<span data-gf-persistent></span>` | DITA-friendly |
+| Id | `<span id="gf-persistent"></span>` | Legacy; kept for backward compatibility |
+
+The flag element can be hidden and placed anywhere on the page — detection runs
+over the whole document with no ordering constraints.
+
+```html
+<!-- Mark this page as a trainer/instructor page -->
+<span class="gf-persistent" hidden></span>
+```
+
+A legacy heuristic also treats a page as trainer context if it contains an
+anchor whose exact text is `ANALYSIS`. This is fragile (it false-positives on
+any page with such a link) and is retained only for backward compatibility —
+prefer an explicit flag above.
+
+### Why a class and data-attribute, not just an id
+
+The AAAC training material is produced through a DITA-OT / Oxygen WebHelp
+publishing pipeline. **DITA-OT topic-scopes and uniquifies every `@id`** in its
+HTML output, so an authored `id="gf-persistent"` is rewritten to something
+page-specific (e.g. `id="ariaid-title1_gf-persistent"`) and
+`getElementById('gf-persistent')` never matches — instructor pages would
+silently fall back to ephemeral `sessionStorage`.
+
+A DITA `@outputclass`, by contrast, is passed straight through to the HTML
+`@class` **verbatim and un-mangled** (this is exactly how `table.gram-config`
+itself is detected), and classes are not uniquified. So `.gf-persistent` is
+reliably emittable from DITA and stable on every page.
+
+DITA integrators add the class to an instructor-only marker they already emit
+(profiled out of the student build via DITAVAL), so no extra authoring is
+required — students get no flag and stay ephemeral:
+
+```xml
+<p outputclass="gf-persistent" audience="instructor">…</p>
+```
+
+→ renders to `class="p gf-persistent"` on instructor pages only. No id, no
+post-processing, no client-side shim.
+
 ## File Protocol Compatibility
 
 GramFrame supports `file://` protocol for offline use. The standalone IIFE build (`gramframe.bundle.js`) bundles all CSS inline, avoiding cross-origin restrictions. See [ADR-013](ADRs/ADR-013-File-Protocol-Compatibility.md).

--- a/src/core/storage.js
+++ b/src/core/storage.js
@@ -5,9 +5,22 @@
  * in browser storage. Trainers get localStorage (permanent); students get
  * sessionStorage (cleared on browser close).
  *
- * Context detection: a page is treated as a trainer page if EITHER an anchor
- * with exact text "ANALYSIS" is present, OR an element with id "gf-persistent"
- * exists anywhere on the page. All other pages are student pages.
+ * Context detection: a page is treated as a trainer page if ANY of the
+ * following is present anywhere on the page:
+ *   - an element with id "gf-persistent",
+ *   - an element with class "gf-persistent",
+ *   - an element carrying the data-gf-persistent attribute, OR
+ *   - (legacy) an anchor whose exact text is "ANALYSIS".
+ * All other pages are student pages.
+ *
+ * The class and data-attribute forms exist so the flag can be emitted from a
+ * DITA-OT / Oxygen WebHelp publishing pipeline. DITA-OT topic-scopes and
+ * uniquifies every @id in its HTML output, so an authored id="gf-persistent"
+ * is rewritten to something page-specific and getElementById() never matches.
+ * @outputclass, by contrast, is passed straight through to the HTML @class
+ * verbatim and un-mangled (this is exactly how table.gram-config is already
+ * detected), and classes are not uniquified — so .gf-persistent is reliably
+ * emittable from DITA and stable on every page.
  */
 
 /// <reference path="../types.js" />
@@ -19,16 +32,24 @@ const SCHEMA_VERSION = 1
 const KEY_PREFIX = 'gramframe::'
 
 /**
+ * CSS selector matching the explicit trainer-persistence flag. Accepts the
+ * id, class, or data-attribute form. Exported for unit testing.
+ * @type {string}
+ */
+export const TRAINER_FLAG_SELECTOR = '#gf-persistent, .gf-persistent, [data-gf-persistent]'
+
+/**
  * Detect whether the current page is a trainer or student context.
  * A page is treated as trainer context if EITHER condition holds:
- *   - an anchor element with exact text "ANALYSIS" is present, OR
- *   - an element with id "gf-persistent" exists anywhere on the page.
+ *   - an explicit persistence flag (id, class, or data-attribute) is present
+ *     anywhere on the page (see TRAINER_FLAG_SELECTOR), OR
+ *   - (legacy) an anchor element with exact text "ANALYSIS" is present.
  * All other pages are student context.
  * @returns {'trainer' | 'student'}
  */
 export function detectUserContext() {
-  // Explicit persistence flag: an element with id "gf-persistent"
-  if (document.getElementById('gf-persistent')) {
+  // Explicit persistence flag: id, class, or data-attribute form.
+  if (document.querySelector(TRAINER_FLAG_SELECTOR)) {
     return 'trainer'
   }
   // Legacy detection: an anchor whose exact text is "ANALYSIS"

--- a/tests/detect-user-context.spec.js
+++ b/tests/detect-user-context.spec.js
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Unit tests for detectUserContext() and TRAINER_FLAG_SELECTOR in
+ * src/core/storage.js.
+ *
+ * The module touches `document`, so it is imported and exercised in the
+ * browser via page.evaluate against a controlled DOM. A deliberately empty
+ * fixture (blank-page.html) is used so no GramFrame instance interferes with
+ * detection.
+ */
+
+/**
+ * Set document.body.innerHTML to `html`, import the storage module, and return
+ * the result of detectUserContext().
+ * @param {import('@playwright/test').Page} page
+ * @param {string} html - markup to place in the body before detection
+ * @returns {Promise<'trainer' | 'student'>}
+ */
+async function detectWith(page, html) {
+  return page.evaluate(async (markup) => {
+    document.body.innerHTML = markup
+    const mod = await import('/src/core/storage.js')
+    return mod.detectUserContext()
+  }, html)
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/tests/fixtures/blank-page.html')
+})
+
+test('returns "trainer" for the legacy id="gf-persistent" flag', async ({ page }) => {
+  const context = await detectWith(page, '<span id="gf-persistent" hidden></span>')
+  expect(context).toBe('trainer')
+})
+
+test('returns "trainer" for the class="gf-persistent" flag (DITA outputclass)', async ({ page }) => {
+  const context = await detectWith(page, '<span class="p edition-instructor gf-persistent"></span>')
+  expect(context).toBe('trainer')
+})
+
+test('returns "trainer" for the data-gf-persistent attribute flag', async ({ page }) => {
+  const context = await detectWith(page, '<span data-gf-persistent></span>')
+  expect(context).toBe('trainer')
+})
+
+test('returns "trainer" for the legacy ANALYSIS anchor heuristic', async ({ page }) => {
+  const context = await detectWith(page, '<a href="#">ANALYSIS</a>')
+  expect(context).toBe('trainer')
+})
+
+test('returns "student" when no flag is present', async ({ page }) => {
+  const context = await detectWith(page, '<p>Ordinary student page content</p>')
+  expect(context).toBe('student')
+})
+
+test('TRAINER_FLAG_SELECTOR is exported and matches all three flag forms', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const mod = await import('/src/core/storage.js')
+    document.body.innerHTML =
+      '<span id="gf-persistent"></span>' +
+      '<span class="gf-persistent"></span>' +
+      '<span data-gf-persistent></span>'
+    return {
+      selector: mod.TRAINER_FLAG_SELECTOR,
+      matches: document.querySelectorAll(mod.TRAINER_FLAG_SELECTOR).length
+    }
+  })
+  expect(typeof result.selector).toBe('string')
+  expect(result.selector).toContain('#gf-persistent')
+  expect(result.selector).toContain('.gf-persistent')
+  expect(result.selector).toContain('[data-gf-persistent]')
+  expect(result.matches).toBe(3)
+})

--- a/tests/fixtures/blank-page.html
+++ b/tests/fixtures/blank-page.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Blank Page - detectUserContext unit tests</title>
+</head>
+<body>
+  <!-- Intentionally empty: storage.js is imported and exercised directly via
+       page.evaluate so detectUserContext() can be unit-tested against a
+       controlled DOM, with no GramFrame instance interfering. -->
+</body>
+</html>

--- a/tests/fixtures/persistent-class-page.html
+++ b/tests/fixtures/persistent-class-page.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Persistent Class Page - Storage Test</title>
+  <link rel="stylesheet" href="../../src/gramframe.css" />
+  <script type="module" src="../../src/main.js"></script>
+</head>
+<body>
+  <h1>Persistent Class Page</h1>
+  <!-- No id and no ANALYSIS link: the DITA-friendly class flag forces trainer
+       persistence. This mirrors how DITA-OT/Oxygen emit @outputclass. -->
+  <span class="p edition-instructor gf-persistent" hidden></span>
+
+  <div class="component-container">
+    <table class="gram-config">
+      <tr>
+        <td colspan="2">
+          <img src="../../sample/mock-gram.png" alt="Sample Spectrogram">
+        </td>
+      </tr>
+      <tr><td>time-start</td><td>0</td></tr>
+      <tr><td>time-end</td><td>60</td></tr>
+      <tr><td>freq-start</td><td>0</td></tr>
+      <tr><td>freq-end</td><td>100</td></tr>
+    </table>
+  </div>
+
+  <div class="diagnostics-panel" style="display:none;">
+    <pre id="state-display">Loading...</pre>
+  </div>
+</body>
+</html>

--- a/tests/storage.spec.js
+++ b/tests/storage.spec.js
@@ -337,6 +337,27 @@ test.describe('gf-persistent flag forces trainer persistence', () => {
     const stateAfter = await getStateFromPage(page)
     expect(stateAfter.analysis.markers.length).toBe(stateBefore.analysis.markers.length)
   })
+
+  // The DITA-friendly class flag must drive the full localStorage pipeline,
+  // not just detection — DITA-OT id-mangling makes the class form the one the
+  // AAAC publishing pipeline can actually emit.
+  test('page with class="gf-persistent" uses localStorage (not sessionStorage)', async ({ page }) => {
+    await page.goto('/tests/fixtures/persistent-class-page.html')
+    await page.evaluate(() => {
+      localStorage.clear()
+      sessionStorage.clear()
+    })
+    const gfp = await gotoFixture(page, '/tests/fixtures/persistent-class-page.html')
+
+    await addAnalysisMarker(gfp, 200, 150)
+    await page.waitForTimeout(300)
+
+    const localKeys = await gfp.getStorageKeys('local')
+    expect(localKeys.length).toBeGreaterThan(0)
+
+    const sessionKeys = await gfp.getStorageKeys('session')
+    expect(sessionKeys.length).toBe(0)
+  })
 })
 
 // ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`detectUserContext()` in `src/core/storage.js` decided trainer vs. student — and therefore `localStorage` (persistent annotations) vs. `sessionStorage` (ephemeral) — solely by `document.getElementById('gf-persistent')`. That works for hand-authored HTML, but it **cannot be satisfied from a DITA/Oxygen publishing pipeline**, which is how the AAAC training material is produced.

DITA-OT (and Oxygen WebHelp) topic-scope and uniquify every element `@id`, so an authored `id="gf-persistent"` is rewritten per-page (e.g. `id="ariaid-title1_gf-persistent"`) and `getElementById('gf-persistent')` never matches — instructor pages silently fall back to ephemeral `sessionStorage`.

## Change

Also accept a **class** (`.gf-persistent`) and a **data-attribute** (`[data-gf-persistent]`) as trainer flags, keeping the `id` for backward compatibility. DITA `@outputclass` is passed through to the HTML `@class` verbatim and un-mangled (exactly how `table.gram-config` is already detected), and classes aren't uniquified — so `.gf-persistent` is reliably emittable from DITA and stable on every page. The integrator can drive persistence purely from DITA customisation, profiling the instructor-only marker out of the student build via DITAVAL (no extra authoring).

Detection now uses a single exported selector:

```js
export const TRAINER_FLAG_SELECTOR = '#gf-persistent, .gf-persistent, [data-gf-persistent]'
```

## Acceptance criteria

- [x] `<span class="gf-persistent">` / `<span data-gf-persistent>` → `detectUserContext()` returns `'trainer'`, annotations persist to `localStorage`
- [x] Legacy `id="gf-persistent"` still returns `'trainer'`
- [x] No flag → `'student'` + `sessionStorage`
- [x] `TRAINER_FLAG_SELECTOR` exported for unit testing
- [x] Unit tests covering id, class, data-attribute, and the negative case (`tests/detect-user-context.spec.js`)
- [x] Documented in `docs/HTML-Integration-Guide.md` with the DITA-OT id-mangling rationale

## Backward compatibility

Fully backward compatible. The legacy `id="gf-persistent"` and the `"ANALYSIS"` anchor heuristic still trigger trainer context, so existing embedders, fixtures, and the preview/debug samples are unaffected.

## Tests

- New `tests/detect-user-context.spec.js` — 6 unit tests (id / class / data-attribute / legacy anchor / student / exported selector). **All pass.**
- New e2e test + `persistent-class-page.html` fixture confirming `class="gf-persistent"` drives the full `localStorage` pipeline (not just detection). **All 17 storage tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1PucHHFUDRRo2g7zC6aLq)_