### PR TITLE
ci: add typecheck and build steps to Tests workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Type check
+        run: yarn typecheck
+
+      - name: Build
+        run: yarn build
+
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 


### PR DESCRIPTION
## Summary

Follow-up to #177. The new **Tests** workflow currently runs only the Playwright suite. This extends it to also run:

- **`yarn typecheck`** — `tsc --noEmit` with the project's pinned TypeScript `5.8.3`, so type regressions are caught in CI.
- **`yarn build`** — `vite build`, so build breakages are caught in CI.

Order: install → typecheck → build → install browsers → test.

## Context

While reviewing #177 I initially believed `yarn typecheck` was failing on `main`. That turned out to be an environment artifact: before `yarn install` ran, the command fell through to the **global `tsc` 6.0.2** (`/opt/node22/bin/tsc`), which flags `TS2882` on the `import './gramframe.css'` side-effect import in `src/index.js`. With the pinned **TypeScript 5.8.3** from `devDependencies`, typecheck passes cleanly. Since CI uses `yarn install --frozen-lockfile`, it gets 5.8.3 and stays green.

> Note for a future TypeScript 6.x bump: that CSS side-effect import will need an ambient `declare module '*.css'` (or `allowArbitraryExtensions` / a `vite/client` reference). Not in scope here.

## Verification

Run locally against the pinned toolchain:
- `yarn typecheck` → ✅ clean (`Done in 4.00s`)
- `yarn build` → ✅ built in 498ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1PucHHFUDRRo2g7zC6aLq)_