### PR TITLE
fix: refresh markers/harmonics tables when clearing gram

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -306,6 +306,14 @@ export class GramFrame {
       this.currentMode.activate()
     }
 
+    // Refresh the persistent markers and harmonics tables (always visible,
+    // regardless of the active mode) so cleared annotations also disappear
+    // from the tables above the spectrogram, not just the SVG overlay
+    updatePersistentPanels(this)
+
+    // Refresh LED displays (e.g. Doppler readouts) to reflect the cleared state
+    updateLEDDisplays(this, this.state)
+
     notifyStateListeners(this.state, this.stateListeners)
   }
 

--- a/tests/storage.spec.js
+++ b/tests/storage.spec.js
@@ -379,6 +379,10 @@ test.describe('US3: Clear gram button', () => {
     const stateBefore = await getStateFromPage(page)
     expect(stateBefore.analysis.markers.length).toBeGreaterThan(0)
 
+    // The marker should appear as a row in the markers table above the gram
+    const markerRows = page.locator('.gram-frame-table tbody tr')
+    expect(await markerRows.count()).toBeGreaterThan(0)
+
     // Click clear gram button
     const clearBtn = page.locator('.gram-frame-clear-btn')
     await expect(clearBtn).toBeVisible()
@@ -389,6 +393,9 @@ test.describe('US3: Clear gram button', () => {
     const stateAfter = await getStateFromPage(page)
     expect(stateAfter.analysis.markers.length).toBe(0)
     expect(stateAfter.harmonics.harmonicSets.length).toBe(0)
+
+    // Verify the markers table above the gram is also cleared (not just the SVG)
+    expect(await markerRows.count()).toBe(0)
 
     // Verify storage is cleared
     const keys = await gfp.getStorageKeys('local')


### PR DESCRIPTION
## Problem

When an instructor clicks **Clear gram**, annotations disappeared from the spectrogram (SVG overlay) but lingered in the tables above it (the markers table and harmonics panel).

## Cause

`_clearGram()` in `src/main.js` reset the annotation state and called `featureRenderer.renderAllPersistentFeatures()` (which redraws the SVG) plus `currentMode.cleanup()/activate()`. But:

- The markers table (analysis) and harmonics panel are **always visible regardless of the active mode**, and are refreshed via `updatePersistentPanels()`.
- `AnalysisMode.activate()` is a no-op, so the cleanup/activate dance never rebuilt those tables.
- Doppler LED readouts were likewise not refreshed.

The mode-switch path already calls `updatePersistentPanels(this)` and `updateLEDDisplays(this, this.state)` — `_clearGram()` was simply missing the same refresh.

## Fix

Call `updatePersistentPanels(this)` and `updateLEDDisplays(this, this.state)` in `_clearGram()` so the tables and LED readouts reflect the cleared state. Both functions were already imported.

## Test

Strengthened the existing US3 clear-gram test to assert the markers table rows are removed (not just the underlying state). Verified the new assertion fails without the fix and passes with it. All 35 storage + analysis tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARCket1mwZGbUevJZQczhf

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARCket1mwZGbUevJZQczhf)_