### PR TITLE
docs: document how to check the GramFrame version

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,18 @@ Trainees or students using sonar training manuals in HTML format.
 ## Usage
 
 Include the JavaScript file via `<script>`, and place a config table with the appropriate class on your HTML page. The component will auto-initialize after page load.
+
+## Checking the version
+
+To identify which version of GramFrame an instance is running — useful when
+reporting or debugging an issue:
+
+- **In the UI:** hover over the **Pan** button. A tooltip shows `GramFrame vX.Y.Z`.
+  (The tooltip is available even before zooming in, while the button is disabled.)
+- **Programmatically:** read `state.version` via the public API:
+  ```js
+  GramFrame.addStateListener(state => console.log(state.version))
+  ```
+
+Released builds show the real version (e.g. `v0.1.12`); local development builds
+show `vDEV` until `yarn generate-version` runs.


### PR DESCRIPTION
## Summary

Follow-up to #181, which added a way to read a GramFrame instance's version (Pan button tooltip + a single `getVersion()` source of truth). That capability wasn't documented anywhere — this adds a short **"Checking the version"** section to the README.

## What it covers

- **UI route:** hover the **Pan** button to see `GramFrame vX.Y.Z` (works even while the button is disabled, before zooming in).
- **Programmatic route:** read `state.version` via the public `GramFrame.addStateListener(...)` API. (There's no dedicated `getVersion()` method on the public API — the state listener is the only public path, so that's what's documented.)
- A note that released builds show the real version while dev builds show `vDEV` until `yarn generate-version` runs.

Documentation-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrV8WBAsULghxpC6j7d9J5

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrV8WBAsULghxpC6j7d9J5)_