### PR TITLE
Spec: Student tonal 24-hour expiry (GH #184)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,8 @@ Example configuration:
 - Browser Web Storage API (localStorage / sessionStorage) (155-browser-storage)
 - JavaScript (ES2020+), JSDoc-typed, no compilation + None at runtime (zero runtime deps); Vite for build (156-expand-image-toggle)
 - N/A — expand state is in-memory only (explicitly NOT browser storage) (156-expand-image-toggle)
+- JavaScript (ES2020+), JSDoc-typed, no compilation step + None at runtime (zero runtime dependencies); Vite for build (157-student-tonal-expiry)
+- Browser Web Storage API — `sessionStorage` (student), `localStorage` (trainer) (157-student-tonal-expiry)
 
 ## Recent Changes
 - 154-enrich-docs: Added Markdown documentation (no code changes) + N/A (documentation-only feature)

--- a/specs/157-student-tonal-expiry/checklists/requirements.md
+++ b/specs/157-student-tonal-expiry/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Student Tonal Expiry (24-Hour Persistence Limit)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- All items pass. The one design choice that could reasonably vary (whether the 24-hour
+  window is measured from first creation or from last save) is documented as a stated
+  assumption rather than a blocking clarification, since a sensible default exists and the
+  issue's wording supports it.

--- a/specs/157-student-tonal-expiry/contracts/storage-expiry.md
+++ b/specs/157-student-tonal-expiry/contracts/storage-expiry.md
@@ -1,0 +1,76 @@
+# Contract: Annotation Load Expiry Behavior
+
+**Feature**: 157-student-tonal-expiry
+**Module**: `src/core/storage.js`
+**Date**: 2026-07-17
+
+This is the behavioral contract for the persistence read path after adding the
+student 24-hour expiry gate. GramFrame is a browser component, so the "contract"
+is the observable behavior of the storage module's public functions, verified by
+Playwright e2e tests. No network or CLI surface is involved.
+
+## Affected surface
+
+- `loadAnnotations(instanceIndex?) -> StoredAnnotations | null` — **behavior changed**
+- `isAnnotationExpired(savedAt, nowMs) -> boolean` — **new, exported** (pure predicate)
+- `STUDENT_TTL_MS: number` — **new** exported constant (`86_400_000`)
+- `saveAnnotations`, `clearAnnotations`, `detectUserContext`, `buildStorageKey`,
+  `getStorage`, `TRAINER_FLAG_SELECTOR` — **unchanged**
+
+## `isAnnotationExpired(savedAt, nowMs)`
+
+| Input `savedAt` | Input `nowMs` relation | Returns |
+|-----------------|------------------------|---------|
+| valid ISO, age `> 24h` | `nowMs - t > 86_400_000` | `true` |
+| valid ISO, age `≤ 24h` | `0 ≤ nowMs - t ≤ 86_400_000` | `false` |
+| valid ISO, future | `nowMs - t < 0` | `true` |
+| `undefined` / `null` / `""` | any | `true` |
+| non-date string | `Date.parse` → `NaN` | `true` |
+
+Pure and side-effect-free; identical output for identical inputs.
+
+## `loadAnnotations()` behavior matrix
+
+Assumes a record exists under the derived key and passes the version check
+unless noted.
+
+| Context | Record `savedAt` | Result | Side effect |
+|---------|------------------|--------|-------------|
+| student | age `≤ 24h` | returns the record | none |
+| student | age `> 24h` | returns `null` | `removeItem(key)`; info log |
+| student | missing / unparseable | returns `null` | `removeItem(key)`; info log |
+| student | future | returns `null` | `removeItem(key)`; info log |
+| trainer | age `> 24h` | returns the record | none (permanence preserved) |
+| trainer | missing `savedAt` | returns the record | none (expiry gate skipped) |
+| any | version mismatch | returns `null` | `removeItem(key)` (pre-existing) |
+| any | no record / storage unavailable | returns `null` | none |
+
+## Invariants
+
+1. **Trainer permanence**: with `context === 'trainer'`, `loadAnnotations()`
+   never discards on age. (FR-006, SC-003)
+2. **Fail safe**: any student record that cannot be proven fresh (`savedAt`
+   missing/invalid/future) is discarded. (FR-009)
+3. **Single read path**: all restoration flows through `loadAnnotations()`, so
+   the gate cannot be bypassed by another consumer. (research Decision 1)
+4. **No silent errors**: discards are logged at info/warn level; no error is
+   surfaced to the student UI. (SC-005)
+5. **Idempotent load**: after an expired load, the key is gone, so a subsequent
+   load returns `null` with no side effect.
+
+## Test obligations (Playwright)
+
+- **T-A (expiry)**: seed a student record, backdate its `savedAt` to >24h ago,
+  reload → no annotations restored AND storage key removed. (US1, SC-001)
+- **T-B (within window)**: seed a student record with recent `savedAt`, reload →
+  annotations restored. (US1 scenario 2, SC-002)
+- **T-C (trainer permanence)**: on a trainer page, backdate `savedAt` to >24h,
+  reload → annotations still restored. (US3, SC-003)
+- **T-D (malformed)**: student record with removed/garbage `savedAt`, reload →
+  discarded. (FR-009)
+- **T-E (fresh session)**: existing session-scope behavior still yields no
+  restore in a new session. (US2, FR-008) — may be covered by existing 155 tests.
+
+Tests MUST read the storage key the app actually wrote (enumerate
+`sessionStorage`/`localStorage` for the `gramframe::` prefix) rather than
+reconstructing it, to remain robust to key-derivation details.

--- a/specs/157-student-tonal-expiry/data-model.md
+++ b/specs/157-student-tonal-expiry/data-model.md
@@ -1,0 +1,74 @@
+# Phase 1 Data Model: Student Tonal Expiry
+
+**Feature**: 157-student-tonal-expiry
+**Date**: 2026-07-17
+
+No new persisted entity is introduced. This feature reinterprets an existing
+field (`savedAt`) as an expiry basis for student-context records. The schema and
+`SCHEMA_VERSION` are unchanged, so existing stored records remain readable.
+
+## Entity: Stored Annotation Set (`StoredAnnotations`)
+
+Existing record persisted per GramFrame instance (see `src/types.js`). Fields
+relevant to this feature:
+
+| Field | Type | Existing? | Role in this feature |
+|-------|------|-----------|----------------------|
+| `version` | number | Yes | Schema gate (unchanged). |
+| `savedAt` | string (ISO-8601) | Yes | **Expiry basis.** Time of last save; compared against `now` for student records. |
+| `analysis` | object | Yes | Payload (unchanged). |
+| `harmonics` | object | Yes | Payload (unchanged). |
+| `doppler` | object | Yes | Payload (unchanged). |
+
+**No fields added, removed, or renamed.** No migration required.
+
+## Derived concept: Persistence Context
+
+Not stored — derived per page at load/save time by `detectUserContext()`:
+
+| Context | Storage | Expiry applied? |
+|---------|---------|-----------------|
+| `trainer` | `localStorage` | No — permanent (FR-006). |
+| `student` | `sessionStorage` | Yes — discarded when older than 24h (FR-002). |
+
+## Expiry Rule (validation logic)
+
+Evaluated on load for **student** records only:
+
+```
+STUDENT_TTL_MS = 24 * 60 * 60 * 1000   // 24 hours
+
+isAnnotationExpired(savedAt, nowMs):
+    t = Date.parse(savedAt)
+    if t is NaN            -> expired   (missing / unparseable)   [FR-009]
+    age = nowMs - t
+    if age < 0            -> expired    (future timestamp)        [FR-009]
+    if age > STUDENT_TTL_MS -> expired  (older than 24h)          [FR-002]
+    otherwise             -> not expired                          [FR-004]
+```
+
+## State Transitions (per student record, on page load)
+
+```
+                         load student record
+                                │
+                 ┌──────────────┴───────────────┐
+        version mismatch                    version ok
+                │                                │
+             discard                    isAnnotationExpired(savedAt, now)?
+          (existing behavior)             │                    │
+                                        true                 false
+                                          │                    │
+                                  removeItem(key)        restore into state
+                                  return null            (FR-004)
+                                  (FR-003)
+```
+
+Trainer records skip the expiry branch entirely and always restore (subject to
+the pre-existing version check).
+
+## Non-persisted timing note
+
+Expiry is evaluated using wall-clock `Date.now()` at load. There is no stored
+countdown and no background timer; a gram left open is not force-cleared
+mid-view — the check re-runs on the next load (spec Assumptions, FR-007).

--- a/specs/157-student-tonal-expiry/plan.md
+++ b/specs/157-student-tonal-expiry/plan.md
@@ -1,0 +1,112 @@
+# Implementation Plan: Student Tonal Expiry (24-Hour Persistence Limit)
+
+**Branch**: `157-student-tonal-expiry` | **Date**: 2026-07-17 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/157-student-tonal-expiry/spec.md`
+
+## Summary
+
+Cap **student**-context annotation persistence at 24 hours to protect assessment
+integrity, while leaving **trainer**-context annotations permanent. Technical
+approach: add an age gate to the single storage read path
+(`loadAnnotations()` in `src/core/storage.js`) that discards a student record
+when `now - savedAt > 24h` (also discarding records with missing/unparseable/
+future timestamps), removing the stale key. No schema change or data migration
+is needed because the stored record already carries a `savedAt` timestamp.
+
+## Technical Context
+
+**Language/Version**: JavaScript (ES2020+), JSDoc-typed, no compilation step
+**Primary Dependencies**: None at runtime (zero runtime dependencies); Vite for build
+**Storage**: Browser Web Storage API — `sessionStorage` (student), `localStorage` (trainer)
+**Testing**: Playwright end-to-end tests (`yarn test`); `yarn typecheck` for JSDoc types
+**Target Platform**: Modern browsers (desktop) hosting sonar-training HTML pages
+**Project Type**: Single-project browser component (SVG overlay library)
+**Performance Goals**: No measurable impact — one timestamp comparison per page load
+**Constraints**: Offline-capable; must not regress trainer permanence; fail safe toward clearing student data
+**Scale/Scope**: One small module touched (`src/core/storage.js`); a handful of e2e tests added
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SVG-First Rendering | ✅ N/A | No rendering/overlay changes; purely a storage-policy change. |
+| II. Test-First (NON-NEGOTIABLE) | ✅ Pass | Playwright e2e added for expiry, retention-within-window, and trainer-permanence; `yarn typecheck` + `yarn test` must pass before merge. |
+| III. Modular Mode Architecture | ✅ Pass | No mode coupling; change confined to `src/core/storage.js`. Modes are unaffected. |
+| IV. Declarative HTML Configuration | ✅ Pass | No new configuration surface; 24h is a fixed policy constant, not HTML config. Trainer/student detection unchanged. |
+
+**Technical Constraints check**: State management, HMR, Vite, and JSDoc
+type-checking are all unaffected. No violations.
+
+**Result**: PASS — no violations, Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/157-student-tonal-expiry/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── storage-expiry.md   # Phase 1 output — behavioral contract for loadAnnotations()
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (from /speckit.specify)
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+└── core/
+    └── storage.js        # MODIFIED: add student-context age gate to loadAnnotations();
+                          #           add isAnnotationExpired() predicate + STUDENT_TTL_MS constant
+
+tests/
+├── browser-storage.spec.js   # EXTENDED (or new sibling): expiry, within-window, trainer-permanence
+└── helpers/
+    └── (existing helpers)     # reuse; read the app-written storage key rather than reconstruct it
+```
+
+**Structure Decision**: Single-project layout (Option 1). The change is a
+localized edit to one core module plus e2e coverage. No new directories or
+modules are introduced; existing `src/core/storage.js` already owns all
+persistence logic and is the correct home for the expiry policy.
+
+## Design Overview
+
+1. **Constant**: `const STUDENT_TTL_MS = 24 * 60 * 60 * 1000` in `storage.js`.
+2. **Predicate**: `isAnnotationExpired(savedAt, nowMs)` — pure function returning
+   `true` when `savedAt` is missing/unparseable, in the future, or older than
+   `STUDENT_TTL_MS`. Exported for unit-level testing.
+3. **Gate in `loadAnnotations()`**: after the version check, if
+   `context === 'student'` and `isAnnotationExpired(data.savedAt, Date.now())`,
+   then `storage.removeItem(key)`, log an informational discard, and return
+   `null`. Trainer context bypasses the gate entirely.
+4. **No changes** to `saveAnnotations()` (it already stamps `savedAt` on every
+   write, which provides the sliding window) or to `main.js`.
+
+## Complexity Tracking
+
+> No Constitution violations — section intentionally left empty.
+
+## Phase Outputs
+
+- **Phase 0** (`research.md`): decisions on where/how to enforce expiry, basis
+  of the window, malformed-timestamp handling, trainer no-op, and test approach.
+  All clarifications resolved.
+- **Phase 1** (`data-model.md`, `contracts/storage-expiry.md`, `quickstart.md`):
+  the (unchanged) stored entity annotated with the expiry rule, the behavioral
+  contract for `loadAnnotations()` across contexts and timestamp conditions, and
+  a manual verification walkthrough.
+- **Phase 2** (`tasks.md`): produced by `/speckit.tasks` — not part of this plan.
+
+## Post-Design Constitution Re-Check
+
+After Phase 1 design, all gates still PASS: the design remains a single-module
+storage-policy change with Playwright coverage, no rendering/mode/config impact,
+and no new complexity to justify.

--- a/specs/157-student-tonal-expiry/quickstart.md
+++ b/specs/157-student-tonal-expiry/quickstart.md
@@ -1,0 +1,95 @@
+# Quickstart: Verifying Student Tonal Expiry
+
+**Feature**: 157-student-tonal-expiry
+**Date**: 2026-07-17
+
+A short manual walkthrough to confirm the 24-hour student expiry works and that
+trainer permanence is preserved. Assumes `yarn dev` is running.
+
+## Prerequisites
+
+```bash
+yarn dev        # start the dev server with a sample gram page
+```
+
+Open a **student** sample page (one WITHOUT the trainer flag — no
+`#gf-persistent` / `.gf-persistent` / `[data-gf-persistent]` element and no
+`ANALYSIS` anchor).
+
+## 1. Recent annotations survive a reload (within 24h)
+
+1. Add an analysis marker (or harmonic set / doppler curve) to the gram.
+2. Reload the page.
+3. **Expect**: the annotation is restored and visible. (SC-002)
+
+## 2. Old annotations are discarded (>24h)
+
+Simulate the passage of >24 hours by backdating the stored `savedAt`, then
+reload. In the browser devtools console:
+
+```js
+// Find the GramFrame record in sessionStorage (student context) and backdate it
+for (const k of Object.keys(sessionStorage)) {
+  if (k.startsWith('gramframe::')) {
+    const rec = JSON.parse(sessionStorage.getItem(k))
+    rec.savedAt = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString() // 25h ago
+    sessionStorage.setItem(k, JSON.stringify(rec))
+    console.log('backdated', k)
+  }
+}
+```
+
+Then reload the page.
+
+- **Expect**: no annotations are restored; the gram opens clean. (SC-001)
+- **Expect**: the `gramframe::…` key has been removed from `sessionStorage`
+  (re-run `Object.keys(sessionStorage)` to confirm). (FR-003)
+- **Expect**: no error dialog or console error surfaced to the student. (SC-005)
+
+## 3. Malformed timestamp is treated as expired
+
+```js
+for (const k of Object.keys(sessionStorage)) {
+  if (k.startsWith('gramframe::')) {
+    const rec = JSON.parse(sessionStorage.getItem(k))
+    delete rec.savedAt                // or: rec.savedAt = 'not-a-date'
+    sessionStorage.setItem(k, JSON.stringify(rec))
+  }
+}
+```
+
+Reload → **expect** the record is discarded. (FR-009)
+
+## 4. Trainer annotations are permanent
+
+Open a **trainer** sample page (WITH a `.gf-persistent` flag or an `ANALYSIS`
+anchor). Add an annotation, then backdate its `savedAt` in `localStorage`:
+
+```js
+for (const k of Object.keys(localStorage)) {
+  if (k.startsWith('gramframe::')) {
+    const rec = JSON.parse(localStorage.getItem(k))
+    rec.savedAt = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString() // 10 days ago
+    localStorage.setItem(k, JSON.stringify(rec))
+  }
+}
+```
+
+Reload → **expect** the annotation is STILL restored. (SC-003, FR-006)
+
+## 5. Instructor override via fresh session
+
+With student annotations present, start a fresh browser session (close all tabs
+for the origin / new private window) and reopen the gram.
+
+- **Expect**: no annotations restored (session storage started empty). (US2, FR-008)
+
+## Automated equivalent
+
+```bash
+yarn typecheck
+yarn test        # includes the new expiry / permanence Playwright specs
+```
+
+All three quality gates (`yarn typecheck`, `yarn test`, `yarn build`) must pass
+before merge (Constitution: Quality Gates).

--- a/specs/157-student-tonal-expiry/research.md
+++ b/specs/157-student-tonal-expiry/research.md
@@ -1,0 +1,108 @@
+# Phase 0 Research: Student Tonal Expiry (24-Hour Persistence Limit)
+
+**Feature**: 157-student-tonal-expiry
+**Date**: 2026-07-17
+
+This feature extends the existing browser-storage persistence layer (feature
+155-browser-storage) rather than introducing new technology. Research therefore
+focuses on how the current mechanism behaves and where a 24-hour age check
+fits cleanly, resolving the open decisions from the spec.
+
+## Existing mechanism (as-built)
+
+- `src/core/storage.js` persists a per-page `StoredAnnotations` object.
+- Trainer pages use `localStorage` (permanent); student pages use
+  `sessionStorage` (cleared on browser/tab close). Context is chosen by
+  `detectUserContext()`.
+- Every stored record **already carries** `savedAt`, an ISO-8601 timestamp
+  written on each save (`saveAnnotations()` sets `savedAt: new Date().toISOString()`).
+- `loadAnnotations()` reads the record, validates `version === SCHEMA_VERSION`,
+  and returns it; `main.js#_restoreAnnotations()` merges it into state on init.
+- Saves are triggered by a state listener (`_setupStorageSaveListener`) that
+  re-saves whenever the annotation snapshot changes, so `savedAt` reflects the
+  **most recent** annotation change.
+
+**Implication**: No schema change and no data migration are required. The
+`savedAt` field needed for an age check is already present in existing records.
+
+## Decision 1 — Where to enforce expiry
+
+**Decision**: Enforce the age check inside `loadAnnotations()` in
+`src/core/storage.js`, for the student context only.
+
+**Rationale**: `loadAnnotations()` is the single read path and already discards
+records on version mismatch (removing the key). Adding an age gate there means
+every consumer (`_restoreAnnotations`) automatically benefits, and the "discard
++ remove key" pattern already exists to copy. Keeping it in the storage module
+honors separation of concerns (Constitution: state/rendering/UI separation).
+
+**Alternatives considered**:
+- *Check in `main.js#_restoreAnnotations`* — would leak storage-policy logic
+  into the component and duplicate the discard/remove behavior. Rejected.
+- *Background timer that clears at 24h* — adds lifecycle complexity, does not
+  match the assessment scenario (which is a page revisit = load), and risks
+  clearing data while a student is mid-view. Rejected (see spec assumptions).
+
+## Decision 2 — Expiry basis and window
+
+**Decision**: Expire when `now - savedAt > 24 hours`, measured from the record's
+`savedAt` (last-save time). Apply to student context only; trainer context is
+never aged out.
+
+**Rationale**: `savedAt` is refreshed on every annotation change, so a
+sliding "last activity" window keeps actively-worked grams alive and lets idle
+ones age out — exactly the assessment scenario. Matches the issue wording
+("persistent for 24 hours") and the spec's documented assumption.
+
+**Alternatives considered**:
+- *Measure from first creation* — would need a new `createdAt` field (schema
+  change + migration) and could delete a gram a student is still actively
+  editing. Rejected.
+- *Make the duration configurable via HTML config* — the issue specifies a
+  fixed 24h policy; configurability is unnecessary scope. Rejected. The value
+  will live as a named constant so it is easy to locate and adjust in code.
+
+## Decision 3 — Handling malformed / skewed timestamps
+
+**Decision**: Treat a student record whose `savedAt` is missing, unparseable,
+or in the future as expired → discard and remove the key.
+
+**Rationale**: Fail safe toward clearing (FR-009). A clock set backwards or a
+hand-edited record must not grant indefinite persistence. `Date.parse()`
+returning `NaN` covers missing/unparseable; a negative age covers future
+timestamps.
+
+**Alternatives considered**:
+- *Keep records with bad timestamps* — could be exploited to bypass expiry and
+  contradicts the integrity goal. Rejected.
+
+## Decision 4 — Trainer path unchanged
+
+**Decision**: The age check is gated on `context === 'student'`. Trainer
+(`localStorage`) records skip it entirely.
+
+**Rationale**: FR-006 requires trainer permanence. Gating by context is a
+one-line guard and keeps the trainer workflow a strict no-op (guarded by a
+dedicated test per SC-003).
+
+## Decision 5 — Testing approach
+
+**Decision**: Add Playwright e2e coverage that manipulates the record's
+`savedAt` via `page.evaluate` against `sessionStorage`, then reloads and asserts
+restored/absent annotations. Also add unit-level coverage of the pure age
+predicate if a unit harness is convenient; otherwise rely on e2e.
+
+**Rationale**: Constitution mandates Playwright e2e for user-facing behavior.
+Directly writing a backdated `savedAt` into storage is deterministic and avoids
+waiting real time. The existing storage tests (feature 155) provide a pattern to
+follow.
+
+**Open risk**: Tests must set the storage key using the same key-derivation as
+`buildStorageKey()` (path-based). The test helper will read the key the app
+wrote rather than reconstruct it, to stay robust.
+
+## Unresolved clarifications
+
+None. All spec `[NEEDS CLARIFICATION]` markers were already resolved during
+`/speckit.specify`; the one design choice (last-save vs creation basis) is
+settled in Decision 2.

--- a/specs/157-student-tonal-expiry/spec.md
+++ b/specs/157-student-tonal-expiry/spec.md
@@ -1,0 +1,110 @@
+# Feature Specification: Student Tonal Expiry (24-Hour Persistence Limit)
+
+**Feature Branch**: `157-student-tonal-expiry`
+**Created**: 2026-07-17
+**Status**: Draft
+**Input**: User description: "GH issue 184 — Reduce persistence of tonals for students"
+
+## Background *(context)*
+
+GramFrame persists a user's tonal annotations (analysis markers, harmonic sets, doppler curves) in browser storage so they survive page reloads. Two audiences are distinguished automatically:
+
+- **Trainer/instructor pages** — annotations persist permanently (they build teaching material).
+- **Student pages** — annotations persist only for the current browser session.
+
+The problem reported for the P9/10 course: students may remain logged in for **several weeks** without closing the browser or shutting down the PC. Because student annotations currently survive for the whole browser session, they can accumulate for that entire period. When students are later **assessed**, they can navigate back to grams they previously annotated and read off the tonals they marked earlier — undermining the integrity of the assessment.
+
+Instructors can work around this today only by forcing everyone to log off every few days. The requested improvement is to cap student annotation persistence at **24 hours**, with the existing ability for instructors to force an immediate reset by having students start a fresh session (log out and back in / close the browser).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Old student annotations do not resurface during assessment (Priority: P1)
+
+A student annotated several grams during earlier lessons. Days later, during an assessment, they revisit those same grams hoping to reuse their earlier markings. Because more than 24 hours have passed since those annotations were last saved, the grams open clean — the earlier tonals are gone.
+
+**Why this priority**: This is the core purpose of the issue — protecting assessment integrity. Without it, the feature delivers no value.
+
+**Independent Test**: Create student-context annotations, simulate the passage of more than 24 hours since they were saved, reload the gram page, and confirm no annotations are restored and none remain in storage.
+
+**Acceptance Scenarios**:
+
+1. **Given** a student page with saved annotations whose last-saved time is more than 24 hours ago, **When** the page is reloaded, **Then** no annotations are displayed and the stored entry is removed.
+2. **Given** a student page with saved annotations whose last-saved time is within the last 24 hours, **When** the page is reloaded, **Then** those annotations are restored and displayed as before.
+3. **Given** a student page whose browser has stayed open continuously for more than 24 hours, **When** the student navigates back to a previously annotated gram (a page load), **Then** annotations older than 24 hours are not restored.
+
+---
+
+### User Story 2 - Instructors can force an immediate reset (Priority: P2)
+
+An instructor wants all previously marked tonals cleared before an assessment without waiting for the 24-hour window. They ask students to start a fresh session (log out and log back in, or close and reopen the browser).
+
+**Why this priority**: Provides instructors an immediate override, matching the workaround described in the issue. Builds on existing session-scoped behavior rather than introducing new mechanics.
+
+**Independent Test**: Save student annotations, start a fresh browser session, reload the gram page, and confirm no annotations are restored.
+
+**Acceptance Scenarios**:
+
+1. **Given** a student page with saved annotations, **When** the student begins a fresh browser session and reopens the gram, **Then** no previously saved annotations are restored (regardless of the 24-hour window).
+
+---
+
+### User Story 3 - Trainer annotations remain permanent (Priority: P1)
+
+An instructor building course material annotates grams on trainer pages and expects those annotations to remain available indefinitely across days and weeks.
+
+**Why this priority**: The change must not regress the trainer workflow. Loss of trainer material would be a serious defect, so this is guarded at P1.
+
+**Independent Test**: Create trainer-context annotations, simulate the passage of well over 24 hours, reload the trainer page, and confirm annotations are still restored.
+
+**Acceptance Scenarios**:
+
+1. **Given** a trainer page with saved annotations whose last-saved time is more than 24 hours ago, **When** the page is reloaded, **Then** all annotations are restored and displayed.
+
+---
+
+### Edge Cases
+
+- **Boundary**: Annotations saved exactly at the 24-hour mark are treated consistently (see FR-002 — the window is "more than 24 hours"). Just under 24 hours restores; just over discards.
+- **Missing or unreadable timestamp**: A stored student entry with no valid last-saved time, or an unparseable value, is treated as expired and discarded (fail safe toward clearing).
+- **Future / skewed timestamp**: If the recorded last-saved time is in the future (e.g., the system clock was changed), the entry is treated as expired and discarded rather than kept indefinitely.
+- **Re-saving refreshes the window**: If a student edits and re-saves annotations on a gram, the 24-hour countdown restarts from the new save — actively worked-on grams stay available; untouched ones age out.
+- **Multiple grams on one page**: Each stored entry ages independently based on its own last-saved time.
+- **Storage unavailable**: If browser storage cannot be read, the page opens with no restored annotations (existing behavior, no error surfaced to the student).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST record, for each stored student annotation set, the time it was last saved, so its age can be evaluated on load.
+- **FR-002**: When a gram page loads in student context, the system MUST treat a stored annotation set as expired if more than 24 hours have elapsed since it was last saved.
+- **FR-003**: Expired student annotation sets MUST NOT be restored or displayed, and MUST be removed from storage during the load.
+- **FR-004**: Student annotation sets that are within the 24-hour window MUST continue to be restored and displayed on reload, exactly as they are today.
+- **FR-005**: Saving or modifying a student's annotations MUST reset the 24-hour window by updating the recorded last-saved time.
+- **FR-006**: Trainer-context annotations MUST continue to persist indefinitely; the 24-hour expiry MUST NOT apply to them.
+- **FR-007**: The 24-hour expiry MUST be enforced on page load even when the browser session has not ended (i.e., a browser or tab left open beyond 24 hours still results in expiry the next time the annotated gram is loaded).
+- **FR-008**: A fresh browser session MUST continue to start with no restored student annotations, preserving the instructor's ability to force an immediate reset by having students log out and back in / reopen the browser.
+- **FR-009**: A stored student entry whose last-saved time is missing, unparseable, or in the future MUST be treated as expired and discarded.
+
+### Key Entities *(include if feature involves data)*
+
+- **Stored Annotation Set**: The persisted collection of a page's tonal annotations (analysis markers, harmonic sets, doppler curve) together with a **last-saved timestamp** and the persistence context (student vs trainer). The timestamp and context together determine, on load, whether the set is restored or discarded.
+- **Persistence Context**: The trainer-vs-student classification already derived for each page. Trainer context = indefinite persistence; student context = 24-hour expiry plus session scope.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A student who annotated a gram more than 24 hours earlier sees that gram open with no previously marked tonals when they revisit it.
+- **SC-002**: A student who annotated a gram within the last 24 hours (same browser session) still sees those annotations restored on reload — no loss of recent work.
+- **SC-003**: Trainer annotations remain visible after an arbitrary elapsed time (days or weeks) with a 100% restoration rate — zero regression to the trainer workflow.
+- **SC-004**: Instructors can guarantee a clean slate for all students before an assessment by directing a fresh-session restart, with no previously marked tonals surviving that restart.
+- **SC-005**: No student-facing errors or warnings are produced when stored annotations expire or are discarded — the gram simply opens clean.
+
+## Assumptions
+
+- Expiry is evaluated on page load (and when annotations are read from storage), not via a background timer; a gram left open in the browser is not forcibly cleared mid-view, but the age check applies the next time it is loaded. This matches the assessment scenario, where revisiting a gram is a page load.
+- The 24-hour window is measured from the **last time the annotation set was saved**, not from first creation, so ongoing work refreshes the window. This is a reasonable default given the issue's wording ("persistent for 24 hours"); actively worked-on grams should not disappear while a student is still using them.
+- The 24-hour duration is a fixed policy value defined by this feature (per the issue); it is not exposed as an end-user setting.
+- Existing session-scoped behavior for student pages is retained; the 24-hour cap is an additional constraint that can only shorten, never extend, how long student annotations survive.
+- Trainer/student context detection is unchanged and out of scope for this feature; this feature only changes how long student-context data survives.
+- The stored data format already carries (or can carry) a save timestamp, so this feature does not require students to re-annotate existing grams; entries lacking a usable timestamp are simply treated as expired.

--- a/specs/157-student-tonal-expiry/tasks.md
+++ b/specs/157-student-tonal-expiry/tasks.md
@@ -1,0 +1,169 @@
+# Tasks: Student Tonal Expiry (24-Hour Persistence Limit)
+
+**Input**: Design documents from `/specs/157-student-tonal-expiry/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/storage-expiry.md, quickstart.md
+
+**Tests**: INCLUDED. The project Constitution makes Playwright e2e coverage NON-NEGOTIABLE (Principle II), so test tasks are mandatory here, not optional.
+
+**Organization**: Tasks are grouped by user story so each can be implemented and tested independently. Note: US1 and US3 both touch `loadAnnotations()` in `src/core/storage.js` (the student age gate and the trainer skip guard are two branches of the same edit), so they are sequenced back-to-back.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Exact file paths are included in each task
+
+## Path Conventions
+
+Single-project browser component: source in `src/`, Playwright tests in `tests/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the working environment before touching persistence logic.
+
+- [ ] T001 Confirm baseline is green by running `yarn typecheck` and `yarn test` (record any pre-existing failures — e.g. the `state.version === "DEV"` metadata tests — so they are not mistaken for regressions from this feature)
+- [ ] T002 Re-read `src/core/storage.js` and `src/main.js#_restoreAnnotations` to confirm the single read path and the existing `savedAt` write in `saveAnnotations()` (per research.md Decision 1)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add the shared, pure expiry building blocks that every story depends on. No behavior change to `loadAnnotations()` yet.
+
+**⚠️ CRITICAL**: User story work cannot begin until this phase is complete.
+
+- [ ] T003 Add `export const STUDENT_TTL_MS = 24 * 60 * 60 * 1000` constant to `src/core/storage.js` (near `SCHEMA_VERSION`), with a JSDoc comment stating it is the fixed 24-hour student persistence policy
+- [ ] T004 Implement and export the pure predicate `isAnnotationExpired(savedAt, nowMs)` in `src/core/storage.js` returning `true` when `savedAt` is missing/unparseable (`Date.parse` → `NaN`), in the future (`nowMs - t < 0`), or older than `STUDENT_TTL_MS`; otherwise `false` — matching the table in `contracts/storage-expiry.md`
+- [ ] T005 Add a JSDoc `@param`/`@returns` signature for `isAnnotationExpired` so `yarn typecheck` covers it, then run `yarn typecheck` to confirm zero errors
+
+**Checkpoint**: Shared expiry predicate + constant exist and typecheck; ready to wire into the load path.
+
+---
+
+## Phase 3: User Story 1 - Old student annotations do not resurface (Priority: P1) 🎯 MVP
+
+**Goal**: When a gram is reopened in student context more than 24 hours after its annotations were last saved, nothing is restored and the stale storage key is removed.
+
+**Independent Test**: On a student page, backdate a stored record's `savedAt` to >24h ago, reload, and confirm no annotations render and the `gramframe::` key is gone.
+
+### Tests for User Story 1 (write first, expect FAIL before T009)
+
+- [ ] T006 [P] [US1] Add e2e test "student annotations older than 24h are discarded on load" to `tests/storage.spec.js`: seed annotations on a student sample page, read back the app-written `gramframe::` key from `sessionStorage`, rewrite its `savedAt` to 25h ago, reload, assert no markers/harmonics/doppler restored AND the key was removed (contract T-A, SC-001, FR-003)
+- [ ] T007 [P] [US1] Add e2e test "student annotations within 24h are restored on load" to `tests/storage.spec.js`: seed annotations, reload without altering `savedAt` (and with a `savedAt` set to ~1h ago), assert they are restored (contract T-B, SC-002, FR-004)
+- [ ] T008 [P] [US1] Add e2e test "student record with missing/garbage savedAt is discarded" to `tests/storage.spec.js`: delete or corrupt `savedAt`, reload, assert discarded and key removed (contract T-D, FR-009)
+
+### Implementation for User Story 1
+
+- [ ] T009 [US1] In `loadAnnotations()` (`src/core/storage.js`), after the existing `version` check, add the student gate: if `detectUserContext() === 'student'` (reuse the `context` already computed in the function) and `isAnnotationExpired(data.savedAt, Date.now())`, then `storage.removeItem(key)`, emit a `console.warn`/info discard message, and `return null` (research Decision 1; contract behavior matrix)
+- [ ] T010 [US1] Run T006–T008; confirm they now pass. Run `yarn typecheck` and the full `yarn test` to check for regressions
+
+**Checkpoint**: Student expiry works end-to-end and is independently testable.
+
+---
+
+## Phase 4: User Story 3 - Trainer annotations remain permanent (Priority: P1)
+
+**Goal**: Trainer-context annotations are never aged out; the expiry gate is a strict no-op for trainers.
+
+**Independent Test**: On a trainer page, backdate a stored record's `savedAt` to well over 24h (e.g. 10 days), reload, and confirm annotations are still restored.
+
+> Note: The trainer skip is guaranteed by the `context === 'student'` guard added in T009. This phase adds the regression test that locks in permanence and verifies the guard.
+
+### Tests for User Story 3
+
+- [ ] T011 [P] [US3] Add e2e test "trainer annotations survive beyond 24h" to `tests/storage.spec.js`: on a trainer sample page (with a `.gf-persistent` flag or `ANALYSIS` anchor, using `localStorage`), seed annotations, backdate `savedAt` to 10 days ago, reload, assert annotations are STILL restored and the key remains (contract T-C, SC-003, FR-006)
+- [ ] T012 [P] [US3] Add e2e test "trainer record with missing savedAt is NOT discarded" to `tests/storage.spec.js`: on a trainer page, remove `savedAt`, reload, assert annotations still restored (contract behavior matrix, FR-006)
+
+### Implementation for User Story 3
+
+- [ ] T013 [US3] Verify the `context === 'student'` guard in `loadAnnotations()` (T009) correctly bypasses expiry for trainer context; adjust only if T011/T012 reveal a gap. Run `yarn test` to confirm both trainer tests pass
+
+**Checkpoint**: Trainer permanence proven; no regression to the trainer workflow.
+
+---
+
+## Phase 5: User Story 2 - Instructors can force an immediate reset (Priority: P2)
+
+**Goal**: Starting a fresh browser session yields no restored student annotations, giving instructors an immediate override.
+
+**Independent Test**: With student annotations present, start a fresh session (new `sessionStorage` context) and confirm nothing is restored.
+
+> Note: This behavior is provided by the existing `sessionStorage` scoping (feature 155) and is unchanged by this feature. This phase adds/asserts explicit coverage so the override is guarded against future regressions.
+
+### Tests for User Story 2
+
+- [ ] T014 [P] [US2] Add (or confirm existing in `tests/storage.spec.js`) an e2e test "fresh browser session restores no student annotations": seed student annotations, simulate a fresh session (new browser context / cleared `sessionStorage`) per the Playwright pattern already used in `tests/storage.spec.js`, reload, assert nothing restored (contract T-E, US2, FR-008). If already covered by a feature-155 test, reference it here instead of duplicating
+
+### Implementation for User Story 2
+
+- [ ] T015 [US2] No production code change expected. Run `yarn test` to confirm the fresh-session test passes with the new expiry gate in place (the gate must not break the existing session-scope behavior)
+
+**Checkpoint**: Instructor fresh-session override verified alongside the 24h cap.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, type safety, and final quality-gate verification.
+
+- [ ] T016 [P] Update the JSDoc header block at the top of `src/core/storage.js` to document the 24-hour student expiry (mention trainer permanence and the fail-safe on malformed `savedAt`)
+- [ ] T017 [P] If any student sample page lacks annotations tooling for the tests, add/verify a suitable student and trainer sample under `sample/` (only if T006/T011 need a dedicated fixture; otherwise skip)
+- [ ] T018 Run the full quality-gate trio required by the Constitution: `yarn typecheck`, `yarn test`, `yarn build` — all must be green (excluding any pre-existing failures recorded in T001)
+- [ ] T019 Walk through `quickstart.md` steps 1–5 manually against `yarn dev` to confirm the observable behavior matches the spec's success criteria
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+
+- **Setup (Phase 1)** → no dependencies.
+- **Foundational (Phase 2)** → depends on Setup. **BLOCKS all user stories** (T009/T013 require `isAnnotationExpired` + `STUDENT_TTL_MS`).
+- **US1 (Phase 3)** → depends on Foundational. Delivers the MVP.
+- **US3 (Phase 4)** → depends on T009 (shares the `loadAnnotations()` edit). Sequence after US1.
+- **US2 (Phase 5)** → depends on Foundational; independent of US1/US3 code but should run after T009 to confirm no regression.
+- **Polish (Phase 6)** → after all stories.
+
+### Story independence notes
+
+- US1 and US3 are two branches of the same `loadAnnotations()` change; implement US1's T009 first, then US3's tests assert the trainer branch. Their tests are independent.
+- US2 requires no new production code — it guards existing session scoping.
+
+### Within-phase parallel opportunities
+
+- Foundational: T003 and T004 touch the same file → sequential; T005 after both.
+- US1 tests T006, T007, T008 are `[P]` (independent test cases, same spec file — coordinate to avoid edit collisions; can be authored together).
+- US3 tests T011, T012 are `[P]`.
+- Polish T016 and T017 are `[P]`.
+
+### Parallel execution example
+
+```
+# After Phase 2 is complete, author the US1 test cases together:
+T006, T007, T008  (all target tests/storage.spec.js — same file, so land as one coordinated edit)
+# Then implement:
+T009 → T010
+# Then US3:
+T011, T012 (author together) → T013
+```
+
+## Implementation Strategy
+
+- **MVP = User Story 1** (Phase 1 → 2 → 3). This alone delivers the core assessment-integrity value: old student tonals stop resurfacing.
+- **Increment 2 = User Story 3** (Phase 4): lock in trainer permanence (guards against regression; same edit).
+- **Increment 3 = User Story 2** (Phase 5): explicit coverage of the instructor fresh-session override.
+- **Finish** with Phase 6 quality gates and the quickstart walkthrough.
+
+Total scope is intentionally small: one production file changed (`src/core/storage.js`), one test file extended (`tests/storage.spec.js`), no schema change or migration.
+
+## Task count summary
+
+- Setup: 2 (T001–T002)
+- Foundational: 3 (T003–T005)
+- US1 (P1, MVP): 5 (T006–T010)
+- US3 (P1): 3 (T011–T013)
+- US2 (P2): 2 (T014–T015)
+- Polish: 4 (T016–T019)
+- **Total: 19 tasks**


### PR DESCRIPTION
## Summary

Adds the feature specification for [issue #184](https://github.com/DeepBlueCLtd/GramFrame/issues/184) — "Reduce persistence of tonals for students".

Today student annotations persist for the entire browser session, which can last weeks if the PC is never shut down. That lets students revisit previously annotated grams during assessment. This spec caps **student** annotation persistence at **24 hours** while keeping **trainer** annotations permanent, and preserves the instructor override of forcing a reset via a fresh session (log out / back in).

This PR is **spec-only** — no source code changes yet. It is the output of `/speckit.specify` and is intended as the input to `/speckit.plan`.

## Files

- `specs/157-student-tonal-expiry/spec.md` — feature specification (user stories, functional requirements, success criteria, assumptions).
- `specs/157-student-tonal-expiry/checklists/requirements.md` — spec quality checklist (all items passing).

## Key decisions captured in the spec

- Expiry is evaluated on page load (matches the assessment revisit scenario); no background timer.
- The 24-hour window is measured from the **last save** of an annotation set, so actively worked-on grams stay available and untouched ones age out.
- Fail-safe toward clearing: entries with a missing, unparseable, or future timestamp are treated as expired.
- Trainer/student context detection is unchanged and out of scope.

Closes #184 once implemented (spec stage only for now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WaLrii2aRGWYMt2TjfHfiy)_