### PR TITLE
Spec: Symbols on harmonic pins (#185)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,8 @@ Example configuration:
 - Browser Web Storage API (localStorage / sessionStorage) (155-browser-storage)
 - JavaScript (ES2020+), JSDoc-typed, no compilation + None at runtime (zero runtime deps); Vite for build (156-expand-image-toggle)
 - N/A — expand state is in-memory only (explicitly NOT browser storage) (156-expand-image-toggle)
+- JavaScript ES2020+, JSDoc-typed (no TS compilation) + None at runtime (zero runtime deps); Vite for build (157-harmonic-pin-symbols)
+- Browser Web Storage (localStorage for trainers / sessionStorage for (157-harmonic-pin-symbols)
 
 ## Recent Changes
 - 154-enrich-docs: Added Markdown documentation (no code changes) + N/A (documentation-only feature)

--- a/specs/157-harmonic-pin-symbols/checklists/requirements.md
+++ b/specs/157-harmonic-pin-symbols/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Symbols on Harmonic Pins
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- All items pass. The only open design decision (whether to offer additional
+  filled symbols beyond circle/square/diamond, e.g. triangle/star) is captured
+  as an Assumption and does not affect scope; it can be finalised during
+  `/speckit.plan` without changing requirements.

--- a/specs/157-harmonic-pin-symbols/contracts/persistence-schema.md
+++ b/specs/157-harmonic-pin-symbols/contracts/persistence-schema.md
@@ -1,0 +1,67 @@
+# Contract: Persistence Schema (Backward-Compatible)
+
+## Storage module — `src/core/storage.js`
+
+### SCHEMA_VERSION
+
+**Unchanged: `SCHEMA_VERSION = 1`.**
+
+> ⚠️ `loadAnnotations` discards data with a **strict** check
+> `data.version !== SCHEMA_VERSION`. Bumping the version would DELETE all
+> existing v1 annotations on first load. The `symbol` field is therefore added
+> additively **without** a version bump.
+
+### Save — `saveAnnotations`
+
+Extend the harmonic-set mapping to include the symbol:
+
+```js
+harmonicSets: (state.harmonics?.harmonicSets || []).map(hs => ({
+  id: hs.id,
+  color: hs.color,
+  anchorTime: hs.anchorTime,
+  spacing: hs.spacing,
+  symbol: hs.symbol || 'circle'   // NEW
+}))
+```
+
+### Load — `loadAnnotations`
+
+No change. Returns the raw `StoredAnnotations` (version `1`), including any
+`symbol` present. Legacy records simply lack the key.
+
+## Restore — `src/main.js` `_restoreAnnotations`
+
+Apply the default when the field is absent (legacy data):
+
+```js
+if (saved.harmonics && Array.isArray(saved.harmonics.harmonicSets)) {
+  this.state.harmonics.harmonicSets = saved.harmonics.harmonicSets.map(hs => ({
+    ...hs,
+    symbol: hs.symbol || 'circle'   // legacy → circle
+  }))
+}
+```
+
+## Compatibility matrix
+
+| Stored data | Loaded by | Result |
+|-------------|-----------|--------|
+| v1 **without** `symbol` (legacy) | new build | loads; each set → `circle` |
+| v1 **with** `symbol` (new) | new build | loads; symbol preserved |
+| v1 **with** `symbol` (new) | old build | loads; unknown `symbol` key ignored |
+| v1 without `symbol` | old build | loads unchanged (baseline) |
+
+All four cases load successfully — no data loss in any direction.
+
+## Round-trip invariant
+
+> For any harmonic set created and saved by the new build, reloading yields a
+> harmonic set whose `symbol` equals the saved value (FR-008 / SC-004).
+
+## Test hooks
+
+- Seed storage with a legacy blob (no `symbol`) → reload → assert every pin/table
+  swatch is `circle` (SC-005).
+- Create sets with distinct symbols → save → reload → assert each `symbol`
+  survives (SC-004).

--- a/specs/157-harmonic-pin-symbols/contracts/state-shape.md
+++ b/specs/157-harmonic-pin-symbols/contracts/state-shape.md
@@ -1,0 +1,52 @@
+# Contract: State Shape Additions
+
+## Global state — `src/core/state.js` / `GramFrameState`
+
+Add one field, initialised to the default symbol:
+
+```js
+// getInitialState() additions
+selectedSymbol: 'circle'   // SymbolType — symbol applied to the next created harmonic set
+```
+
+- **Type**: `SymbolType` (see symbol-catalog).
+- **Default**: `'circle'`.
+- **Deep-copy**: covered by the existing deep-copy-before-notify path; a string
+  field needs no special handling.
+- **Writer**: `SymbolPicker.js` sets `state.selectedSymbol` on selection change.
+- **Reader**: `HarmonicsMode.addHarmonicSet` reads it when creating a set.
+
+## Harmonic set — `HarmonicSet` (runtime)
+
+```js
+/**
+ * @property {SymbolType} symbol - Filled shape drawn at the top of each pin
+ */
+```
+
+Assigned at creation (parallels colour):
+
+```js
+// HarmonicsMode.addHarmonicSet
+const symbol = this.instance.state.selectedSymbol || 'circle'
+const harmonicSet = { id, color, anchorTime, spacing, symbol }
+```
+
+## Type definitions — `src/types.js`
+
+Add:
+
+```js
+/** @typedef {'circle'|'square'|'diamond'|'triangle'|'triangle-down'|'star'} SymbolType */
+```
+
+Extend `HarmonicSet` with `symbol: SymbolType`, `StoredHarmonicSet` with
+`symbol?: SymbolType`, and the state typedef with `selectedSymbol: SymbolType`.
+
+## Invariants
+
+- Every harmonic set created after this feature has a defined `symbol`.
+- Reading `state.selectedSymbol` always yields a valid `SymbolType` (default
+  `circle`).
+- No other mode reads or writes `selectedSymbol` (harmonics-only concern; the
+  field lives in shared state only to mirror the colour-picker pattern).

--- a/specs/157-harmonic-pin-symbols/contracts/symbol-catalog.md
+++ b/specs/157-harmonic-pin-symbols/contracts/symbol-catalog.md
@@ -1,0 +1,44 @@
+# Contract: Symbol Catalogue
+
+Defines the canonical set of symbols, their identifiers, and the SVG mark each
+produces. This is the single source of truth shared by the selector, the pin
+renderer, and the harmonics-table swatch.
+
+## Catalogue
+
+| id | Display name | SVG primitive (centred at `cx,cy`, radius `r`) |
+|----|--------------|------------------------------------------------|
+| `circle` | Circle | `<circle cx cy r>` |
+| `square` | Square | `<rect x=cx-r y=cy-r width=2r height=2r>` |
+| `diamond` | Diamond | `<polygon>` points (cx,cy-r)(cx+r,cy)(cx,cy+r)(cx-r,cy) |
+| `triangle` | Triangle | `<polygon>` points (cx,cy-r)(cx+r,cy+r)(cx-r,cy+r) |
+| `triangle-down` | Triangle (down) | `<polygon>` points (cx,cy+r)(cx+r,cy-r)(cx-r,cy-r) |
+| `star` | Star | `<polygon>` 5-point star, outer `r`, inner `~0.5r` |
+
+## Factory contract — `src/rendering/symbols.js`
+
+```
+createSymbolMark(symbolType, cx, cy, size, color) → SVGElement
+```
+
+- **Inputs**:
+  - `symbolType`: one of the catalogue ids; any unknown/`null`/`undefined`
+    value MUST fall back to `circle`.
+  - `cx`, `cy`: centre coordinates in the SVG overlay coordinate space.
+  - `size`: nominal diameter in px (default target ~10–12px on a pin).
+  - `color`: fill colour (the harmonic set's hex colour).
+- **Output**: a single SVG element, `fill = color`, no stroke required (filled
+  marks). The element MUST carry a class (e.g. `gram-frame-harmonic-symbol`) so
+  it is removable/queryable, and — for pin marks — `data-harmonic-set-id`.
+- **Purity**: no DOM insertion, no state reads; returns a detached element the
+  caller appends. Same factory is used for the table swatch (small fixed size).
+
+## Default & legacy fallback
+
+- The default selected symbol is `circle`.
+- Any harmonic set with an absent/unrecognised symbol renders as `circle`.
+
+## Extensibility
+
+Adding a symbol = adding one catalogue row + one branch in the factory. No
+changes to state, persistence, or the selector wiring beyond listing the new id.

--- a/specs/157-harmonic-pin-symbols/data-model.md
+++ b/specs/157-harmonic-pin-symbols/data-model.md
@@ -1,0 +1,87 @@
+# Phase 1 Data Model: Symbols on Harmonic Pins
+
+## Entities
+
+### SymbolType (enumeration)
+
+A named filled shape used as a colour-blind-friendly visual code.
+
+| Value | Shape | Notes |
+|-------|-------|-------|
+| `circle` | ● | **Default**; legacy fallback |
+| `square` | ■ | |
+| `diamond` | ◆ | |
+| `triangle` | ▲ | |
+| `triangle-down` | ▼ | inverted triangle |
+| `star` | ★ | |
+
+- **Validation**: A symbol value MUST be one of the enumeration values above.
+  Any unknown/absent value resolves to `circle`.
+- **Default**: `circle`.
+
+### HarmonicSet (extended — runtime state)
+
+Existing entity in `src/types.js`; this feature adds one field.
+
+| Field | Type | Existing? | Description |
+|-------|------|-----------|-------------|
+| `id` | string | existing | Unique identifier |
+| `color` | string (hex) | existing | Display colour for lines/label/symbol |
+| `anchorTime` | number | existing | Y-axis (time) position in seconds |
+| `spacing` | number | existing | Frequency spacing between harmonics (Hz) |
+| **`symbol`** | **SymbolType** | **NEW** | **Filled shape drawn at the top of each pin; shown in the harmonics table** |
+
+- **Relationships**: One symbol per harmonic set; the symbol is drawn on **every
+  pin** of that set and once in the harmonics-table row for that set.
+- **Assignment on creation**: `symbol = state.selectedSymbol ?? 'circle'`
+  (parallels the existing `color = state.selectedColor` logic in
+  `HarmonicsMode.addHarmonicSet`).
+- **State transitions**: none intrinsic; symbol is set at creation. (Future
+  per-set re-editing is out of scope for this feature.)
+
+### GramFrameState (extended — global)
+
+| Field | Type | Existing? | Description |
+|-------|------|-----------|-------------|
+| `selectedColor` | string (hex) | existing | Colour applied to the next created feature |
+| **`selectedSymbol`** | **SymbolType** | **NEW** | **Symbol applied to the next created harmonic set** |
+
+- **Default**: `selectedSymbol: 'circle'` (initialised in `src/core/state.js`).
+- **Writer**: the symbol selector UI (`SymbolPicker.js`).
+- **Readers**: `HarmonicsMode.addHarmonicSet` (both click/drag and manual-add
+  paths, since manual-add calls the same function).
+
+### StoredHarmonicSet (extended — persisted)
+
+Persisted subset in `src/core/storage.js` / `src/types.js`; adds one field.
+
+| Field | Type | Existing? | Description |
+|-------|------|-----------|-------------|
+| `id` | string | existing | Unique identifier |
+| `color` | string (hex) | existing | Display colour |
+| `anchorTime` | number | existing | Y-axis position (s) |
+| `spacing` | number | existing | Frequency spacing (Hz) |
+| **`symbol`** | **SymbolType (optional)** | **NEW** | **Persisted symbol; ABSENT in legacy (pre-feature) records** |
+
+- **Save**: `saveAnnotations` writes `symbol: hs.symbol` for every set.
+- **Load**: `loadAnnotations` returns the raw record; `_restoreAnnotations` in
+  `main.js` applies `symbol: hs.symbol || 'circle'` so legacy records (no
+  `symbol`) become `circle`.
+- **Schema version**: `SCHEMA_VERSION` stays **1** — the field is additive and
+  backward-compatible; no migration and no data discard.
+
+## Backward-compatibility invariant
+
+> A stored annotations blob written by any prior build (with no `symbol` on its
+> harmonic sets) MUST load without error, and every such harmonic set MUST
+> render with the `circle` symbol.
+
+This is guaranteed by (a) not changing `SCHEMA_VERSION`, and (b) the
+`hs.symbol || 'circle'` fallback on restore.
+
+## Derived / rendering data (not persisted)
+
+- **Pin symbol mark**: computed at render time from `(harmonicSet.symbol,
+  lineX, lineTop, size, harmonicSet.color)` by `src/rendering/symbols.js`.
+- **Table symbol swatch**: computed from `(harmonicSet.symbol, color)` by the
+  same factory; not stored.

--- a/specs/157-harmonic-pin-symbols/plan.md
+++ b/specs/157-harmonic-pin-symbols/plan.md
@@ -1,0 +1,133 @@
+# Implementation Plan: Symbols on Harmonic Pins
+
+**Branch**: `157-harmonic-pin-symbols` | **Date**: 2026-07-17 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/157-harmonic-pin-symbols/spec.md`
+
+## Summary
+
+Add a per-harmonic-set **symbol** (a filled shape: circle, square, diamond, and
+additional shapes) as a colour-blind-friendly visual code that complements the
+existing per-set colour. A symbol drop-down is added next to the colour picker
+in the main control panel; the currently selected symbol is applied to each new
+harmonic set (created via click/drag or the manual add dialog). Each pin renders
+a filled, colour-coded symbol at the top of its vertical line (clear of the pin
+label, which sits to the right of the line), and the harmonics table shows the
+symbol in the set's colour. The symbol is persisted with each harmonic set;
+legacy records saved before this feature reload with a default circle.
+
+Technical approach: extend the harmonic-set data shape with a `symbol` field,
+add a `selectedSymbol` field to global state fed by a new symbol-selector UI
+component, render symbols as SVG `<path>`/`<polygon>` marks in the existing
+harmonic cursor group, mirror the mark in the harmonics table (inline SVG), and
+extend the persistence layer with an **additive, backward-compatible** `symbol`
+field (no schema-version bump, so existing v1 data still loads).
+
+## Technical Context
+
+**Language/Version**: JavaScript ES2020+, JSDoc-typed (no TS compilation)
+**Primary Dependencies**: None at runtime (zero runtime deps); Vite for build
+**Storage**: Browser Web Storage (localStorage for trainers / sessionStorage for
+students), via `src/core/storage.js`; `StoredHarmonicSet` gains an optional
+`symbol` field. Schema version stays `1` (additive, backward-compatible).
+**Testing**: Playwright end-to-end (`yarn test`), `GramFramePage` helper class
+**Target Platform**: Modern evergreen browsers (SVG-based overlay component)
+**Project Type**: Single-project front-end library/component (Option 1)
+**Performance Goals**: Interactive 60fps overlay; symbol rendering must not add
+perceptible lag during click/drag creation or re-render of persistent features
+**Constraints**: SVG-only overlays (no Canvas/absolute-DOM for overlays);
+`yarn typecheck` + `yarn test` + `yarn build` must all pass; state deep-copied
+before listener notification; HMR preserves listeners
+**Scale/Scope**: ~6–8 filled symbol shapes; unbounded harmonic sets per instance
+(practically a handful); one new UI component; edits to ~8 existing files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+**I. SVG-First Rendering** — PASS. Symbols are rendered as SVG marks
+(`<path>`/`<polygon>`/`<circle>`) appended to the existing `cursorGroup`, using
+the established `calculateZoomAwarePosition` coordinate transform. No Canvas or
+absolute-positioned DOM overlays. The harmonics-table symbol swatch is inline
+SVG inside the existing table cell (table is normal DOM UI, not a spectrogram
+overlay — consistent with the current colour swatch `<div>`). Marks carry
+`data-*` attributes for Playwright queryability.
+
+**II. Test-First (NON-NEGOTIABLE)** — PASS (with obligation). New Playwright
+coverage will be added for: symbol selector presence/options, symbol on pin
+after click/drag creation, symbol on pin after manual-add, symbol shown in the
+harmonics table in set colour, persistence round-trip of the symbol, and legacy
+(no-symbol) reload defaulting to circle. `yarn typecheck` and `yarn test` must
+pass before merge.
+
+**III. Modular Mode Architecture** — PASS. Harmonic-specific rendering stays in
+`src/modes/harmonics/`. The symbol selector is a shared UI component (like the
+colour picker) writing to global `state.selectedSymbol`; harmonic set creation
+reads it exactly as it already reads `state.selectedColor`. No mode-to-mode
+dependencies introduced; no changes required to other modes.
+
+**IV. Declarative HTML Configuration** — PASS / N/A. No change to the
+`gram-config` table contract; the symbol is a runtime interaction attribute, not
+authored configuration.
+
+**Technical Constraints** — PASS. JSDoc types updated for `HarmonicSet`,
+`StoredHarmonicSet`, and `selectedSymbol`; state remains centralized and
+deep-copied; persistence remains backward-compatible.
+
+**Result**: No violations. Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/157-harmonic-pin-symbols/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   ├── symbol-catalog.md      # Available symbols + default/legacy contract
+│   ├── state-shape.md         # selectedSymbol + HarmonicSet.symbol contract
+│   └── persistence-schema.md  # StoredHarmonicSet.symbol backward-compat contract
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (already created by /speckit.specify)
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── components/
+│   ├── SymbolPicker.js          # NEW — drop-down symbol selector (writes state.selectedSymbol)
+│   ├── ColorPicker.js           # unchanged (sibling reference for placement/pattern)
+│   ├── MainUI.js                # EDIT — mount SymbolPicker next to the colour picker
+│   ├── HarmonicPanel.js         # EDIT — render symbol swatch (in set colour) in table row
+│   └── UIComponents.js          # EDIT — re-export createSymbolPicker (mirrors color picker)
+├── core/
+│   ├── state.js                 # EDIT — add selectedSymbol default ('circle')
+│   └── storage.js               # EDIT — persist hs.symbol (additive; SCHEMA_VERSION stays 1)
+├── modes/
+│   └── harmonics/
+│       ├── HarmonicsMode.js     # EDIT — set symbol on create; render symbol mark at pin top
+│       └── ManualHarmonicModal.js # (no UI change; symbol taken from global state on create)
+├── rendering/
+│   └── symbols.js               # NEW — pure SVG mark factory (shape → SVG element/path)
+├── main.js                      # EDIT — _restoreAnnotations applies default 'circle' when symbol absent
+└── types.js                     # EDIT — HarmonicSet.symbol, StoredHarmonicSet.symbol, selectedSymbol, SymbolType
+
+tests/
+├── harmonic-symbols.spec.js     # NEW — selector, pin render, table swatch, persistence, legacy default
+└── helpers/                     # EDIT if needed — GramFramePage helpers for symbol assertions
+```
+
+**Structure Decision**: Single-project front-end component (constitution
+Option 1). New symbol rendering lives in a small pure module `src/rendering/
+symbols.js` (shape→SVG), consumed by both the harmonic pin renderer and the
+harmonics-table swatch so the two stay visually identical. The selector follows
+the existing `ColorPicker.js` → `MainUI.js` → global-state pattern exactly,
+keeping symbol handling parallel to colour handling throughout.
+
+## Complexity Tracking
+
+> No constitution violations — section intentionally empty.

--- a/specs/157-harmonic-pin-symbols/quickstart.md
+++ b/specs/157-harmonic-pin-symbols/quickstart.md
@@ -1,0 +1,62 @@
+# Quickstart: Symbols on Harmonic Pins
+
+## What this feature does
+
+Adds a **symbol** (filled shape) to each harmonic set as a colour-blind-friendly
+code alongside colour. You pick a symbol from a drop-down next to the colour
+picker; every new harmonic set draws that filled symbol — in the set's colour —
+at the top of each pin and in the harmonics table.
+
+## Try it (manual)
+
+1. `yarn dev` and open the debug page.
+2. Switch to **Harmonics** mode.
+3. In the control panel, next to **Color**, open the new **Symbol** drop-down and
+   pick e.g. **Diamond**. Pick a colour too.
+4. Click/drag on the spectrogram to create a harmonic set → each pin shows a
+   filled diamond in the chosen colour at the top of its vertical line, clear of
+   the pin-number label (which sits to the right of the line).
+5. Check the **Harmonics** table on the right → the set's row shows a diamond in
+   the same colour.
+6. Use the **Manual** add dialog to add another set → it uses the currently
+   selected symbol too.
+7. Reload the page (on a trainer/persistent page) → sets come back with their
+   symbols intact.
+
+## Verify legacy behaviour
+
+1. In devtools, seed storage with a pre-feature blob (harmonic sets **without** a
+   `symbol` field), keeping `version: 1`.
+2. Reload → every legacy harmonic set renders with a **circle** and does not
+   error.
+
+## Developer entry points
+
+| Concern | File |
+|---------|------|
+| Symbol drop-down UI | `src/components/SymbolPicker.js` (new) |
+| Mount next to colour picker | `src/components/MainUI.js` |
+| Default selected symbol | `src/core/state.js` (`selectedSymbol: 'circle'`) |
+| Assign symbol on create | `src/modes/harmonics/HarmonicsMode.js` (`addHarmonicSet`) |
+| Draw symbol on pin | `src/modes/harmonics/HarmonicsMode.js` (`renderHarmonicSet`) + `src/rendering/symbols.js` (new) |
+| Table swatch | `src/components/HarmonicPanel.js` |
+| Persist symbol | `src/core/storage.js` (`saveAnnotations`) |
+| Legacy default on load | `src/main.js` (`_restoreAnnotations`) |
+| Types | `src/types.js` (`SymbolType`, `HarmonicSet.symbol`, `StoredHarmonicSet.symbol`, `selectedSymbol`) |
+
+## Gates before merge
+
+```bash
+yarn typecheck   # zero errors
+yarn test        # all Playwright tests green (incl. new harmonic-symbols spec)
+yarn build       # clean production build
+```
+
+## Key design guardrails
+
+- **SVG only** — symbols are SVG marks in `cursorGroup`; no Canvas, no
+  absolute-DOM overlays (constitution I).
+- **No schema bump** — `SCHEMA_VERSION` stays `1`; `symbol` is additive so
+  legacy data is never discarded (see contracts/persistence-schema.md).
+- **Mirror the colour pattern** — symbol handling parallels `selectedColor`
+  end-to-end so the code stays consistent and discoverable.

--- a/specs/157-harmonic-pin-symbols/research.md
+++ b/specs/157-harmonic-pin-symbols/research.md
@@ -1,0 +1,123 @@
+# Phase 0 Research: Symbols on Harmonic Pins
+
+All Technical Context items were resolvable from the existing codebase and the
+issue; there are no remaining NEEDS CLARIFICATION items. Decisions below record
+the reasoning so Phase 1/2 can proceed unambiguously.
+
+## Decision 1 — Symbol catalogue
+
+**Decision**: Offer filled shapes: **circle, square, diamond, triangle,
+inverted-triangle, star**. Circle is the default and the legacy fallback.
+
+**Rationale**: The issue explicitly names circle, square, diamond and asks
+"are there any other typical filled symbols we could plot?". Triangle,
+inverted-triangle, and star are the standard additional filled markers used by
+plotting libraries (matplotlib/plotly/d3 symbol sets) and remain distinguishable
+at small (~10px) sizes rendered on a pin and in a table cell. Six shapes give
+analysts enough distinct codes without crowding the drop-down or risking
+shape-confusion at small sizes.
+
+**Alternatives considered**:
+- *Only the three named shapes* — rejected; the issue invites more, and three is
+  limiting when many sets coexist.
+- *Plus/cross/hexagon/pentagon* — deferred; plus/cross are line marks (not
+  "filled"), and hexagon/pentagon read as circles at ~10px. Kept out to preserve
+  at-a-glance distinctiveness. The catalogue is a data list and can be extended
+  later without architectural change.
+
+## Decision 2 — Symbol rendering technique (SVG)
+
+**Decision**: Render each symbol as an SVG mark appended to the existing
+`instance.cursorGroup`, positioned at the **top of each pin's vertical line**
+(at `lineTop`, centred on `lineX`), filled with the harmonic set's colour.
+Implement a pure factory `src/rendering/symbols.js` that maps `(symbolType, cx,
+cy, size, color)` → an SVG element (`<circle>`, `<polygon>`, or `<path>`).
+
+**Rationale**: Constitution Principle I mandates SVG for all overlays and use of
+the established coordinate transforms. Pins are already SVG lines produced in
+`HarmonicsMode.renderHarmonicSet` via `calculateZoomAwarePosition`; adding a
+sibling SVG mark at `lineTop` reuses that geometry and stays zoom/expand-aware.
+A shared pure factory lets the harmonics table reuse the identical shape drawing
+so the on-pin mark and the table swatch match exactly.
+
+**Alternatives considered**:
+- *Canvas or Unicode/emoji glyphs in a `<text>` element* — Canvas is forbidden
+  by the constitution; text glyphs render inconsistently across fonts/OSes and
+  are hard to colour precisely and query in tests.
+- *One symbol per pin vs one per set* — one symbol per set (drawn on every pin
+  of that set) is chosen, mirroring how colour is a per-set attribute.
+
+**Placement detail**: The pin label (harmonic number) is drawn at `lineX + 3,
+lineTop + 12` (right of the line). The symbol is centred on the line at the very
+top (`lineTop`, offset slightly up), so it does not overlap the label — directly
+satisfying FR-006. Near the top edge of the spectrogram the mark is nudged so it
+stays fully visible.
+
+## Decision 3 — Symbol selector UI
+
+**Decision**: A native `<select>` drop-down (`src/components/SymbolPicker.js`),
+mounted in the controls column immediately after the colour picker in
+`MainUI.js`. Each option shows the shape name; the selector writes the chosen
+value to `state.selectedSymbol`. Optionally each option is prefixed with a small
+inline-SVG/Unicode preview for recognisability.
+
+**Rationale**: The issue asks specifically for a "drop-down". This mirrors the
+existing colour-picker placement and the global-state pattern
+(`state.selectedColor`), so harmonic creation can read `state.selectedSymbol`
+with the same fallback logic it already uses for colour. Native `<select>` is
+zero-dependency, accessible, and Playwright-friendly.
+
+**Alternatives considered**:
+- *Custom pop-over palette* — heavier, more code, no benefit over a native
+  select for ~6 options.
+- *Per-set editing in the table* — out of scope for this issue (which is about
+  choosing the symbol for the *next* set); can be added later.
+
+## Decision 4 — Persistence & backward compatibility
+
+**Decision**: Add `symbol` as an **optional, additive** field on
+`StoredHarmonicSet`. **Keep `SCHEMA_VERSION = 1`.** On load, when a harmonic
+set has no `symbol`, apply the default `'circle'` in `_restoreAnnotations`.
+
+**Rationale**: `loadAnnotations` in `src/core/storage.js` currently discards
+stored data with a **strict** check `data.version !== SCHEMA_VERSION`. Bumping
+the version to 2 would therefore *delete every existing v1 annotation* on first
+load — the opposite of the issue's requirement to "display a circle marker when
+we reload legacy harmonics that were persisted before this change." Because the
+new field is purely additive (older builds simply ignore an unknown key, and the
+new build tolerates its absence), no version bump is needed. This preserves all
+existing saved work and satisfies FR-008/FR-009 and SC-004/SC-005.
+
+**Alternatives considered**:
+- *Bump SCHEMA_VERSION to 2 with a migration* — rejected: the strict-equality
+  guard discards non-matching versions outright, so this would destroy legacy
+  data unless the guard is also rewritten into a migration path — more code and
+  more risk for no benefit over an additive field.
+- *Store symbol only when non-default* — unnecessary micro-optimisation; always
+  writing the field keeps save/load symmetric and simpler to reason about.
+
+## Decision 5 — Harmonics table affordance
+
+**Decision**: In `HarmonicPanel.js`, render the set's symbol as a small inline
+SVG mark filled with the set's colour, in (or alongside) the existing colour
+cell, produced by the same `src/rendering/symbols.js` factory.
+
+**Rationale**: FR-007 / the issue's core accessibility goal — the table should
+show the symbol in the harmonic colour as a colour-blind affordance. Reusing the
+shared factory guarantees the table mark matches the on-pin mark.
+
+**Alternatives considered**:
+- *Separate CSS-shape implementation for the table* — rejected; risks visual
+  drift from the SVG pin mark and duplicates shape logic.
+
+## Summary of resolved unknowns
+
+| Topic | Resolution |
+|-------|------------|
+| Which symbols | circle, square, diamond, triangle, inverted-triangle, star |
+| Default / legacy fallback | circle |
+| Render tech | SVG marks via shared pure factory (`rendering/symbols.js`) |
+| Selector | native `<select>` next to colour picker → `state.selectedSymbol` |
+| Persistence | additive `symbol` field, `SCHEMA_VERSION` stays 1 |
+| Table affordance | inline SVG mark in set colour, same factory |
+| One-per-set vs per-pin | one symbol per set, drawn on every pin |

--- a/specs/157-harmonic-pin-symbols/spec.md
+++ b/specs/157-harmonic-pin-symbols/spec.md
@@ -1,0 +1,180 @@
+# Feature Specification: Symbols on Harmonic Pins
+
+**Feature Branch**: `157-harmonic-pin-symbols`  
+**Created**: 2026-07-17  
+**Status**: Draft  
+**Input**: User description: "GH issue 185 — Symbols on harmonic pins"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Distinguish harmonic sets by symbol as well as colour (Priority: P1)
+
+An analyst is examining a spectrogram that contains several overlapping harmonic
+sets. Before placing a new harmonic set they choose both a colour and a symbol
+(circle, square, or diamond) from the main control panel. When they draw the
+harmonic set, a filled symbol in the chosen colour appears at the top of each
+pin. Because each set now carries a distinct symbol as well as a colour, the
+analyst — including a colour-blind analyst — can tell the sets apart at a
+glance, both on the overlay and in the harmonics table.
+
+**Why this priority**: This is the core value of the feature. Colour alone is
+insufficient for colour-blind analysts, and even for others overlapping sets in
+similar colours are hard to separate. The symbol affordance is what the issue
+asks for and delivers immediate accessibility benefit.
+
+**Independent Test**: Select a symbol from the selector, create a harmonic set,
+and confirm a filled symbol of that shape and colour renders at the top of the
+pins and appears next to that set in the harmonics table. Fully testable on its
+own and delivers the primary value.
+
+**Acceptance Scenarios**:
+
+1. **Given** the control panel with a symbol selector, **When** the analyst
+   opens the selector, **Then** they can choose from at least circle, square,
+   and diamond filled symbols.
+2. **Given** the analyst has chosen a colour and a symbol, **When** they create
+   a harmonic set by click/drag, **Then** a filled symbol of the chosen shape
+   and colour is displayed at the top of the pin.
+3. **Given** the analyst has chosen a colour and a symbol, **When** they add a
+   harmonic set via the manual add dialog, **Then** the created set shows the
+   same chosen symbol at the top of its pin.
+4. **Given** a harmonic set with an assigned symbol, **When** the analyst views
+   the harmonics table, **Then** the set's row shows that symbol rendered in the
+   set's colour.
+5. **Given** a pin with a symbol at its top, **When** the analyst reads the pin
+   label, **Then** the label (drawn to the right of the vertical line) is not
+   obscured by the symbol.
+
+---
+
+### User Story 2 - Preserve symbols across save and reload (Priority: P2)
+
+An analyst annotates a spectrogram with several symbol-coded harmonic sets and
+later reopens the same material. Every harmonic set returns with the same colour
+and the same symbol it was created with, so the analyst's colour/symbol coding
+survives the round trip.
+
+**Why this priority**: The colour/symbol coding only stays useful if it
+persists. Without persistence the analyst must re-assign symbols each session,
+undermining the accessibility benefit. Depends on Story 1 existing.
+
+**Independent Test**: Create harmonic sets with different symbols, persist and
+reload the annotations, and confirm each set reloads with its original symbol.
+
+**Acceptance Scenarios**:
+
+1. **Given** harmonic sets each carrying a distinct symbol, **When** the
+   annotations are saved and reloaded, **Then** each set is restored with its
+   original symbol and colour.
+
+---
+
+### User Story 3 - Gracefully display legacy harmonics that predate symbols (Priority: P2)
+
+An analyst reloads annotations that were saved before symbols existed. Those
+harmonic sets have no stored symbol, yet they must still render cleanly. Each
+legacy harmonic set is shown with a default circle symbol so the display is
+consistent and nothing appears broken.
+
+**Why this priority**: Existing saved annotations must not break or disappear
+when the feature ships. Backward compatibility protects analysts' prior work.
+
+**Independent Test**: Load annotation data that lacks any symbol information and
+confirm every harmonic set renders with a circle symbol without error.
+
+**Acceptance Scenarios**:
+
+1. **Given** persisted harmonic data created before this feature (no symbol
+   recorded), **When** the annotations are reloaded, **Then** each affected
+   harmonic set displays a circle symbol.
+2. **Given** such legacy harmonic sets are reloaded and shown with a circle,
+   **When** the analyst changes or re-saves them, **Then** the now-assigned
+   symbol persists on subsequent reloads.
+
+---
+
+### Edge Cases
+
+- When the analyst has not explicitly chosen a symbol yet, a sensible default
+  symbol (circle) is used so every new harmonic set always has a symbol.
+- When many harmonic sets share the same colour but different symbols, each set
+  remains individually distinguishable by its symbol.
+- When a pin sits near the top edge of the spectrogram, the symbol still renders
+  legibly and does not overlap the pin label.
+- When the same symbol and colour are chosen for more than one set, the system
+  allows it (symbol is a visual aid, not a uniqueness constraint).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The main control panel MUST provide a symbol selector alongside
+  the existing colour selector.
+- **FR-002**: The symbol selector MUST be presented as a drop-down list of
+  filled symbols and MUST include at least circle, square, and diamond.
+- **FR-003**: The system MUST record the analyst's currently selected symbol so
+  it applies to the next harmonic set created.
+- **FR-004**: When a harmonic set is created by click/drag, the system MUST
+  render a filled symbol of the selected shape at the top of the pin, in the
+  harmonic set's colour.
+- **FR-005**: When a harmonic set is created via the manual add dialog, the
+  system MUST apply the selected symbol in the same way as click/drag creation.
+- **FR-006**: The pin symbol MUST be positioned so that it does not conflict
+  with or obscure the pin label, which is drawn to the right of the vertical
+  line.
+- **FR-007**: The harmonics table MUST display each harmonic set's symbol,
+  rendered in that set's colour, as a colour-blind-friendly affordance.
+- **FR-008**: The persisted representation of a harmonic set MUST include its
+  symbol so the symbol is restored on reload.
+- **FR-009**: When reloading persisted harmonic sets that have no recorded
+  symbol (legacy data), the system MUST display a circle symbol for those sets.
+- **FR-010**: The system MUST assign a default symbol (circle) to any new
+  harmonic set for which the analyst has not explicitly chosen a symbol.
+- **FR-011**: Each symbol in the selector MUST be visually distinguishable from
+  the others at the size rendered on a pin and in the harmonics table.
+
+### Key Entities *(include if data involved)*
+
+- **Harmonic Set**: A set of harmonic overlay pins the analyst places on the
+  spectrogram. Already carries a colour and position/spacing; this feature adds
+  a **symbol** attribute (one of the available filled shapes) that determines
+  the marker drawn at the top of each pin and shown in the harmonics table.
+- **Symbol**: A named filled shape (circle, square, diamond, and any additional
+  shapes offered) used as a colour-blind-friendly visual code for a harmonic
+  set. Selected in the control panel and persisted with the harmonic set.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An analyst can assign a symbol to a new harmonic set and see it on
+  the pin within a single interaction (one selection plus one create action),
+  with no additional steps.
+- **SC-002**: 100% of harmonic sets created after this feature ships display a
+  filled, colour-coded symbol at the top of their pins.
+- **SC-003**: 100% of harmonic sets shown in the harmonics table display their
+  symbol in the set's colour.
+- **SC-004**: When saved and reloaded, 100% of harmonic sets retain the symbol
+  they were assigned.
+- **SC-005**: 100% of legacy harmonic sets (persisted before this feature) load
+  without error and display a circle symbol.
+- **SC-006**: A colour-blind analyst can correctly distinguish overlapping
+  harmonic sets that share similar colours by symbol alone.
+
+## Assumptions
+
+- The symbol set offered is circle, square, and diamond at minimum. Additional
+  common filled shapes (for example triangle and star) may be added to give
+  analysts more distinct options; the exact final list is a design detail that
+  does not change scope.
+- Symbols are a visual coding aid only; the system does not enforce uniqueness
+  of symbol or symbol+colour combinations across harmonic sets.
+- The symbol applies to the whole harmonic set (one symbol per set, shown on
+  each pin of that set), consistent with colour being a per-set attribute.
+- The default symbol for both new sets with no explicit choice and reloaded
+  legacy sets is a circle.
+- Persistence uses the existing annotation storage mechanism; this feature
+  extends the stored harmonic-set record with a symbol field and remains
+  backward compatible with records that lack it.
+- The manual add dialog and click/drag creation both draw the new symbol from
+  the same currently selected symbol in the control panel.

--- a/specs/157-harmonic-pin-symbols/tasks.md
+++ b/specs/157-harmonic-pin-symbols/tasks.md
@@ -1,0 +1,204 @@
+# Tasks: Symbols on Harmonic Pins
+
+**Input**: Design documents from `/specs/157-harmonic-pin-symbols/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: INCLUDED — the GramFrame constitution (Principle II, Test-First,
+NON-NEGOTIABLE) requires Playwright coverage for all user-facing behavior, and
+the spec defines explicit acceptance scenarios per story.
+
+**Organization**: Tasks are grouped by user story so each can be implemented and
+tested independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on incomplete tasks)
+- **[Story]**: US1 / US2 / US3 (from spec.md)
+- Exact file paths included
+
+## Path Conventions
+
+Single-project front-end component: `src/` and `tests/` at repository root
+(per plan.md Structure Decision).
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: No project initialization needed (existing repo, zero runtime
+deps). Establish the shared type vocabulary the whole feature uses.
+
+- [ ] T001 Add `SymbolType` JSDoc typedef (`'circle'|'square'|'diamond'|'triangle'|'triangle-down'|'star'`) in `src/types.js`, and extend `HarmonicSet` with `symbol: SymbolType`, `StoredHarmonicSet` with optional `symbol?: SymbolType`, and the `GramFrameState` typedef with `selectedSymbol: SymbolType` (see contracts/state-shape.md)
+
+**Checkpoint**: Types compile — `yarn typecheck` still clean.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core building blocks every user story depends on: the default
+selected-symbol state and the shared SVG mark factory.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T002 Add `selectedSymbol: 'circle'` default to the initial state in `src/core/state.js` (mirrors `selectedColor`)
+- [ ] T003 [P] Create shared pure SVG mark factory `src/rendering/symbols.js` exporting `createSymbolMark(symbolType, cx, cy, size, color) → SVGElement` for all catalogue shapes (circle, square, diamond, triangle, triangle-down, star), defaulting unknown/absent values to `circle`, with class `gram-frame-harmonic-symbol` and `fill = color` (see contracts/symbol-catalog.md)
+
+**Checkpoint**: Factory returns a correct detached SVG element for every symbol
+id; state exposes `selectedSymbol`.
+
+---
+
+## Phase 3: User Story 1 - Distinguish harmonic sets by symbol as well as colour (Priority: P1) 🎯 MVP
+
+**Goal**: Analyst chooses a symbol from a control-panel drop-down; every new
+harmonic set (click/drag or manual add) draws that filled symbol in the set's
+colour at the top of each pin (clear of the pin label), and the harmonics table
+shows the symbol in the set's colour.
+
+**Independent Test**: Select a symbol, create a harmonic set, and confirm the
+filled symbol of that shape/colour renders at the top of the pins and in the
+harmonics-table row; verify the pin label is not obscured.
+
+### Tests for User Story 1 ⚠️ (write first, ensure they fail before implementation)
+
+- [ ] T004 [P] [US1] Add Playwright test: symbol drop-down is present in the control panel and offers circle/square/diamond (plus the additional shapes) in `tests/harmonic-symbols.spec.js`
+- [ ] T005 [P] [US1] Add Playwright test: selecting a symbol + colour then creating a harmonic set by click/drag renders a filled symbol of that shape and colour at the top of each pin, and the pin-number label remains readable (right of the line) in `tests/harmonic-symbols.spec.js`
+- [ ] T006 [P] [US1] Add Playwright test: creating a harmonic set via the manual add dialog uses the currently selected symbol in `tests/harmonic-symbols.spec.js`
+- [ ] T007 [P] [US1] Add Playwright test: each harmonics-table row shows the set's symbol rendered in the set's colour in `tests/harmonic-symbols.spec.js`
+
+### Implementation for User Story 1
+
+- [ ] T008 [P] [US1] Create `src/components/SymbolPicker.js` exporting `createSymbolPicker(state)` — a native `<select>` drop-down listing the catalogue shapes (optionally with inline-SVG previews) that writes the chosen value to `state.selectedSymbol` (follow the `src/components/ColorPicker.js` pattern)
+- [ ] T009 [US1] Re-export `createSymbolPicker` from `src/components/UIComponents.js` (mirrors the `createColorPicker` re-export)
+- [ ] T010 [US1] Mount the symbol picker in the controls column immediately after the colour picker in `src/components/MainUI.js`, label it "Symbol", and store `instance.symbolPicker` reference
+- [ ] T011 [US1] In `HarmonicsMode.addHarmonicSet` (`src/modes/harmonics/HarmonicsMode.js`), assign `symbol = this.instance.state.selectedSymbol || 'circle'` and include `symbol` in the created `harmonicSet` object (covers both click/drag and manual-add, which call this function)
+- [ ] T012 [US1] In `HarmonicsMode.renderHarmonicSet` (`src/modes/harmonics/HarmonicsMode.js`), draw the set's symbol via `createSymbolMark` at the top of each pin (centred on `lineX`, at/just above `lineTop`), filled with `harmonicSet.color`, appended to `cursorGroup` with `data-harmonic-set-id`; nudge downward if it would clip the top edge; ensure `renderPersistentFeatures` clears prior symbol marks alongside the harmonic lines
+- [ ] T013 [US1] In `src/components/HarmonicPanel.js`, render the set's symbol as an inline SVG mark (from `createSymbolMark`) filled with the set's colour in the row's colour cell, for both `createHarmonicRow` and the row-update path
+
+**Checkpoint**: US1 fully functional — symbol selectable, drawn on pins and in
+the table, label unobstructed. MVP deliverable.
+
+---
+
+## Phase 4: User Story 2 - Preserve symbols across save and reload (Priority: P2)
+
+**Goal**: Symbols assigned to harmonic sets survive a save/reload round-trip.
+
+**Independent Test**: Create sets with distinct symbols, persist and reload, and
+confirm each set returns with its original symbol and colour.
+
+**Depends on**: US1 (sets must carry a `symbol`). Persistence uses the additive
+field with **no** `SCHEMA_VERSION` bump (see contracts/persistence-schema.md).
+
+### Tests for User Story 2 ⚠️
+
+- [ ] T014 [P] [US2] Add Playwright test: create harmonic sets with different symbols, trigger save, reload the instance, and assert each set's symbol (on pins and in the table) is preserved in `tests/harmonic-symbols.spec.js`
+
+### Implementation for User Story 2
+
+- [ ] T015 [US2] In `saveAnnotations` (`src/core/storage.js`), include `symbol: hs.symbol || 'circle'` in the persisted harmonic-set mapping; keep `SCHEMA_VERSION = 1` (additive field, no bump)
+- [ ] T016 [US2] In `_restoreAnnotations` (`src/main.js`), map restored harmonic sets to carry their persisted `symbol` (preserving explicit values)
+
+**Checkpoint**: US1 + US2 work — symbols persist across reload.
+
+---
+
+## Phase 5: User Story 3 - Gracefully display legacy harmonics that predate symbols (Priority: P2)
+
+**Goal**: Harmonic sets persisted before this feature (no `symbol`) reload
+without error, each shown with a default circle.
+
+**Independent Test**: Seed storage with a pre-feature blob (`version: 1`,
+harmonic sets lacking `symbol`), reload, and confirm every set renders a circle
+and nothing errors.
+
+**Depends on**: US1 (rendering path) and shares the `_restoreAnnotations` edit
+with US2. Critical constraint: the strict `version !== SCHEMA_VERSION` guard
+means the version MUST stay `1` so legacy data is not discarded.
+
+### Tests for User Story 3 ⚠️
+
+- [ ] T017 [P] [US3] Add Playwright test: seed storage with a legacy `version: 1` annotations blob whose harmonic sets have no `symbol`, reload, and assert every pin and table swatch renders `circle` with no console error in `tests/harmonic-symbols.spec.js`
+
+### Implementation for User Story 3
+
+- [ ] T018 [US3] In `_restoreAnnotations` (`src/main.js`), apply `symbol: hs.symbol || 'circle'` when mapping restored harmonic sets so legacy sets default to circle (extends the T016 mapping)
+- [ ] T019 [US3] Verify `loadAnnotations`/`SCHEMA_VERSION` remain unchanged so legacy v1 blobs are not discarded; add an inline note in `src/core/storage.js` documenting that `symbol` is additive and must not trigger a version bump
+
+**Checkpoint**: All three stories work — new symbols, persistence, and legacy
+fallback.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Styling, helpers, and quality gates.
+
+- [ ] T020 [P] Add any needed CSS for the symbol picker and table swatch alignment in `src/gramframe.css` (match colour-picker/lozenge styling)
+- [ ] T021 [P] Add `GramFramePage` helper methods for symbol assertions (e.g. read a pin's symbol shape/fill and a table row's swatch) in `tests/helpers/`
+- [ ] T022 Run `yarn typecheck` — resolve all JSDoc type errors
+- [ ] T023 Run `yarn test` — all Playwright tests green (including `tests/harmonic-symbols.spec.js`)
+- [ ] T024 Run `yarn build` — clean production build
+- [ ] T025 [P] Verify the manual walkthrough in `specs/157-harmonic-pin-symbols/quickstart.md` matches actual behavior (selector, pins, table, reload, legacy)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+
+- **Setup (P1: T001)** → no dependencies; do first.
+- **Foundational (P2: T002–T003)** → depends on T001; **blocks all user stories**.
+- **US1 (P3)** → depends on Foundational. This is the MVP.
+- **US2 (P4)** → depends on US1 (sets must carry a symbol).
+- **US3 (P5)** → depends on US1; shares the `_restoreAnnotations` edit with US2
+  (do US2's T016 before/with US3's T018).
+- **Polish (P6)** → after the targeted stories are complete.
+
+### Story completion order
+
+1. Foundational (T001–T003)
+2. **US1** — MVP (T004–T013)
+3. **US2** — persistence (T014–T016)
+4. **US3** — legacy fallback (T017–T019)
+5. Polish (T020–T025)
+
+### Within-story parallelism
+
+- **US1 tests** T004–T007 are all `[P]` (independent assertions, same new spec
+  file — write as separate `test(...)` blocks).
+- **US1 impl**: T008 (`SymbolPicker.js`) is `[P]` vs T012/T013 (different files);
+  T009→T010 are sequential (re-export then mount). T011/T012 are in the same file
+  (`HarmonicsMode.js`) so not parallel with each other.
+- Cross-file impl tasks touching distinct files can proceed in parallel once
+  Foundational is done.
+
+### Parallel execution example (US1)
+
+```
+# After T001–T003:
+Run T004, T005, T006, T007 (tests) in parallel — they fail initially.
+Then T008 [P] (SymbolPicker) alongside starting T013 [P] (HarmonicPanel).
+Then T009 → T010 (wire selector into MainUI).
+Then T011 → T012 (HarmonicsMode create + render).
+Re-run US1 tests → green.
+```
+
+## Implementation Strategy
+
+- **MVP = Foundational + US1** (T001–T013): symbol selectable and rendered on
+  pins and in the table. Independently demoable and valuable on its own.
+- **Increment 2 = US2** (T014–T016): symbols persist across reload.
+- **Increment 3 = US3** (T017–T019): legacy annotations reload with circles.
+- **Finish** with Polish (T020–T025) and the three quality gates
+  (`typecheck` / `test` / `build`) required by the constitution before merge.
+
+## Notes
+
+- Keep `SCHEMA_VERSION = 1` throughout — bumping it would delete existing v1
+  annotations because of the strict version guard in `loadAnnotations`.
+- All symbol rendering is SVG (constitution Principle I); no Canvas or
+  absolute-positioned DOM overlays.
+- Symbol handling parallels the existing colour handling end-to-end
+  (`selectedColor` → `selectedSymbol`, per-set `color` → per-set `symbol`).


### PR DESCRIPTION
## Summary

Adds the feature specification for **Symbols on Harmonic Pins** (closes the spec phase for #185). This is a Spec Kit `/speckit.specify` artifact — no product code yet; the plan and implementation follow via `/speckit.plan` and `/speckit.implement`.

The spec covers:
- A **symbol selector** (drop-down) alongside the existing harmonic colour picker, offering filled circle, square, and diamond (with triangle/star noted as an open design option).
- **Colour-coded symbols at the top of each harmonic pin**, positioned so they don't clash with the pin label.
- **Symbols shown in the harmonics table** in each set's colour — the colour-blind affordance requested in the issue.
- **Persistence** of the symbol per harmonic set.
- **Legacy compatibility** — harmonic sets saved before this change reload with a default circle symbol.

## Files

- `specs/157-harmonic-pin-symbols/spec.md` — feature specification (3 prioritised user stories, 11 functional requirements, 6 success criteria, edge cases, assumptions).
- `specs/157-harmonic-pin-symbols/checklists/requirements.md` — spec quality checklist (all items pass, no open clarifications).

## Notes

Spec-only change; no runtime behaviour is modified. Relates to #185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFzX5B8cRg1Jep89eNqHoT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFzX5B8cRg1Jep89eNqHoT)_