### PR TITLE
Stamp app version before build and test (fixes #188)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "scripts": {
     "generate-version": "node scripts/generate-version.js",
     "dev": "vite",
+    "prebuild": "yarn generate-version",
     "build": "vite build",
     "build:standalone": "BUILD_STANDALONE=true vite build",
+    "pretest": "yarn generate-version",
     "test": "playwright test",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
## Summary

Fixes #188. The `Playwright tests` CI check was failing 6 tests because the app version was never stamped before the test job ran. `src/utils/version.js` ships the placeholder `export const VERSION = 'DEV'`, and nothing in the test pipeline replaced it, so `state.version` was `"DEV"` at test time — failing the `expectValidMetadata` assertion that expects a `\d+.\d+.\d+` version string.

## Change

Wire the existing `generate-version` script as npm lifecycle hooks in `package.json`:

- `prebuild` → `yarn generate-version` (runs before `yarn build`)
- `pretest` → `yarn generate-version` (runs before `yarn test`)

Because tests run against the `yarn dev` server (not the build output), the `pretest` hook is what actually fixes the failing tests: `generate-version` writes the real semver into `src/utils/version.js` on disk before the dev server serves it. The `prebuild` hook keeps production builds stamped too, so local and CI behavior match.

This follows Option 1 from the issue (keeps the metadata assertion strict and exercises the real version-stamping path) without needing to edit the CI workflow, since the hooks fire automatically during `yarn build` and `yarn test`.

## Verification

- Ran all 6 previously-failing tests locally with the hooks in place — all pass:
  - `analysis-mode.spec.js` → maintain state consistency during concurrent operations
  - `doppler-mode.spec.js` → maintain state consistency during complex operations
  - `harmonics-mode.spec.js` → maintain state consistency during complex operations
  - `mode-integration.spec.js` → keyboard events consistently across modes
  - `mode-integration.spec.js` → recover from interrupted operations during mode switch
  - `mode-integration.spec.js` → mode switching during error conditions
- `yarn typecheck` passes.
- The committed `src/utils/version.js` retains the `DEV` placeholder so release stamping keeps working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151tCVcnZ3gm6tb95ka95kQ

---
_Generated by [Claude Code](https://claude.ai/code/session_0151tCVcnZ3gm6tb95ka95kQ)_