### PR TITLE
Add 24-hour student tonal expiry to annotation persistence

### DIFF
--- a/specs/157-student-tonal-expiry/tasks.md
+++ b/specs/157-student-tonal-expiry/tasks.md
@@ -23,8 +23,8 @@ Single-project browser component: source in `src/`, Playwright tests in `tests/`
 
 **Purpose**: Confirm the working environment before touching persistence logic.
 
-- [ ] T001 Confirm baseline is green by running `yarn typecheck` and `yarn test` (record any pre-existing failures — e.g. the `state.version === "DEV"` metadata tests — so they are not mistaken for regressions from this feature)
-- [ ] T002 Re-read `src/core/storage.js` and `src/main.js#_restoreAnnotations` to confirm the single read path and the existing `savedAt` write in `saveAnnotations()` (per research.md Decision 1)
+- [X] T001 Confirm baseline is green by running `yarn typecheck` and `yarn test` (record any pre-existing failures — e.g. the `state.version === "DEV"` metadata tests — so they are not mistaken for regressions from this feature)
+- [X] T002 Re-read `src/core/storage.js` and `src/main.js#_restoreAnnotations` to confirm the single read path and the existing `savedAt` write in `saveAnnotations()` (per research.md Decision 1)
 
 ---
 
@@ -34,9 +34,9 @@ Single-project browser component: source in `src/`, Playwright tests in `tests/`
 
 **⚠️ CRITICAL**: User story work cannot begin until this phase is complete.
 
-- [ ] T003 Add `export const STUDENT_TTL_MS = 24 * 60 * 60 * 1000` constant to `src/core/storage.js` (near `SCHEMA_VERSION`), with a JSDoc comment stating it is the fixed 24-hour student persistence policy
-- [ ] T004 Implement and export the pure predicate `isAnnotationExpired(savedAt, nowMs)` in `src/core/storage.js` returning `true` when `savedAt` is missing/unparseable (`Date.parse` → `NaN`), in the future (`nowMs - t < 0`), or older than `STUDENT_TTL_MS`; otherwise `false` — matching the table in `contracts/storage-expiry.md`
-- [ ] T005 Add a JSDoc `@param`/`@returns` signature for `isAnnotationExpired` so `yarn typecheck` covers it, then run `yarn typecheck` to confirm zero errors
+- [X] T003 Add `export const STUDENT_TTL_MS = 24 * 60 * 60 * 1000` constant to `src/core/storage.js` (near `SCHEMA_VERSION`), with a JSDoc comment stating it is the fixed 24-hour student persistence policy
+- [X] T004 Implement and export the pure predicate `isAnnotationExpired(savedAt, nowMs)` in `src/core/storage.js` returning `true` when `savedAt` is missing/unparseable (`Date.parse` → `NaN`), in the future (`nowMs - t < 0`), or older than `STUDENT_TTL_MS`; otherwise `false` — matching the table in `contracts/storage-expiry.md`
+- [X] T005 Add a JSDoc `@param`/`@returns` signature for `isAnnotationExpired` so `yarn typecheck` covers it, then run `yarn typecheck` to confirm zero errors
 
 **Checkpoint**: Shared expiry predicate + constant exist and typecheck; ready to wire into the load path.
 
@@ -50,14 +50,14 @@ Single-project browser component: source in `src/`, Playwright tests in `tests/`
 
 ### Tests for User Story 1 (write first, expect FAIL before T009)
 
-- [ ] T006 [P] [US1] Add e2e test "student annotations older than 24h are discarded on load" to `tests/storage.spec.js`: seed annotations on a student sample page, read back the app-written `gramframe::` key from `sessionStorage`, rewrite its `savedAt` to 25h ago, reload, assert no markers/harmonics/doppler restored AND the key was removed (contract T-A, SC-001, FR-003)
-- [ ] T007 [P] [US1] Add e2e test "student annotations within 24h are restored on load" to `tests/storage.spec.js`: seed annotations, reload without altering `savedAt` (and with a `savedAt` set to ~1h ago), assert they are restored (contract T-B, SC-002, FR-004)
-- [ ] T008 [P] [US1] Add e2e test "student record with missing/garbage savedAt is discarded" to `tests/storage.spec.js`: delete or corrupt `savedAt`, reload, assert discarded and key removed (contract T-D, FR-009)
+- [X] T006 [P] [US1] Add e2e test "student annotations older than 24h are discarded on load" to `tests/storage.spec.js`: seed annotations on a student sample page, read back the app-written `gramframe::` key from `sessionStorage`, rewrite its `savedAt` to 25h ago, reload, assert no markers/harmonics/doppler restored AND the key was removed (contract T-A, SC-001, FR-003)
+- [X] T007 [P] [US1] Add e2e test "student annotations within 24h are restored on load" to `tests/storage.spec.js`: seed annotations, reload without altering `savedAt` (and with a `savedAt` set to ~1h ago), assert they are restored (contract T-B, SC-002, FR-004)
+- [X] T008 [P] [US1] Add e2e test "student record with missing/garbage savedAt is discarded" to `tests/storage.spec.js`: delete or corrupt `savedAt`, reload, assert discarded and key removed (contract T-D, FR-009)
 
 ### Implementation for User Story 1
 
-- [ ] T009 [US1] In `loadAnnotations()` (`src/core/storage.js`), after the existing `version` check, add the student gate: if `detectUserContext() === 'student'` (reuse the `context` already computed in the function) and `isAnnotationExpired(data.savedAt, Date.now())`, then `storage.removeItem(key)`, emit a `console.warn`/info discard message, and `return null` (research Decision 1; contract behavior matrix)
-- [ ] T010 [US1] Run T006–T008; confirm they now pass. Run `yarn typecheck` and the full `yarn test` to check for regressions
+- [X] T009 [US1] In `loadAnnotations()` (`src/core/storage.js`), after the existing `version` check, add the student gate: if `detectUserContext() === 'student'` (reuse the `context` already computed in the function) and `isAnnotationExpired(data.savedAt, Date.now())`, then `storage.removeItem(key)`, emit a `console.warn`/info discard message, and `return null` (research Decision 1; contract behavior matrix)
+- [X] T010 [US1] Run T006–T008; confirm they now pass. Run `yarn typecheck` and the full `yarn test` to check for regressions
 
 **Checkpoint**: Student expiry works end-to-end and is independently testable.
 
@@ -73,12 +73,12 @@ Single-project browser component: source in `src/`, Playwright tests in `tests/`
 
 ### Tests for User Story 3
 
-- [ ] T011 [P] [US3] Add e2e test "trainer annotations survive beyond 24h" to `tests/storage.spec.js`: on a trainer sample page (with a `.gf-persistent` flag or `ANALYSIS` anchor, using `localStorage`), seed annotations, backdate `savedAt` to 10 days ago, reload, assert annotations are STILL restored and the key remains (contract T-C, SC-003, FR-006)
-- [ ] T012 [P] [US3] Add e2e test "trainer record with missing savedAt is NOT discarded" to `tests/storage.spec.js`: on a trainer page, remove `savedAt`, reload, assert annotations still restored (contract behavior matrix, FR-006)
+- [X] T011 [P] [US3] Add e2e test "trainer annotations survive beyond 24h" to `tests/storage.spec.js`: on a trainer sample page (with a `.gf-persistent` flag or `ANALYSIS` anchor, using `localStorage`), seed annotations, backdate `savedAt` to 10 days ago, reload, assert annotations are STILL restored and the key remains (contract T-C, SC-003, FR-006)
+- [X] T012 [P] [US3] Add e2e test "trainer record with missing savedAt is NOT discarded" to `tests/storage.spec.js`: on a trainer page, remove `savedAt`, reload, assert annotations still restored (contract behavior matrix, FR-006)
 
 ### Implementation for User Story 3
 
-- [ ] T013 [US3] Verify the `context === 'student'` guard in `loadAnnotations()` (T009) correctly bypasses expiry for trainer context; adjust only if T011/T012 reveal a gap. Run `yarn test` to confirm both trainer tests pass
+- [X] T013 [US3] Verify the `context === 'student'` guard in `loadAnnotations()` (T009) correctly bypasses expiry for trainer context; adjust only if T011/T012 reveal a gap. Run `yarn test` to confirm both trainer tests pass
 
 **Checkpoint**: Trainer permanence proven; no regression to the trainer workflow.
 
@@ -94,11 +94,11 @@ Single-project browser component: source in `src/`, Playwright tests in `tests/`
 
 ### Tests for User Story 2
 
-- [ ] T014 [P] [US2] Add (or confirm existing in `tests/storage.spec.js`) an e2e test "fresh browser session restores no student annotations": seed student annotations, simulate a fresh session (new browser context / cleared `sessionStorage`) per the Playwright pattern already used in `tests/storage.spec.js`, reload, assert nothing restored (contract T-E, US2, FR-008). If already covered by a feature-155 test, reference it here instead of duplicating
+- [X] T014 [P] [US2] Add (or confirm existing in `tests/storage.spec.js`) an e2e test "fresh browser session restores no student annotations": seed student annotations, simulate a fresh session (new browser context / cleared `sessionStorage`) per the Playwright pattern already used in `tests/storage.spec.js`, reload, assert nothing restored (contract T-E, US2, FR-008). If already covered by a feature-155 test, reference it here instead of duplicating
 
 ### Implementation for User Story 2
 
-- [ ] T015 [US2] No production code change expected. Run `yarn test` to confirm the fresh-session test passes with the new expiry gate in place (the gate must not break the existing session-scope behavior)
+- [X] T015 [US2] No production code change expected. Run `yarn test` to confirm the fresh-session test passes with the new expiry gate in place (the gate must not break the existing session-scope behavior)
 
 **Checkpoint**: Instructor fresh-session override verified alongside the 24h cap.
 
@@ -108,10 +108,10 @@ Single-project browser component: source in `src/`, Playwright tests in `tests/`
 
 **Purpose**: Documentation, type safety, and final quality-gate verification.
 
-- [ ] T016 [P] Update the JSDoc header block at the top of `src/core/storage.js` to document the 24-hour student expiry (mention trainer permanence and the fail-safe on malformed `savedAt`)
-- [ ] T017 [P] If any student sample page lacks annotations tooling for the tests, add/verify a suitable student and trainer sample under `sample/` (only if T006/T011 need a dedicated fixture; otherwise skip)
-- [ ] T018 Run the full quality-gate trio required by the Constitution: `yarn typecheck`, `yarn test`, `yarn build` — all must be green (excluding any pre-existing failures recorded in T001)
-- [ ] T019 Walk through `quickstart.md` steps 1–5 manually against `yarn dev` to confirm the observable behavior matches the spec's success criteria
+- [X] T016 [P] Update the JSDoc header block at the top of `src/core/storage.js` to document the 24-hour student expiry (mention trainer permanence and the fail-safe on malformed `savedAt`)
+- [X] T017 [P] If any student sample page lacks annotations tooling for the tests, add/verify a suitable student and trainer sample under `sample/` (only if T006/T011 need a dedicated fixture; otherwise skip)
+- [X] T018 Run the full quality-gate trio required by the Constitution: `yarn typecheck`, `yarn test`, `yarn build` — all must be green (excluding any pre-existing failures recorded in T001)
+- [X] T019 Walk through `quickstart.md` steps 1–5 manually against `yarn dev` to confirm the observable behavior matches the spec's success criteria
 
 ---
 

--- a/src/core/storage.js
+++ b/src/core/storage.js
@@ -5,6 +5,12 @@
  * in browser storage. Trainers get localStorage (permanent); students get
  * sessionStorage (cleared on browser close).
  *
+ * Student persistence is additionally capped at 24 hours (feature 157): on
+ * load, a student-context record whose `savedAt` is older than
+ * STUDENT_TTL_MS — or missing, unparseable, or in the future — is discarded
+ * and its key removed (fail-safe toward clearing). Trainer-context records are
+ * exempt and remain permanent regardless of age. See isAnnotationExpired().
+ *
  * Context detection: a page is treated as a trainer page if ANY of the
  * following is present anywhere on the page:
  *   - an element with id "gf-persistent",
@@ -28,6 +34,15 @@
 /** @type {number} */
 const SCHEMA_VERSION = 1
 
+/**
+ * Fixed 24-hour student persistence policy. Student-context annotations older
+ * than this (measured from their last-save `savedAt`) are discarded on load.
+ * This is a fixed policy — not HTML-configurable — so it lives as a named
+ * constant. Trainer-context records are never subject to it.
+ * @type {number}
+ */
+export const STUDENT_TTL_MS = 24 * 60 * 60 * 1000
+
 /** @type {string} */
 const KEY_PREFIX = 'gramframe::'
 
@@ -37,6 +52,37 @@ const KEY_PREFIX = 'gramframe::'
  * @type {string}
  */
 export const TRAINER_FLAG_SELECTOR = '#gf-persistent, .gf-persistent, [data-gf-persistent]'
+
+/**
+ * Determine whether a student-context annotation record has expired.
+ *
+ * A record is treated as expired (and therefore discarded on load) when its
+ * `savedAt` timestamp cannot be proven fresh. This is deliberately fail-safe
+ * toward clearing student data:
+ *   - missing / unparseable `savedAt` (`Date.parse` → `NaN`) → expired,
+ *   - a `savedAt` in the future (`nowMs - t < 0`) → expired (guards clock skew
+ *     and hand-edited records),
+ *   - a `savedAt` older than {@link STUDENT_TTL_MS} → expired.
+ * Otherwise the record is within the 24-hour window and is NOT expired.
+ *
+ * Pure and side-effect-free: identical inputs always yield identical output.
+ * Applies to student context only — trainer records never call this.
+ *
+ * @param {string | undefined | null} savedAt - ISO-8601 timestamp of the last save
+ * @param {number} nowMs - Current wall-clock time in ms (e.g. `Date.now()`)
+ * @returns {boolean} True when the record should be discarded as expired
+ */
+export function isAnnotationExpired(savedAt, nowMs) {
+  const t = Date.parse(/** @type {string} */ (savedAt))
+  if (Number.isNaN(t)) {
+    return true
+  }
+  const age = nowMs - t
+  if (age < 0) {
+    return true
+  }
+  return age > STUDENT_TTL_MS
+}
 
 /**
  * Detect whether the current page is a trainer or student context.
@@ -174,6 +220,15 @@ export function loadAnnotations(instanceIndex) {
 
     if (!data || data.version !== SCHEMA_VERSION) {
       console.warn('GramFrame: Discarding stored annotations — unrecognised schema version:', data && data.version)
+      storage.removeItem(key)
+      return null
+    }
+
+    // Student 24-hour expiry gate (feature 157). Trainer context is permanent
+    // and bypasses this entirely. A student record that cannot be proven fresh
+    // (missing/unparseable/future/older-than-24h savedAt) is discarded.
+    if (context === 'student' && isAnnotationExpired(data.savedAt, Date.now())) {
+      console.info('GramFrame: Discarding student annotations — older than the 24-hour persistence limit')
       storage.removeItem(key)
       return null
     }

--- a/tests/storage.spec.js
+++ b/tests/storage.spec.js
@@ -430,6 +430,228 @@ test.describe('US3: Clear gram button', () => {
 })
 
 // ──────────────────────────────────────────────────────────────
+// Feature 157 — Student Tonal Expiry (24-hour persistence limit)
+// ──────────────────────────────────────────────────────────────
+
+/**
+ * Helper: rewrite the app-written gramframe:: record's `savedAt` in the given
+ * storage. Reads the key the app actually wrote (enumerating the prefix) rather
+ * than reconstructing it, per the contract's test obligations.
+ * @param {import('@playwright/test').Page} page
+ * @param {'local' | 'session'} storageType
+ * @param {(rec: any) => void} mutate - mutation applied to the parsed record
+ * @returns {Promise<number>} number of records mutated
+ */
+async function mutateStoredRecord(page, storageType, mutate) {
+  return page.evaluate(({ type, mutateSrc }) => {
+    const store = type === 'local' ? localStorage : sessionStorage
+    // eslint-disable-next-line no-new-func
+    const fn = new Function('rec', `(${mutateSrc})(rec)`)
+    let count = 0
+    for (let i = 0; i < store.length; i++) {
+      const k = store.key(i)
+      if (k && k.startsWith('gramframe::')) {
+        const rec = JSON.parse(store.getItem(k))
+        fn(rec)
+        store.setItem(k, JSON.stringify(rec))
+        count++
+      }
+    }
+    return count
+  }, { type: storageType, mutateSrc: mutate.toString() })
+}
+
+test.describe('Feature 157: student 24-hour expiry', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/tests/fixtures/student-page.html')
+    await page.evaluate(() => sessionStorage.clear())
+  })
+
+  // T006 / T-A / SC-001 / FR-003
+  test('student annotations older than 24h are discarded on load', async ({ page }) => {
+    const gfp = await gotoFixture(page, '/tests/fixtures/student-page.html')
+
+    // Seed an annotation (student → sessionStorage)
+    await addAnalysisMarker(gfp, 200, 150)
+    const stateBefore = await getStateFromPage(page)
+    expect(stateBefore.analysis.markers.length).toBeGreaterThan(0)
+
+    // Confirm the app wrote a session key
+    const keysBefore = await gfp.getStorageKeys('session')
+    expect(keysBefore.length).toBeGreaterThan(0)
+
+    // Backdate the app-written record's savedAt to 25h ago
+    const mutated = await mutateStoredRecord(page, 'session', (rec) => {
+      rec.savedAt = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString()
+    })
+    expect(mutated).toBeGreaterThan(0)
+
+    // Reload → expired record must be discarded
+    await page.reload()
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+    await page.waitForTimeout(500)
+
+    const stateAfter = await getStateFromPage(page)
+    expect(stateAfter.analysis.markers.length).toBe(0)
+    expect(stateAfter.harmonics.harmonicSets.length).toBe(0)
+    expect(stateAfter.doppler.fPlus).toBeNull()
+    expect(stateAfter.doppler.fMinus).toBeNull()
+
+    // ...and the stale key must be removed
+    const keysAfter = await gfp.getStorageKeys('session')
+    expect(keysAfter.length).toBe(0)
+  })
+
+  // T007 / T-B / SC-002 / FR-004
+  test('student annotations within 24h are restored on load', async ({ page }) => {
+    const gfp = await gotoFixture(page, '/tests/fixtures/student-page.html')
+
+    await addAnalysisMarker(gfp, 200, 150)
+    const stateBefore = await getStateFromPage(page)
+    expect(stateBefore.analysis.markers.length).toBeGreaterThan(0)
+
+    // Set savedAt to ~1h ago — well within the 24h window
+    const mutated = await mutateStoredRecord(page, 'session', (rec) => {
+      rec.savedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString()
+    })
+    expect(mutated).toBeGreaterThan(0)
+
+    await page.reload()
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+    await page.waitForTimeout(500)
+
+    const stateAfter = await getStateFromPage(page)
+    expect(stateAfter.analysis.markers.length).toBe(stateBefore.analysis.markers.length)
+
+    // Key must still be present
+    const keysAfter = await gfp.getStorageKeys('session')
+    expect(keysAfter.length).toBeGreaterThan(0)
+  })
+
+  // T008 / T-D / FR-009
+  test('student record with missing/garbage savedAt is discarded', async ({ page }) => {
+    const gfp = await gotoFixture(page, '/tests/fixtures/student-page.html')
+
+    await addAnalysisMarker(gfp, 200, 150)
+    const stateBefore = await getStateFromPage(page)
+    expect(stateBefore.analysis.markers.length).toBeGreaterThan(0)
+
+    // Corrupt savedAt into an unparseable value (also covers the missing case)
+    const mutated = await mutateStoredRecord(page, 'session', (rec) => {
+      rec.savedAt = 'not-a-date'
+    })
+    expect(mutated).toBeGreaterThan(0)
+
+    await page.reload()
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+    await page.waitForTimeout(500)
+
+    const stateAfter = await getStateFromPage(page)
+    expect(stateAfter.analysis.markers.length).toBe(0)
+
+    const keysAfter = await gfp.getStorageKeys('session')
+    expect(keysAfter.length).toBe(0)
+  })
+})
+
+// ──────────────────────────────────────────────────────────────
+// Feature 157 — Trainer permanence (US3) & fresh-session override (US2)
+// ──────────────────────────────────────────────────────────────
+
+test.describe('Feature 157: trainer permanence beyond 24h', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/tests/fixtures/persistent-flag-page.html')
+    await page.evaluate(() => {
+      localStorage.clear()
+      sessionStorage.clear()
+    })
+  })
+
+  // T011 / T-C / SC-003 / FR-006
+  test('trainer annotations survive beyond 24h', async ({ page }) => {
+    const gfp = await gotoFixture(page, '/tests/fixtures/persistent-flag-page.html')
+
+    // Seed on a trainer page (localStorage)
+    await addAnalysisMarker(gfp, 200, 150)
+    const stateBefore = await getStateFromPage(page)
+    expect(stateBefore.analysis.markers.length).toBeGreaterThan(0)
+
+    const localKeysBefore = await gfp.getStorageKeys('local')
+    expect(localKeysBefore.length).toBeGreaterThan(0)
+
+    // Backdate savedAt to 10 days ago — far beyond 24h
+    const mutated = await mutateStoredRecord(page, 'local', (rec) => {
+      rec.savedAt = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString()
+    })
+    expect(mutated).toBeGreaterThan(0)
+
+    await page.reload()
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+    await page.waitForTimeout(500)
+
+    // Trainer permanence: still restored, key intact
+    const stateAfter = await getStateFromPage(page)
+    expect(stateAfter.analysis.markers.length).toBe(stateBefore.analysis.markers.length)
+
+    const localKeysAfter = await gfp.getStorageKeys('local')
+    expect(localKeysAfter.length).toBeGreaterThan(0)
+  })
+
+  // T012 / FR-006 — trainer records skip the expiry gate entirely
+  test('trainer record with missing savedAt is NOT discarded', async ({ page }) => {
+    const gfp = await gotoFixture(page, '/tests/fixtures/persistent-flag-page.html')
+
+    await addAnalysisMarker(gfp, 200, 150)
+    const stateBefore = await getStateFromPage(page)
+    expect(stateBefore.analysis.markers.length).toBeGreaterThan(0)
+
+    // Remove savedAt — would expire a student record, but must NOT touch trainer
+    const mutated = await mutateStoredRecord(page, 'local', (rec) => {
+      delete rec.savedAt
+    })
+    expect(mutated).toBeGreaterThan(0)
+
+    await page.reload()
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+    await page.waitForTimeout(500)
+
+    const stateAfter = await getStateFromPage(page)
+    expect(stateAfter.analysis.markers.length).toBe(stateBefore.analysis.markers.length)
+
+    const localKeysAfter = await gfp.getStorageKeys('local')
+    expect(localKeysAfter.length).toBeGreaterThan(0)
+  })
+})
+
+test.describe('Feature 157: instructor fresh-session override (US2)', () => {
+  // T014 / T-E / FR-008 — a fresh session restores no student annotations.
+  // (Guards the existing sessionStorage scoping against regression from the
+  // new expiry gate; complements the feature-155 new-context test above.)
+  test('fresh browser session restores no student annotations', async ({ browser }) => {
+    const context1 = await browser.newContext()
+    const page1 = await context1.newPage()
+    const gfp1 = await gotoFixture(page1, '/tests/fixtures/student-page.html')
+    await addAnalysisMarker(gfp1, 200, 150)
+
+    const state1 = await getStateFromPage(page1)
+    expect(state1.analysis.markers.length).toBeGreaterThan(0)
+    await context1.close()
+
+    // Fresh session — sessionStorage starts empty regardless of the 24h gate
+    const context2 = await browser.newContext()
+    const page2 = await context2.newPage()
+    const gfp2 = await gotoFixture(page2, '/tests/fixtures/student-page.html')
+
+    const state2 = await getStateFromPage(page2)
+    expect(state2.analysis.markers.length).toBe(0)
+
+    const keys = await gfp2.getStorageKeys('session')
+    expect(keys.length).toBe(0)
+    await context2.close()
+  })
+})
+
+// ──────────────────────────────────────────────────────────────
 // Phase 6: Edge Cases & Cross-Cutting Concerns
 // ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Caps **student**-context annotation persistence at 24 hours to protect assessment integrity, while leaving **trainer**-context annotations permanent. Implements [`specs/157-student-tonal-expiry`](specs/157-student-tonal-expiry).

The change is confined to the single storage read path — no schema change and no data migration, because the stored record already carries a `savedAt` timestamp.

## Changes

**`src/core/storage.js`** (production)
- Added `STUDENT_TTL_MS = 24 * 60 * 60 * 1000` — a fixed (non-configurable) 24-hour policy constant.
- Added the pure, exported predicate `isAnnotationExpired(savedAt, nowMs)`: returns `true` when `savedAt` is missing/unparseable (`Date.parse → NaN`), in the future (`nowMs - t < 0`), or older than `STUDENT_TTL_MS`. Fail-safe toward clearing student data.
- Gated `loadAnnotations()` on `context === 'student'`: when the record is expired it is removed (`removeItem`), an info message is logged, and `null` is returned. **Trainer context bypasses the gate entirely**, so trainer permanence is preserved.
- Updated the module header JSDoc to document the expiry, trainer exemption, and malformed-timestamp fail-safe.

**`tests/storage.spec.js`** (tests)
- Student expiry: >24h discarded + key removed; within-24h restored; missing/garbage `savedAt` discarded.
- Trainer permanence: annotations survive 10 days; missing `savedAt` does **not** discard a trainer record.
- Instructor fresh-session override: a new session restores no student annotations.
- Tests read the storage key the app actually wrote (enumerating the `gramframe::` prefix) rather than reconstructing it.

## Behavior matrix

| Context | `savedAt` | Result | Side effect |
|---------|-----------|--------|-------------|
| student | ≤ 24h | restored | none |
| student | > 24h / missing / unparseable / future | discarded | `removeItem`, info log |
| trainer | any age (incl. missing) | restored | none (permanence preserved) |

## Testing

- `yarn typecheck` — clean.
- `yarn test` — all storage + Feature 157 specs pass; full suite green.
- `yarn build` — succeeds.

**Pre-existing baseline note:** 6 tests asserting `state.version` matches a semver fail on a raw checkout because the version constant reads `"DEV"` until `yarn generate-version` (run by the build) executes. These are unrelated to this feature and pass once the version is generated — matching the baseline recorded in the tasks plan (T001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkPUmYjGW218BtTs2ebaou

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkPUmYjGW218BtTs2ebaou)_