### PR TITLE
feat(storage): cap student annotation persistence at 24 hours (#184)

### DIFF
--- a/specs/157-student-tonal-expiry/tasks.md
+++ b/specs/157-student-tonal-expiry/tasks.md
@@ -23,8 +23,8 @@ Single-project browser component: source in `src/`, Playwright tests in `tests/`
 
 **Purpose**: Confirm the working environment before touching persistence logic.
 
-- [ ] T001 Confirm baseline is green by running `yarn typecheck` and `yarn test` (record any pre-existing failures — e.g. the `state.version === "DEV"` metadata tests — so they are not mistaken for regressions from this feature)
-- [ ] T002 Re-read `src/core/storage.js` and `src/main.js#_restoreAnnotations` to confirm the single read path and the existing `savedAt` write in `saveAnnotations()` (per research.md Decision 1)
+- [X] T001 Confirm baseline is green by running `yarn typecheck` and `yarn test` (record any pre-existing failures — e.g. the `state.version === "DEV"` metadata tests — so they are not mistaken for regressions from this feature)
+- [X] T002 Re-read `src/core/storage.js` and `src/main.js#_restoreAnnotations` to confirm the single read path and the existing `savedAt` write in `saveAnnotations()` (per research.md Decision 1)
 
 ---
 
@@ -34,9 +34,9 @@ Single-project browser component: source in `src/`, Playwright tests in `tests/`
 
 **⚠️ CRITICAL**: User story work cannot begin until this phase is complete.
 
-- [ ] T003 Add `export const STUDENT_TTL_MS = 24 * 60 * 60 * 1000` constant to `src/core/storage.js` (near `SCHEMA_VERSION`), with a JSDoc comment stating it is the fixed 24-hour student persistence policy
-- [ ] T004 Implement and export the pure predicate `isAnnotationExpired(savedAt, nowMs)` in `src/core/storage.js` returning `true` when `savedAt` is missing/unparseable (`Date.parse` → `NaN`), in the future (`nowMs - t < 0`), or older than `STUDENT_TTL_MS`; otherwise `false` — matching the table in `contracts/storage-expiry.md`
-- [ ] T005 Add a JSDoc `@param`/`@returns` signature for `isAnnotationExpired` so `yarn typecheck` covers it, then run `yarn typecheck` to confirm zero errors
+- [X] T003 Add `export const STUDENT_TTL_MS = 24 * 60 * 60 * 1000` constant to `src/core/storage.js` (near `SCHEMA_VERSION`), with a JSDoc comment stating it is the fixed 24-hour student persistence policy
+- [X] T004 Implement and export the pure predicate `isAnnotationExpired(savedAt, nowMs)` in `src/core/storage.js` returning `true` when `savedAt` is missing/unparseable (`Date.parse` → `NaN`), in the future (`nowMs - t < 0`), or older than `STUDENT_TTL_MS`; otherwise `false` — matching the table in `contracts/storage-expiry.md`
+- [X] T005 Add a JSDoc `@param`/`@returns` signature for `isAnnotationExpired` so `yarn typecheck` covers it, then run `yarn typecheck` to confirm zero errors
 
 **Checkpoint**: Shared expiry predicate + constant exist and typecheck; ready to wire into the load path.
 
@@ -50,14 +50,14 @@ Single-project browser component: source in `src/`, Playwright tests in `tests/`
 
 ### Tests for User Story 1 (write first, expect FAIL before T009)
 
-- [ ] T006 [P] [US1] Add e2e test "student annotations older than 24h are discarded on load" to `tests/storage.spec.js`: seed annotations on a student sample page, read back the app-written `gramframe::` key from `sessionStorage`, rewrite its `savedAt` to 25h ago, reload, assert no markers/harmonics/doppler restored AND the key was removed (contract T-A, SC-001, FR-003)
-- [ ] T007 [P] [US1] Add e2e test "student annotations within 24h are restored on load" to `tests/storage.spec.js`: seed annotations, reload without altering `savedAt` (and with a `savedAt` set to ~1h ago), assert they are restored (contract T-B, SC-002, FR-004)
-- [ ] T008 [P] [US1] Add e2e test "student record with missing/garbage savedAt is discarded" to `tests/storage.spec.js`: delete or corrupt `savedAt`, reload, assert discarded and key removed (contract T-D, FR-009)
+- [X] T006 [P] [US1] Add e2e test "student annotations older than 24h are discarded on load" to `tests/storage.spec.js`: seed annotations on a student sample page, read back the app-written `gramframe::` key from `sessionStorage`, rewrite its `savedAt` to 25h ago, reload, assert no markers/harmonics/doppler restored AND the key was removed (contract T-A, SC-001, FR-003)
+- [X] T007 [P] [US1] Add e2e test "student annotations within 24h are restored on load" to `tests/storage.spec.js`: seed annotations, reload without altering `savedAt` (and with a `savedAt` set to ~1h ago), assert they are restored (contract T-B, SC-002, FR-004)
+- [X] T008 [P] [US1] Add e2e test "student record with missing/garbage savedAt is discarded" to `tests/storage.spec.js`: delete or corrupt `savedAt`, reload, assert discarded and key removed (contract T-D, FR-009)
 
 ### Implementation for User Story 1
 
-- [ ] T009 [US1] In `loadAnnotations()` (`src/core/storage.js`), after the existing `version` check, add the student gate: if `detectUserContext() === 'student'` (reuse the `context` already computed in the function) and `isAnnotationExpired(data.savedAt, Date.now())`, then `storage.removeItem(key)`, emit a `console.warn`/info discard message, and `return null` (research Decision 1; contract behavior matrix)
-- [ ] T010 [US1] Run T006–T008; confirm they now pass. Run `yarn typecheck` and the full `yarn test` to check for regressions
+- [X] T009 [US1] In `loadAnnotations()` (`src/core/storage.js`), after the existing `version` check, add the student gate: if `detectUserContext() === 'student'` (reuse the `context` already computed in the function) and `isAnnotationExpired(data.savedAt, Date.now())`, then `storage.removeItem(key)`, emit a `console.warn`/info discard message, and `return null` (research Decision 1; contract behavior matrix)
+- [X] T010 [US1] Run T006–T008; confirm they now pass. Run `yarn typecheck` and the full `yarn test` to check for regressions
 
 **Checkpoint**: Student expiry works end-to-end and is independently testable.
 
@@ -73,12 +73,12 @@ Single-project browser component: source in `src/`, Playwright tests in `tests/`
 
 ### Tests for User Story 3
 
-- [ ] T011 [P] [US3] Add e2e test "trainer annotations survive beyond 24h" to `tests/storage.spec.js`: on a trainer sample page (with a `.gf-persistent` flag or `ANALYSIS` anchor, using `localStorage`), seed annotations, backdate `savedAt` to 10 days ago, reload, assert annotations are STILL restored and the key remains (contract T-C, SC-003, FR-006)
-- [ ] T012 [P] [US3] Add e2e test "trainer record with missing savedAt is NOT discarded" to `tests/storage.spec.js`: on a trainer page, remove `savedAt`, reload, assert annotations still restored (contract behavior matrix, FR-006)
+- [X] T011 [P] [US3] Add e2e test "trainer annotations survive beyond 24h" to `tests/storage.spec.js`: on a trainer sample page (with a `.gf-persistent` flag or `ANALYSIS` anchor, using `localStorage`), seed annotations, backdate `savedAt` to 10 days ago, reload, assert annotations are STILL restored and the key remains (contract T-C, SC-003, FR-006)
+- [X] T012 [P] [US3] Add e2e test "trainer record with missing savedAt is NOT discarded" to `tests/storage.spec.js`: on a trainer page, remove `savedAt`, reload, assert annotations still restored (contract behavior matrix, FR-006)
 
 ### Implementation for User Story 3
 
-- [ ] T013 [US3] Verify the `context === 'student'` guard in `loadAnnotations()` (T009) correctly bypasses expiry for trainer context; adjust only if T011/T012 reveal a gap. Run `yarn test` to confirm both trainer tests pass
+- [X] T013 [US3] Verify the `context === 'student'` guard in `loadAnnotations()` (T009) correctly bypasses expiry for trainer context; adjust only if T011/T012 reveal a gap. Run `yarn test` to confirm both trainer tests pass
 
 **Checkpoint**: Trainer permanence proven; no regression to the trainer workflow.
 
@@ -94,11 +94,11 @@ Single-project browser component: source in `src/`, Playwright tests in `tests/`
 
 ### Tests for User Story 2
 
-- [ ] T014 [P] [US2] Add (or confirm existing in `tests/storage.spec.js`) an e2e test "fresh browser session restores no student annotations": seed student annotations, simulate a fresh session (new browser context / cleared `sessionStorage`) per the Playwright pattern already used in `tests/storage.spec.js`, reload, assert nothing restored (contract T-E, US2, FR-008). If already covered by a feature-155 test, reference it here instead of duplicating
+- [X] T014 [P] [US2] Add (or confirm existing in `tests/storage.spec.js`) an e2e test "fresh browser session restores no student annotations": seed student annotations, simulate a fresh session (new browser context / cleared `sessionStorage`) per the Playwright pattern already used in `tests/storage.spec.js`, reload, assert nothing restored (contract T-E, US2, FR-008). If already covered by a feature-155 test, reference it here instead of duplicating
 
 ### Implementation for User Story 2
 
-- [ ] T015 [US2] No production code change expected. Run `yarn test` to confirm the fresh-session test passes with the new expiry gate in place (the gate must not break the existing session-scope behavior)
+- [X] T015 [US2] No production code change expected. Run `yarn test` to confirm the fresh-session test passes with the new expiry gate in place (the gate must not break the existing session-scope behavior)
 
 **Checkpoint**: Instructor fresh-session override verified alongside the 24h cap.
 
@@ -108,10 +108,10 @@ Single-project browser component: source in `src/`, Playwright tests in `tests/`
 
 **Purpose**: Documentation, type safety, and final quality-gate verification.
 
-- [ ] T016 [P] Update the JSDoc header block at the top of `src/core/storage.js` to document the 24-hour student expiry (mention trainer permanence and the fail-safe on malformed `savedAt`)
-- [ ] T017 [P] If any student sample page lacks annotations tooling for the tests, add/verify a suitable student and trainer sample under `sample/` (only if T006/T011 need a dedicated fixture; otherwise skip)
-- [ ] T018 Run the full quality-gate trio required by the Constitution: `yarn typecheck`, `yarn test`, `yarn build` — all must be green (excluding any pre-existing failures recorded in T001)
-- [ ] T019 Walk through `quickstart.md` steps 1–5 manually against `yarn dev` to confirm the observable behavior matches the spec's success criteria
+- [X] T016 [P] Update the JSDoc header block at the top of `src/core/storage.js` to document the 24-hour student expiry (mention trainer permanence and the fail-safe on malformed `savedAt`)
+- [X] T017 [P] If any student sample page lacks annotations tooling for the tests, add/verify a suitable student and trainer sample under `sample/` (only if T006/T011 need a dedicated fixture; otherwise skip)
+- [X] T018 Run the full quality-gate trio required by the Constitution: `yarn typecheck`, `yarn test`, `yarn build` — all must be green (excluding any pre-existing failures recorded in T001)
+- [X] T019 Walk through `quickstart.md` steps 1–5 manually against `yarn dev` to confirm the observable behavior matches the spec's success criteria
 
 ---
 
@@ -167,3 +167,29 @@ Total scope is intentionally small: one production file changed (`src/core/stora
 - US2 (P2): 2 (T014–T015)
 - Polish: 4 (T016–T019)
 - **Total: 19 tasks**
+
+## Implementation Notes (completed 2026-07-17)
+
+All 19 tasks complete. Summary of the delivered change:
+
+- **`src/core/storage.js`**: added `STUDENT_TTL_MS` (24h) constant, the pure
+  `isAnnotationExpired(savedAt, nowMs)` predicate, and the student-context
+  expiry gate in `loadAnnotations()` (after the version check). Trainer context
+  bypasses the gate. Module JSDoc header updated to document the policy.
+- **`tests/storage.spec.js`**: added the "Feature 157: student annotation 24h
+  expiry" describe block covering T-A…T-E — older-than-24h discard, within-24h
+  restore, missing/garbage/future `savedAt` discard, trainer permanence beyond
+  24h, trainer-with-missing-`savedAt` retained, and fresh-session override.
+
+**Baseline note (T001)**: `yarn typecheck` has one pre-existing error unrelated
+to this feature — `src/index.js(11): TS2882` for the side-effect CSS import
+(`import './gramframe.css'`), identical on `origin/main`. No new typecheck
+errors were introduced by this feature. `yarn test` (126 tests) and `yarn build`
+are green.
+
+**T017**: skipped — the existing `tests/fixtures/student-page.html` and
+`trainer-page.html` fixtures were sufficient; no new sample fixture was needed.
+
+**T019**: the quickstart's manual steps are covered by the automated
+equivalents in the new describe block (see the "Automated equivalent" section of
+`quickstart.md`).

--- a/src/core/storage.js
+++ b/src/core/storage.js
@@ -21,12 +21,28 @@
  * verbatim and un-mangled (this is exactly how table.gram-config is already
  * detected), and classes are not uniquified — so .gf-persistent is reliably
  * emittable from DITA and stable on every page.
+ *
+ * Student expiry: student-context annotations (sessionStorage) additionally
+ * expire 24 hours after they were last saved. On load, a student record older
+ * than STUDENT_TTL_MS — or one whose savedAt timestamp is missing, unparseable,
+ * or in the future — is discarded (fail-safe toward clearing), protecting the
+ * integrity of later assessments. Trainer-context annotations (localStorage)
+ * are never aged out and persist indefinitely.
  */
 
 /// <reference path="../types.js" />
 
 /** @type {number} */
 const SCHEMA_VERSION = 1
+
+/**
+ * Fixed 24-hour student persistence policy. Student-context annotation sets are
+ * treated as expired once more than this many milliseconds have elapsed since
+ * they were last saved. This is a fixed policy value (per GH issue 184), not an
+ * end-user setting. Trainer-context annotations are exempt (permanent).
+ * @type {number}
+ */
+export const STUDENT_TTL_MS = 24 * 60 * 60 * 1000
 
 /** @type {string} */
 const KEY_PREFIX = 'gramframe::'
@@ -155,8 +171,36 @@ export function saveAnnotations(state, instanceIndex) {
 }
 
 /**
+ * Determine whether a student-context annotation set has expired.
+ *
+ * A record is expired (returns true) when its last-saved timestamp is missing,
+ * unparseable, in the future, or older than STUDENT_TTL_MS. This is a pure,
+ * side-effect-free predicate — identical output for identical inputs. It is
+ * only applied to student-context records; trainer records never call it.
+ * @param {string | undefined | null} savedAt - ISO-8601 last-saved timestamp from the stored record
+ * @param {number} nowMs - Current wall-clock time in milliseconds (e.g. Date.now())
+ * @returns {boolean} True if the record should be treated as expired and discarded
+ */
+export function isAnnotationExpired(savedAt, nowMs) {
+  const t = Date.parse(/** @type {string} */ (savedAt))
+  if (Number.isNaN(t)) {
+    // Missing or unparseable timestamp — cannot prove freshness, fail safe.
+    return true
+  }
+  const age = nowMs - t
+  if (age < 0) {
+    // Future timestamp (e.g. clock skew) — treat as expired rather than keep indefinitely.
+    return true
+  }
+  return age > STUDENT_TTL_MS
+}
+
+/**
  * Load and validate stored annotations from browser storage.
  * Returns null if no data exists, parsing fails, or version is unrecognised.
+ * For student context, also returns null (and removes the stale key) when the
+ * stored record has expired per the 24-hour policy (see isAnnotationExpired).
+ * Trainer context bypasses the expiry gate entirely (permanent persistence).
  * @param {number} [instanceIndex] - Instance index for multi-instance pages
  * @returns {StoredAnnotations | null}
  */
@@ -174,6 +218,14 @@ export function loadAnnotations(instanceIndex) {
 
     if (!data || data.version !== SCHEMA_VERSION) {
       console.warn('GramFrame: Discarding stored annotations — unrecognised schema version:', data && data.version)
+      storage.removeItem(key)
+      return null
+    }
+
+    // Student-context 24-hour expiry gate. Trainer records are permanent and
+    // skip this branch entirely (FR-006). Fail safe toward clearing (FR-009).
+    if (context === 'student' && isAnnotationExpired(data.savedAt, Date.now())) {
+      console.info('GramFrame: Discarding expired student annotations — last saved:', data.savedAt)
       storage.removeItem(key)
       return null
     }

--- a/tests/storage.spec.js
+++ b/tests/storage.spec.js
@@ -525,3 +525,234 @@ test.describe('Edge cases', () => {
     expect(keysAfter.length).toBeGreaterThan(0)
   })
 })
+
+// ──────────────────────────────────────────────────────────────
+// Feature 157: Student Tonal Expiry (24-Hour Persistence Limit)
+// ──────────────────────────────────────────────────────────────
+
+/**
+ * Rewrite the `savedAt` field of the app-written gramframe:: record in the
+ * given storage. Reads the key the app actually wrote (enumerating the store
+ * for the `gramframe::` prefix) rather than reconstructing it, per the contract.
+ * @param {import('@playwright/test').Page} page
+ * @param {'local' | 'session'} storageType
+ * @param {string | null} newSavedAt - New ISO value, or null to delete the field
+ * @returns {Promise<boolean>} True if a record was found and rewritten
+ */
+async function mutateSavedAt(page, storageType, newSavedAt) {
+  return page.evaluate(({ storageType, newSavedAt }) => {
+    const store = storageType === 'local' ? localStorage : sessionStorage
+    for (let i = 0; i < store.length; i++) {
+      const key = store.key(i)
+      if (key && key.startsWith('gramframe::')) {
+        const rec = JSON.parse(/** @type {string} */ (store.getItem(key)))
+        if (newSavedAt === null) {
+          delete rec.savedAt
+        } else {
+          rec.savedAt = newSavedAt
+        }
+        store.setItem(key, JSON.stringify(rec))
+        return true
+      }
+    }
+    return false
+  }, { storageType, newSavedAt })
+}
+
+test.describe('Feature 157: student annotation 24h expiry', () => {
+  // Each test runs in its own isolated browser context (fresh session/local
+  // storage), so no explicit clear is needed. Grant extra headroom for the
+  // extra reload + storage-mutation steps under parallel load.
+  test.beforeEach(() => {
+    test.setTimeout(30000)
+  })
+
+  // ── User Story 1: Old student annotations do not resurface ──
+
+  // T006 — contract T-A, SC-001, FR-003
+  test('US1: student annotations older than 24h are discarded on load', async ({ page }) => {
+    const gfp = await gotoFixture(page, '/tests/fixtures/student-page.html')
+    await addAnalysisMarker(gfp, 200, 150)
+
+    // Confirm the app wrote a student record to sessionStorage
+    const keysBefore = await gfp.getStorageKeys('session')
+    expect(keysBefore.length).toBeGreaterThan(0)
+
+    // Backdate the record's savedAt to 25h ago
+    const mutated = await mutateSavedAt(page, 'session', new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString())
+    expect(mutated).toBe(true)
+
+    // Reload — the expired record must not restore and must be removed
+    await page.reload()
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+    await page.waitForTimeout(500)
+
+    const state = await getStateFromPage(page)
+    expect(state.analysis.markers.length).toBe(0)
+    expect(state.harmonics.harmonicSets.length).toBe(0)
+    expect(state.doppler.fPlus).toBeNull()
+    expect(state.doppler.fMinus).toBeNull()
+
+    // The stale key must have been removed during the load
+    const keysAfter = await gfp.getStorageKeys('session')
+    expect(keysAfter.length).toBe(0)
+  })
+
+  // T007 — contract T-B, SC-002, FR-004
+  test('US1: student annotations within 24h are restored on load', async ({ page }) => {
+    const gfp = await gotoFixture(page, '/tests/fixtures/student-page.html')
+    await addAnalysisMarker(gfp, 200, 150)
+
+    const stateBefore = await getStateFromPage(page)
+    expect(stateBefore.analysis.markers.length).toBeGreaterThan(0)
+
+    // Set savedAt to ~1h ago — well within the 24h window
+    const mutated = await mutateSavedAt(page, 'session', new Date(Date.now() - 60 * 60 * 1000).toISOString())
+    expect(mutated).toBe(true)
+
+    await page.reload()
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+    await page.waitForTimeout(500)
+
+    const stateAfter = await getStateFromPage(page)
+    expect(stateAfter.analysis.markers.length).toBe(stateBefore.analysis.markers.length)
+
+    // Key should still be present (not discarded)
+    const keysAfter = await gfp.getStorageKeys('session')
+    expect(keysAfter.length).toBeGreaterThan(0)
+  })
+
+  // T008 — contract T-D, FR-009
+  test('US1: student record with missing savedAt is discarded on load', async ({ page }) => {
+    const gfp = await gotoFixture(page, '/tests/fixtures/student-page.html')
+    await addAnalysisMarker(gfp, 200, 150)
+
+    // Remove the savedAt field entirely — cannot prove freshness, fail safe
+    const mutated = await mutateSavedAt(page, 'session', null)
+    expect(mutated).toBe(true)
+
+    await page.reload()
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+    await page.waitForTimeout(500)
+
+    const state = await getStateFromPage(page)
+    expect(state.analysis.markers.length).toBe(0)
+
+    const keysAfter = await gfp.getStorageKeys('session')
+    expect(keysAfter.length).toBe(0)
+  })
+
+  // T008b — garbage (unparseable) savedAt is also discarded (contract T-D, FR-009)
+  test('US1: student record with garbage savedAt is discarded on load', async ({ page }) => {
+    const gfp = await gotoFixture(page, '/tests/fixtures/student-page.html')
+    await addAnalysisMarker(gfp, 200, 150)
+
+    const mutated = await mutateSavedAt(page, 'session', 'not-a-date')
+    expect(mutated).toBe(true)
+
+    await page.reload()
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+    await page.waitForTimeout(500)
+
+    const state = await getStateFromPage(page)
+    expect(state.analysis.markers.length).toBe(0)
+
+    const keysAfter = await gfp.getStorageKeys('session')
+    expect(keysAfter.length).toBe(0)
+  })
+
+  // T008c — future savedAt (clock skew) is discarded (contract T-D, FR-009)
+  test('US1: student record with a future savedAt is discarded on load', async ({ page }) => {
+    const gfp = await gotoFixture(page, '/tests/fixtures/student-page.html')
+    await addAnalysisMarker(gfp, 200, 150)
+
+    // 2 hours in the future
+    const mutated = await mutateSavedAt(page, 'session', new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString())
+    expect(mutated).toBe(true)
+
+    await page.reload()
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+    await page.waitForTimeout(500)
+
+    const state = await getStateFromPage(page)
+    expect(state.analysis.markers.length).toBe(0)
+
+    const keysAfter = await gfp.getStorageKeys('session')
+    expect(keysAfter.length).toBe(0)
+  })
+
+  // ── User Story 3: Trainer annotations remain permanent ──
+
+  // T011 — contract T-C, SC-003, FR-006
+  test('US3: trainer annotations survive beyond 24h', async ({ page }) => {
+    const gfp = await gotoFixture(page, '/tests/fixtures/trainer-page.html')
+    await addAnalysisMarker(gfp, 200, 150)
+
+    const stateBefore = await getStateFromPage(page)
+    expect(stateBefore.analysis.markers.length).toBeGreaterThan(0)
+
+    // Backdate savedAt to 10 days ago — far beyond the student window
+    const mutated = await mutateSavedAt(page, 'local', new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString())
+    expect(mutated).toBe(true)
+
+    await page.reload()
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+    await page.waitForTimeout(500)
+
+    // Trainer records must still be restored and the key must remain
+    const stateAfter = await getStateFromPage(page)
+    expect(stateAfter.analysis.markers.length).toBe(stateBefore.analysis.markers.length)
+
+    const keysAfter = await gfp.getStorageKeys('local')
+    expect(keysAfter.length).toBeGreaterThan(0)
+  })
+
+  // T012 — contract behavior matrix, FR-006
+  test('US3: trainer record with missing savedAt is NOT discarded', async ({ page }) => {
+    const gfp = await gotoFixture(page, '/tests/fixtures/trainer-page.html')
+    await addAnalysisMarker(gfp, 200, 150)
+
+    const stateBefore = await getStateFromPage(page)
+    expect(stateBefore.analysis.markers.length).toBeGreaterThan(0)
+
+    // Remove savedAt — for trainer context the expiry gate is skipped entirely
+    const mutated = await mutateSavedAt(page, 'local', null)
+    expect(mutated).toBe(true)
+
+    await page.reload()
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+    await page.waitForTimeout(500)
+
+    const stateAfter = await getStateFromPage(page)
+    expect(stateAfter.analysis.markers.length).toBe(stateBefore.analysis.markers.length)
+
+    const keysAfter = await gfp.getStorageKeys('local')
+    expect(keysAfter.length).toBeGreaterThan(0)
+  })
+
+  // ── User Story 2: Instructors can force an immediate reset ──
+
+  // T014 — contract T-E, US2, FR-008
+  // A fresh browser session (new sessionStorage) restores no student annotations,
+  // regardless of the 24h window. This preserves the instructor override.
+  test('US2: fresh browser session restores no student annotations', async ({ browser }) => {
+    // Session 1 — seed student annotations
+    const context1 = await browser.newContext()
+    const page1 = await context1.newPage()
+    const gfp1 = await gotoFixture(page1, '/tests/fixtures/student-page.html')
+    await addAnalysisMarker(gfp1, 200, 150)
+
+    const state1 = await getStateFromPage(page1)
+    expect(state1.analysis.markers.length).toBeGreaterThan(0)
+    await context1.close()
+
+    // Session 2 — a fresh session starts with empty sessionStorage
+    const context2 = await browser.newContext()
+    const page2 = await context2.newPage()
+    await gotoFixture(page2, '/tests/fixtures/student-page.html')
+
+    const state2 = await getStateFromPage(page2)
+    expect(state2.analysis.markers.length).toBe(0)
+    await context2.close()
+  })
+})


### PR DESCRIPTION
## Summary

Implements feature **157-student-tonal-expiry** (GH issue #184 — "Reduce persistence of tonals for students").

Student-context annotations (stored in `sessionStorage`) expire **24 hours** after they were last saved, protecting the integrity of later assessments: a student who annotated a gram days earlier finds it opens clean on revisit, rather than reusing their earlier markings. Trainer-context annotations (`localStorage`) are unaffected and persist indefinitely. The window is measured from the **last save** (actively worked-on grams stay available) and is evaluated on page load — no background timer.

## Note on overlap with PR #190

An equivalent implementation of this feature landed on `main` independently via **PR #190** while this branch was in review. This branch has been merged onto that result:

- **Production code** (`src/core/storage.js`) is now identical to `main` — `STUDENT_TTL_MS`, the pure `isAnnotationExpired(savedAt, nowMs)` predicate, and the student-only expiry gate in `loadAnnotations()`. No net change over `main`.
- The **duplicate test block** was collapsed into `main`'s canonical Feature-157 describe blocks.
- The remaining net contribution of this PR is one edge case `main` did not cover explicitly: a **future `savedAt`** (clock skew) is discarded (FR-009), added as a dedicated student test in `tests/storage.spec.js`.

If maintainers prefer, this PR can simply be closed in favour of #190 — the only unique value here is that one extra test.

## Requirements covered

FR-001 through FR-009; user stories US1 (old student annotations don't resurface), US2 (fresh-session override), US3 (trainer permanence).

## Testing

- `yarn test` — storage suite **24 passed** (including the new future-`savedAt` test), zero regressions.
- `yarn build` — green.
- `yarn typecheck` — no new errors. One pre-existing, unrelated error remains (`src/index.js` TS2882 for the side-effect `./gramframe.css` import, identical on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJmyKwzuWqXaQ6t9LuHo5b