### PR TITLE
Plan: harmonic line width trial (spec 158)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,7 @@ Example configuration:
 - Browser Web Storage API — `sessionStorage` (student), `localStorage` (trainer) (157-student-tonal-expiry)
 - JavaScript ES2020+, JSDoc-typed (no TS compilation) + None at runtime (zero runtime deps); Vite for build (157-harmonic-pin-symbols)
 - Browser Web Storage (localStorage for trainers / sessionStorage for students) (157-harmonic-pin-symbols)
+- N/A — no persisted field changes (line width is a pure render-time attribute) (158-harmonic-line-width)
 
 ## Recent Changes
 - 154-enrich-docs: Added Markdown documentation (no code changes) + N/A (documentation-only feature)

--- a/specs/158-harmonic-line-width/contracts/harmonic-line-width.md
+++ b/specs/158-harmonic-line-width/contracts/harmonic-line-width.md
@@ -1,0 +1,60 @@
+# Contract: Harmonic Line Width Rendering
+
+**Feature**: 158-harmonic-line-width
+**Type**: UI rendering contract (SVG DOM output)
+
+GramFrame is a browser UI component, not a service; its "contract" is the DOM it
+produces. This document specifies the observable output contract for harmonic
+line stroke widths — the surface tests assert against.
+
+## Producer
+
+`HarmonicsMode.createHarmonicLine(harmonicNumber, harmonicSet, lineX, lineTop, lineHeight)`
+in `src/modes/harmonics/HarmonicsMode.js`.
+
+## Contract
+
+For each visible harmonic in each rendered harmonic set, the producer MUST emit
+one SVG `<line>` element with:
+
+| Attribute              | Guarantee                                             |
+|------------------------|-------------------------------------------------------|
+| `class`                | equals `gram-frame-harmonic-line`                     |
+| `data-harmonic-number` | the harmonic's integer number as a string             |
+| `stroke-width`         | `"2"` when the harmonic number is **odd**; `"1"` when **even** |
+
+### Formal rule
+
+```text
+given a line L with data-harmonic-number = n (integer ≥ 1):
+  n is odd  ⇒ L.stroke-width == "2"
+  n is even ⇒ L.stroke-width == "1"
+```
+
+### Invariants
+
+- **C-1 (allowed values)**: `stroke-width` is exactly `"1"` or `"2"` for every
+  `.gram-frame-harmonic-line`. No other value appears.
+- **C-2 (determinism)**: Re-rendering the same harmonic set (after drag, zoom,
+  expand, mode switch, or reload) yields the same `stroke-width` for each
+  `data-harmonic-number`.
+- **C-3 (alternation)**: For any two consecutive visible harmonics n and n+1,
+  their lines' `stroke-width` values differ.
+- **C-4 (isolation)**: Only `.gram-frame-harmonic-line` elements are affected.
+  Doppler (`DopplerMode`) and Analysis (`AnalysisMode`) line widths are
+  unchanged, as are harmonic labels, colours, positions, and heights.
+
+## Consumer expectations (tests)
+
+A Playwright test acts as the consumer:
+
+1. Enter Harmonics mode and create a harmonic set with ≥ 2 visible harmonics.
+2. Query all `.gram-frame-harmonic-line` elements.
+3. For each, read `data-harmonic-number` and `stroke-width` and assert the
+   formal rule above (C-1, C-3) and that no other stroke-width values appear.
+
+## Non-goals
+
+- No JSON/HTTP schema (not a service).
+- No new configuration attribute in the `gram-config` table.
+- No persisted field; width is derived, never stored.

--- a/specs/158-harmonic-line-width/data-model.md
+++ b/specs/158-harmonic-line-width/data-model.md
@@ -1,0 +1,61 @@
+# Data Model: Width of Harmonic Lines (Trial)
+
+**Feature**: 158-harmonic-line-width
+**Phase**: 1 (Design & Contracts)
+
+This feature introduces **no new persisted data and no state-shape changes**.
+Line width is a derived, render-time property. This document records the single
+entity touched and the derivation rule, for completeness.
+
+## Entities
+
+### Harmonic Line (existing — no schema change)
+
+The vertical SVG line rendered for one harmonic of a harmonic set. Created in
+`HarmonicsMode.createHarmonicLine()`.
+
+| Attribute            | Source                         | Changed by this feature? |
+|----------------------|--------------------------------|--------------------------|
+| `class`              | `gram-frame-harmonic-line`     | No                       |
+| `data-harmonic-set-id` | `harmonicSet.id`             | No                       |
+| `data-harmonic-number` | `harmonicNumber`             | No                       |
+| `x1`/`x2`            | zoom-aware X position          | No                       |
+| `y1`/`y2`            | `lineTop` … `lineTop+lineHeight` | No                     |
+| `stroke`             | `harmonicSet.color`            | No                       |
+| **`stroke-width`**   | **derived from `harmonicNumber`** | **Yes (was fixed `'2'`)** |
+| `stroke-linecap`     | `round`                        | No                       |
+| `opacity`            | `0.9`                          | No                       |
+
+### Derivation rule (new)
+
+```text
+strokeWidth(harmonicNumber) = (harmonicNumber mod 2 == 0) ? 1 : 2
+```
+
+- Odd harmonic numbers (1, 3, 5, …) → **2px** (current width, kept for comparison)
+- Even harmonic numbers (2, 4, 6, …) → **1px** (thinner, the trial variant)
+- Domain: `harmonicNumber` is a positive integer ≥ 1 (from `getVisibleHarmonics`)
+- Deterministic: pure function of `harmonicNumber`; no state, no time, no index
+
+## State / Persistence
+
+- **State (`src/core/state.js`)**: unchanged. No new field on `harmonicSets` or
+  anywhere in `GramFrameState`.
+- **Persistence (localStorage / sessionStorage)**: unchanged. No stored
+  harmonic-set record gains or loses a field; reloaded data renders with the same
+  derivation. Backward/forward compatible by construction.
+- **Listeners**: unchanged. No new broadcast payload.
+
+## Relationships
+
+- A **Harmonic Set** has many **Harmonic Lines** (one per visible harmonic).
+  This feature changes only how each line's `stroke-width` is computed at render
+  time; the set→line relationship, spacing, colour, and labels are untouched.
+
+## Validation Rules
+
+- **INV-1**: Every rendered harmonic line has `stroke-width` ∈ {1, 2} (SC-002).
+- **INV-2**: For a fixed `harmonicNumber`, `stroke-width` is constant across all
+  re-renders (SC-003).
+- **INV-3**: In any set with ≥ 2 consecutive visible harmonics, adjacent lines
+  differ in width (SC-001).

--- a/specs/158-harmonic-line-width/plan.md
+++ b/specs/158-harmonic-line-width/plan.md
@@ -1,0 +1,99 @@
+# Implementation Plan: Width of Harmonic Lines (Trial)
+
+**Branch**: `158-harmonic-line-width` | **Date**: 2026-07-17 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/158-harmonic-line-width/spec.md`
+
+## Summary
+
+Harmonic vertical lines currently render at a fixed `stroke-width: 2`. The issue
+asks for a trial where every other line is thinner (1px) so a reviewer can
+compare thinner vs current width side by side. The technical approach is a
+minimal, deterministic change in `HarmonicsMode.createHarmonicLine()`: derive the
+stroke width from the harmonic number (odd → 2px, even → 1px) instead of the
+hard-coded `'2'`. No state, config, persistence, or UI changes are required.
+
+## Technical Context
+
+**Language/Version**: JavaScript (ES2020+), JSDoc-typed, no compilation step  
+**Primary Dependencies**: None at runtime (zero runtime dependencies); Vite for build  
+**Storage**: N/A — no persisted field changes (line width is a pure render-time attribute)  
+**Testing**: Playwright end-to-end (`yarn test`); type checking via `yarn typecheck`  
+**Target Platform**: Modern browsers (SVG overlay rendered in the spectrogram container)  
+**Project Type**: Single-project browser component (SVG-based interactive overlay)  
+**Performance Goals**: No change — same number of SVG line elements; one extra modulo per line  
+**Constraints**: SVG-first rendering (Constitution I); width must be a fixed pixel stroke that does not scale with zoom/expand  
+**Scale/Scope**: Single function change (`createHarmonicLine`) plus one Playwright test; ~1 file of source impact
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. SVG-First Rendering**: PASS. The change only alters the `stroke-width`
+  attribute of the existing `<line>` SVG element created in `createHarmonicLine`.
+  No Canvas, no absolute-positioned DOM. Coordinate transforms are untouched. SVG
+  remains DOM-queryable (the `stroke-width` attribute is assertable in tests).
+- **II. Test-First (NON-NEGOTIABLE)**: PASS. A new Playwright assertion verifies
+  the alternating 1px/2px widths on rendered `.gram-frame-harmonic-line`
+  elements. `yarn test` and `yarn typecheck` must pass before merge.
+- **III. Modular Mode Architecture**: PASS. The change is confined to
+  `src/modes/harmonics/HarmonicsMode.js`. No cross-mode coupling; Doppler and
+  Analysis modes are untouched. No `ModeFactory` change.
+- **IV. Declarative HTML Configuration**: PASS. No configuration surface is
+  added or altered; the trial is a fixed render behaviour with no new
+  `gram-config` parameter.
+
+**Result**: No violations. Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/158-harmonic-line-width/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+│   └── harmonic-line-width.md
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+└── modes/
+    └── harmonics/
+        └── HarmonicsMode.js     # createHarmonicLine(): derive stroke-width from harmonic number
+
+tests/
+└── harmonics-mode.spec.js       # add assertion for alternating 1px/2px line widths
+```
+
+**Structure Decision**: Single-project browser component. The feature touches
+exactly one production source file (`HarmonicsMode.js`) and one test file
+(`harmonics-mode.spec.js`). No new modules, directories, or build changes are
+introduced. This respects the modular mode architecture — all harmonic rendering
+logic already lives in `src/modes/harmonics/`.
+
+## Implementation Approach
+
+1. In `HarmonicsMode.createHarmonicLine(harmonicNumber, ...)`, replace the
+   literal `line.setAttribute('stroke-width', '2')` with a width derived from the
+   harmonic number: `const strokeWidth = harmonicNumber % 2 === 0 ? 1 : 2`.
+   Odd harmonics (1, 3, 5, …) keep 2px; even harmonics (2, 4, 6, …) render 1px —
+   yielding the alternating "every other line is 1px" trial.
+2. `harmonicNumber` is already a parameter of `createHarmonicLine`, so no
+   plumbing is needed. The derivation is deterministic per harmonic (FR-002),
+   applies to every set (FR-003), and leaves labels, colour, position, and
+   height untouched (FR-004, FR-005).
+3. Add a Playwright assertion in `tests/harmonics-mode.spec.js` that creates a
+   harmonic set with multiple visible harmonics and verifies the rendered
+   `.gram-frame-harmonic-line` elements alternate between `stroke-width="1"` and
+   `stroke-width="2"` by harmonic number (read via `data-harmonic-number`).
+4. Run `yarn typecheck`, `yarn test`, and `yarn build` (Quality Gates).
+
+## Complexity Tracking
+
+> No Constitution Check violations. This section intentionally left empty.

--- a/specs/158-harmonic-line-width/quickstart.md
+++ b/specs/158-harmonic-line-width/quickstart.md
@@ -1,0 +1,60 @@
+# Quickstart: Width of Harmonic Lines (Trial)
+
+**Feature**: 158-harmonic-line-width
+
+## What this delivers
+
+A trial rendering where harmonic vertical lines alternate in thickness: odd
+harmonics stay at the current 2px, even harmonics render thinner at 1px. This
+lets a reviewer compare thinner vs current line weight on the same spectrogram.
+
+## The change in one place
+
+`src/modes/harmonics/HarmonicsMode.js` → `createHarmonicLine()`:
+
+```js
+// Before
+line.setAttribute('stroke-width', '2')
+
+// After
+const strokeWidth = harmonicNumber % 2 === 0 ? 1 : 2  // even → 1px (thin), odd → 2px (current)
+line.setAttribute('stroke-width', String(strokeWidth))
+```
+
+`harmonicNumber` is already the first parameter of `createHarmonicLine`, so no
+other wiring is needed.
+
+## Try it locally
+
+```bash
+yarn dev
+```
+
+1. Open the dev page and switch to **Harmonics** mode.
+2. Click-drag on the spectrogram to create a harmonic set that shows several
+   harmonic lines.
+3. Observe that consecutive harmonic lines alternate between thin (1px) and the
+   current (2px) weight. The harmonic-number labels are unchanged.
+
+## Verify
+
+```bash
+yarn typecheck   # zero errors
+yarn test        # all Playwright tests green, including the new width assertion
+yarn build       # clean production build
+```
+
+### What the new test checks
+
+In `tests/harmonics-mode.spec.js`, after creating a harmonic set with multiple
+visible harmonics:
+
+- Every `.gram-frame-harmonic-line` has `stroke-width` of exactly `"1"` or `"2"`.
+- Odd `data-harmonic-number` lines are `"2"`; even ones are `"1"`.
+- Consecutive harmonics differ in width.
+
+## Rollback / follow-up
+
+This is a trial. Once the reviewer decides on a final width, a follow-up change
+replaces the alternation with a single chosen `stroke-width`. No data migration
+is involved because nothing is persisted.

--- a/specs/158-harmonic-line-width/research.md
+++ b/specs/158-harmonic-line-width/research.md
@@ -1,0 +1,85 @@
+# Research: Width of Harmonic Lines (Trial)
+
+**Feature**: 158-harmonic-line-width
+**Phase**: 0 (Outline & Research)
+
+This feature has no NEEDS CLARIFICATION markers in its Technical Context — the
+scope is a single, well-understood rendering change. The research below records
+the decisions that shape the (minimal) implementation.
+
+## Decision 1: Current harmonic line width is 2px, so the trial applies
+
+- **Decision**: Proceed with a trial. Harmonic lines are drawn at `stroke-width:
+  2` today, so the issue's "if they are 2px" branch applies (not the "already
+  1px, can't do anything" branch).
+- **Rationale**: `src/modes/harmonics/HarmonicsMode.js` → `createHarmonicLine()`
+  sets `line.setAttribute('stroke-width', '2')` (line 683). This is the only
+  place harmonic vertical lines get their width.
+- **Alternatives considered**: None — the current width is a directly verifiable
+  fact in the source, not a judgement call.
+
+## Decision 2: Interpret "every other line is 1px" as alternation, not a global change
+
+- **Decision**: Render alternating widths within each harmonic set — odd
+  harmonic numbers at 2px (current), even harmonic numbers at 1px (thinner) — so
+  the reviewer sees both weights on the same spectrogram.
+- **Rationale**: The issue explicitly says "produce a *trial* release where every
+  other vertical line is 1px." A trial implies a side-by-side comparison so the
+  reviewer can decide whether 1px reads better than 2px. Converting every line to
+  1px would remove the comparison and pre-empt the decision. Alternation is the
+  most literal reading of "every other line."
+- **Alternatives considered**:
+  - *Make all lines 1px*: rejected — removes the comparison the trial exists to
+    provide and over-commits before the reviewer decides.
+  - *Add a UI toggle to switch width*: rejected — over-engineered for a trial;
+    introduces state/config surface the issue does not ask for and the
+    constitution's declarative-config principle would scrutinise.
+
+## Decision 3: Derive width from harmonic number for determinism
+
+- **Decision**: Compute the width as `harmonicNumber % 2 === 0 ? 1 : 2` inside
+  `createHarmonicLine`, which already receives `harmonicNumber`.
+- **Rationale**: `harmonicNumber` is a stable identity for each line (1, 2, 3,
+  …). Keying width off it guarantees the same harmonic always renders at the same
+  width across every re-render — drag updates, zoom, expand, mode switches, and
+  reloads (FR-002, SC-003). Using a render-loop index would also work but is
+  slightly less stable if visible-harmonic ranges shift; harmonic number is the
+  natural, persistent key. No extra parameter plumbing is required.
+- **Alternatives considered**:
+  - *Alternate by loop index (`forEach` index)*: rejected — index can shift when
+    the visible-harmonic window changes (freqMin/freqMax), so a given harmonic
+    could flip width across re-renders, violating determinism.
+  - *Store width in state / persisted record*: rejected — width is a pure
+    render-time attribute; persisting it adds needless surface and migration
+    concerns (Doppler/Analysis unaffected).
+
+## Decision 4: Fixed pixel stroke, not zoom-scaled
+
+- **Decision**: Keep `stroke-width` as a fixed pixel value (1 or 2), exactly as
+  today's `'2'`.
+- **Rationale**: The existing line already uses a fixed pixel stroke and is not
+  scaled with the coordinate transform; harmonic *positions* are zoom-aware but
+  the stroke weight is intentionally constant. Preserving this keeps the trial an
+  apples-to-apples comparison and satisfies the constraint that width must not
+  change with zoom/expand.
+- **Alternatives considered**: *Scale width with zoom*: rejected — changes
+  behaviour beyond the trial's scope and would make the comparison inconsistent
+  across zoom levels.
+
+## Decision 5: Test via DOM attribute assertion
+
+- **Decision**: Assert the alternating widths by reading the `stroke-width`
+  attribute of `.gram-frame-harmonic-line` elements, keyed by
+  `data-harmonic-number`, in a Playwright test.
+- **Rationale**: SVG-first rendering (Constitution I) keeps the lines
+  DOM-queryable. Each line already carries `data-harmonic-number`, so the test
+  can map harmonic → expected width deterministically. This matches the existing
+  test patterns in `tests/harmonics-mode.spec.js`.
+- **Alternatives considered**: *Visual/screenshot comparison*: rejected as the
+  primary check — attribute assertion is exact and stable; a screenshot is
+  brittle for a 1px difference. Screenshots remain available for manual review.
+
+## Summary
+
+All decisions resolve to a one-line source change plus one test. No unknowns
+remain; Phase 1 proceeds.

--- a/specs/158-harmonic-line-width/spec.md
+++ b/specs/158-harmonic-line-width/spec.md
@@ -1,0 +1,135 @@
+# Feature Specification: Width of Harmonic Lines (Trial)
+
+**Feature Branch**: `158-harmonic-line-width`  
+**Created**: 2026-07-17  
+**Status**: Draft  
+**Input**: GH issue 158 — "Width of harmonics line". A user requested that the
+vertical lines drawn to represent harmonics be a bit thinner. If they are 2px,
+produce a trial release where every other vertical line is 1px. If they are
+already 1px, we can't do anything about it.
+
+## Context & Current State
+
+The vertical lines that represent harmonic pins are currently rendered at a
+stroke width of **2px** (`stroke-width: 2` on each `.gram-frame-harmonic-line`).
+Because the lines are 2px today (not already 1px), the "we can't do anything
+about it" branch does **not** apply, and a trial is warranted.
+
+The purpose of this feature is to produce a **visual trial** so a reviewer can
+compare thinner and thicker harmonic lines side by side on the same spectrogram
+and decide whether thinner lines read better. The trial renders **alternating**
+harmonic lines at 1px and 2px within each harmonic set, rather than committing
+every line to a single new width. This lets the difference be judged directly
+against the current appearance in one glance.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Compare thinner harmonic lines against current width (Priority: P1)
+
+An analyst reviewing the trial release opens a spectrogram and creates (or
+loads) a harmonic set. The vertical harmonic lines now alternate in thickness:
+every other line is drawn thinner (1px) while the lines between them keep the
+current thickness (2px). Seeing both weights on the same set, the analyst can
+judge at a glance whether the thinner line is clearer and preferable, and feed
+that decision back before a final width is chosen.
+
+**Why this priority**: This is the entire purpose of the trial requested in the
+issue. It delivers the comparison the user asked for and is the only behavior
+this feature introduces.
+
+**Independent Test**: Create a harmonic set with several visible harmonics and
+inspect the rendered lines; confirm the lines alternate between 1px and 2px
+stroke widths across consecutive harmonics. Fully testable on its own.
+
+**Acceptance Scenarios**:
+
+1. **Given** a spectrogram in Harmonics mode, **When** the analyst creates a
+   harmonic set that produces multiple visible harmonic lines, **Then** the
+   harmonic lines alternate in stroke width so that every other line is 1px and
+   the remaining lines are 2px.
+2. **Given** a harmonic set with alternating line widths, **When** the analyst
+   reads the harmonic number labels, **Then** the labels remain legible and
+   correctly associated with their lines regardless of the line's width.
+3. **Given** a harmonic set with only one visible harmonic line, **When** it is
+   rendered, **Then** it is drawn without error at a defined width from the
+   alternation scheme.
+
+---
+
+### Edge Cases
+
+- A harmonic set may have only one visible harmonic (e.g., high spacing or a
+  narrow frequency range). The single line still renders correctly at its
+  assigned width.
+- Line width must remain constant for a given harmonic as the view is zoomed or
+  the image expanded — width is a fixed pixel stroke, not a scaled quantity, so
+  it must not change with zoom.
+- Multiple independent harmonic sets on the overlay each apply the same
+  alternation scheme so the comparison is consistent across sets.
+- The alternation is deterministic and tied to the harmonic number (or its
+  rendering index) so the same harmonic always shows the same width across
+  re-renders (drag updates, mode switches, reloads).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST render harmonic vertical lines such that every
+  other line is drawn at 1px stroke width and the remaining lines at 2px stroke
+  width (the current width), producing a directly comparable trial.
+- **FR-002**: The assignment of 1px vs 2px MUST be deterministic for a given
+  harmonic so that the same harmonic renders at the same width on every
+  re-render (drag updates, zoom, expand, mode switch, reload).
+- **FR-003**: The alternation MUST apply consistently to every harmonic set
+  rendered on the overlay.
+- **FR-004**: Harmonic number labels MUST remain legible and correctly
+  positioned relative to their lines irrespective of whether a line is 1px or
+  2px.
+- **FR-005**: The change MUST be limited to the visual stroke width of harmonic
+  lines; harmonic spacing, position, colour, label text, interaction (drag,
+  selection, deletion), and persistence behaviour MUST be unchanged.
+- **FR-006**: No configuration input, control, or persisted field is introduced
+  by this trial; the alternating widths are applied automatically during
+  rendering.
+
+### Key Entities *(include if feature involves data)*
+
+- **Harmonic Line**: The vertical SVG line drawn for a single harmonic of a
+  harmonic set. Already carries position, height, colour, and a harmonic number.
+  This feature makes its **stroke width** depend on the harmonic (alternating
+  1px / 2px) instead of a fixed 2px. No persisted attribute changes.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In a harmonic set with N ≥ 2 visible harmonics, consecutive
+  harmonic lines differ in width, with the width alternating between 1px and 2px.
+- **SC-002**: 100% of rendered harmonic lines carry a stroke width of exactly
+  1px or exactly 2px (no other values).
+- **SC-003**: For any given harmonic, the rendered stroke width is identical
+  before and after a re-render triggered by drag, zoom, expand, mode switch, or
+  reload.
+- **SC-004**: All existing harmonics behaviour (spacing, colour, labels, drag,
+  selection, deletion, persistence) is unchanged, evidenced by the existing
+  harmonics test suite continuing to pass.
+- **SC-005**: A reviewer can visually compare a 1px harmonic line against a 2px
+  harmonic line on the same spectrogram in a single view.
+
+## Assumptions
+
+- "Every other vertical line" is interpreted as alternating widths within a
+  harmonic set (odd-numbered harmonics at one width, even-numbered at the
+  other), producing a side-by-side comparison rather than converting all lines
+  to a single new width. This matches the issue's request for a *trial*.
+- The two widths under trial are 1px (thinner) and 2px (current). The default/
+  current width of 2px is retained on the non-thinned lines so the comparison is
+  against today's appearance.
+- The trial applies only to Harmonics-mode harmonic lines
+  (`.gram-frame-harmonic-line`); Doppler and Analysis mode lines are out of
+  scope.
+- No new UI control is added; the alternation is a fixed rendering behaviour for
+  the trial release. A follow-up may standardise on the chosen width once the
+  reviewer decides.
+- This is a trial to gather feedback; a subsequent change (out of scope here)
+  will settle on a single final width based on the reviewer's decision.


### PR DESCRIPTION
## Summary

Planning artifacts (`/speckit.plan`) for **GH issue #158 — Width of harmonics line**.

The issue asks: harmonic vertical lines are currently 2px; produce a *trial* release where every other vertical line is 1px so a reviewer can compare thinner vs current weight. Confirmed the lines are indeed `stroke-width: 2` today (`src/modes/harmonics/HarmonicsMode.js:683`), so the trial applies.

This PR contains **planning documents only** — no source/behaviour change yet. Implementation lands via `/speckit.tasks` + `/speckit.implement`.

## Approach

Render alternating widths within each harmonic set — odd harmonic numbers stay at 2px (current), even harmonic numbers render at 1px (thinner) — a deterministic, side-by-side comparison. The change is one line in `HarmonicsMode.createHarmonicLine()`:

```js
const strokeWidth = harmonicNumber % 2 === 0 ? 1 : 2
line.setAttribute('stroke-width', String(strokeWidth))
```

`harmonicNumber` is already a parameter, so no plumbing is needed. No state, config, persistence, or UI changes.

## Artifacts

- `spec.md` — user scenarios, functional requirements (FR-001…006), success criteria
- `research.md` — key decisions: alternation vs global change, width keyed off harmonic number for determinism, fixed pixel stroke, DOM-attribute testing
- `data-model.md` — no persisted change; render-time width derivation and invariants
- `contracts/harmonic-line-width.md` — SVG DOM output contract (odd→2px, even→1px)
- `quickstart.md` — the one-line change and verify steps
- `plan.md` — technical context, Constitution Check, structure decision

## Constitution Check

Passes all four principles: SVG-first (only alters `stroke-width` on the existing `<line>`), test-first (new Playwright assertion), modular mode (confined to `src/modes/harmonics/`), declarative config (no new `gram-config` surface). No violations; no complexity tracking needed.

## Test plan

Implementation (follow-up) will add a Playwright assertion in `tests/harmonics-mode.spec.js` verifying rendered `.gram-frame-harmonic-line` elements alternate `stroke-width="1"`/`"2"` by `data-harmonic-number`, plus `yarn typecheck` / `yarn test` / `yarn build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8jpzm6wjPpJdDgaftyhiA)_