### PR TITLE
feat(harmonics): sample harmonic pins to keep dense sets legible (#158)

### DIFF
--- a/specs/158-harmonic-pin-sampling/contracts/sampling-algorithm.md
+++ b/specs/158-harmonic-pin-sampling/contracts/sampling-algorithm.md
@@ -12,7 +12,7 @@ This is the internal contract for the new pure helper module
 ### Constants
 
 ```js
-export const MAX_VISIBLE_PINS = 50
+export const MAX_VISIBLE_PINS = 25
 export const NICE_STEPS = [1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000]
 ```
 
@@ -89,8 +89,8 @@ getVisibleHarmonics(harmonicSet) {
 
 | Scenario | Expected | Spec |
 |----------|----------|------|
-| Visible harmonics ≤ 50 | All drawn, `step = 1` | FR-005, SC-007 |
-| Visible harmonics > 50 | ≤ 50 drawn, `step` from `NICE_STEPS` | FR-001..FR-004, SC-001 |
+| Visible harmonics ≤ 25 | All drawn, `step = 1` | FR-005, SC-007 |
+| Visible harmonics > 25 | ≤ 25 drawn, `step` from `NICE_STEPS` | FR-001..FR-004, SC-001 |
 | Zoom in (span narrows) | Same-or-more pins, same-or-smaller step | FR-007, SC-003 |
 | Zoom out / pan wider | Same-or-fewer pins, same-or-larger step | FR-007, SC-004 |
 | Pan without zoom | Same step; drawn pins are the multiples now in view | Edge cases |

--- a/specs/158-harmonic-pin-sampling/data-model.md
+++ b/specs/158-harmonic-pin-sampling/data-model.md
@@ -54,7 +54,7 @@ Derived from a `HarmonicSet.spacing` and a visible `{freqMin, freqMax}`:
 | `harmonics` | number[]  | The harmonic numbers to draw, in ascending order, length ≤ cap  |
 
 **Invariants**:
-- `harmonics.length ≤ MAX_VISIBLE_PINS` (default 50) — FR-001, SC-001
+- `harmonics.length ≤ MAX_VISIBLE_PINS` (default 25) — FR-001, SC-001
 - If `count ≤ MAX_VISIBLE_PINS` then `step === 1` and `harmonics` is every
   harmonic in `[minHarmonic, maxHarmonic]` — FR-005, SC-007
 - Every value in `harmonics` is a multiple of `step` and lies in
@@ -69,7 +69,7 @@ Derived from a `HarmonicSet.spacing` and a visible `{freqMin, freqMax}`:
 
 | Name               | Value | Meaning                                                    |
 |--------------------|-------|------------------------------------------------------------|
-| `MAX_VISIBLE_PINS` | `50`  | Max pins drawn per harmonic set within the visible span    |
+| `MAX_VISIBLE_PINS` | `25`  | Max pins drawn per harmonic set within the visible span    |
 | `NICE_STEPS`       | `[1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000]` | Ascending nice-number step series; extend by ×10 if a set ever exceeds the largest member |
 
 ## Relationships

--- a/specs/158-harmonic-pin-sampling/plan.md
+++ b/specs/158-harmonic-pin-sampling/plan.md
@@ -47,12 +47,12 @@ the pure sampling helper is additionally unit-testable in isolation
 **Target Platform**: Modern evergreen browsers (SVG-based overlay component)
 **Project Type**: Single-project front-end library/component (Option 1)
 **Performance Goals**: No perceptible lag on zoom/pan re-render; per-set SVG node
-count bounded to ≤ 2 × cap (one line + one label per drawn pin, ≤ 50 pins), down
+count bounded to ≤ 2 × cap (one line + one label per drawn pin, ≤ 25 pins), down
 from potentially thousands today
 **Constraints**: SVG-only overlays; `yarn typecheck` + `yarn test` + `yarn build`
 must all pass; state deep-copied before listener notification; HMR preserves
 listeners; no change to the `gram-config` HTML contract
-**Scale/Scope**: Default cap 50 pins/set; nice-step series covering steps up to
+**Scale/Scope**: Default cap 25 pins/set; nice-step series covering steps up to
 several thousand; edits to ~2 existing files + 1 new pure helper + tests
 
 ## Constitution Check
@@ -69,7 +69,7 @@ existing `data-harmonic-set-id` / `data-harmonic-number` attributes for
 Playwright queryability.
 
 **II. Test-First (NON-NEGOTIABLE)** — PASS (with obligation). New Playwright
-coverage will assert: a dense set (0.5 Hz over a wide range) draws ≤ 50 pins;
+coverage will assert: a dense set (0.5 Hz over a wide range) draws ≤ 25 pins;
 drawn pins are regularly spaced (step from the nice series); a sparse set draws
 all pins unchanged; zooming in increases the number of drawn pins (never
 decreases); zooming out thins again; every drawn label corresponds to a drawn

--- a/specs/158-harmonic-pin-sampling/quickstart.md
+++ b/specs/158-harmonic-pin-sampling/quickstart.md
@@ -7,7 +7,7 @@ A short guide to implementing, running, and manually verifying this feature.
 ## What changes
 
 - **New**: `src/utils/harmonicSampling.js` — pure `chooseSamplingStep()` and
-  `sampledHarmonics()` plus `MAX_VISIBLE_PINS` (50) and `NICE_STEPS`.
+  `sampledHarmonics()` plus `MAX_VISIBLE_PINS` (25) and `NICE_STEPS`.
 - **Edit**: `src/modes/harmonics/HarmonicsMode.js` — `getVisibleHarmonics()` now
   reads the **visible** frequency range (`calculateVisibleDataRange`) and returns
   a sampled, capped list of harmonic numbers.
@@ -41,13 +41,13 @@ yarn build        # clean production build (Constitution Gate)
 2. Add a harmonic set and set its **spacing to 0.5 Hz** over a wide-frequency
    spectrogram.
    - **Before**: a solid block of overlapping lines and unreadable labels.
-   - **After**: at most 50 pins, evenly spaced (e.g. every 5th/10th/25th
+   - **After**: at most 25 pins, evenly spaced (e.g. every 5th/10th/25th
      harmonic), with legible, non-overlapping labels.
 3. **Zoom in** on a region of interest.
    - More pins appear (a finer step) as the visible span narrows; keep zooming
      and eventually every pin in view is shown.
 4. **Zoom out** / **pan** to a wider view.
-   - The overlay thins again and stays ≤ 50 pins; panning keeps the same step,
+   - The overlay thins again and stays ≤ 25 pins; panning keeps the same step,
      with the visible multiples updating for the new position.
 5. Add a **second** harmonic set with a large spacing (few pins).
    - It shows all of its pins unchanged; the cap is applied per set.
@@ -59,13 +59,13 @@ yarn build        # clean production build (Constitution Gate)
 Assert against `.gram-frame-harmonic-line` elements and their
 `data-harmonic-number` attributes:
 
-- Dense 0.5 Hz set → line count ≤ 50.
+- Dense 0.5 Hz set → line count ≤ 25.
 - Drawn `data-harmonic-number`s form a regular arithmetic series (constant step
   from `NICE_STEPS`).
 - Sparse set → all harmonics drawn (no thinning).
 - After a zoom-in step → line count is ≥ the pre-zoom count (never fewer) and
-  still ≤ 50.
-- After zoom-out/reset → line count returns to the thinned (≤ 50) state.
+  still ≤ 25.
+- After zoom-out/reset → line count returns to the thinned (≤ 25) state.
 - Every `.gram-frame-harmonic-number` label matches a rendered line's number.
 
 ## Rollback

--- a/specs/158-harmonic-pin-sampling/research.md
+++ b/specs/158-harmonic-pin-sampling/research.md
@@ -100,14 +100,14 @@ work to the cap.
 
 ## 5. Cap value and configurability
 
-**Decision**: `MAX_VISIBLE_PINS = 50` as a named constant in the new helper
-module (single source of truth), matching the issue's suggested starting value.
-Not exposed via the `gram-config` table.
+**Decision**: `MAX_VISIBLE_PINS = 25` as a named constant in the new helper
+module (single source of truth). Not exposed via the `gram-config` table.
 
-**Rationale**: The issue says "start with 50". Keeping it a constant respects
-Constitution Principle IV (no new authored-config surface) and keeps scope tight;
-it can be promoted to configuration later without rework because it is already a
-single named value.
+**Rationale**: The issue suggested starting at 50; after review the default was
+lowered to 25 to widen pin separation and improve legibility. Keeping it a
+constant respects Constitution Principle IV (no new authored-config surface) and
+keeps scope tight; it can be promoted to configuration later without rework
+because it is already a single named value.
 
 ## 6. Hit-testing / selection consistency
 
@@ -132,7 +132,7 @@ out of scope here to keep the change focused and behaviour-preserving.
 - **Unit**: exercise `chooseSamplingStep()` / `sampledHarmonics()` directly (pure
   functions) for boundary counts (exactly cap, cap+1), step progression, and
   anchor-on-multiples stability under a shifted range.
-- **E2E (Playwright)**: dense-set cap ≤ 50, regular spacing of drawn
+- **E2E (Playwright)**: dense-set cap ≤ 25, regular spacing of drawn
   `data-harmonic-number`s, sparse-set pass-through (all pins), zoom-in reveals
   more pins, zoom-out thins, and label↔line correspondence. Add
   `GramFramePage` helpers to count `.gram-frame-harmonic-line` and read their

--- a/specs/158-harmonic-pin-sampling/spec.md
+++ b/specs/158-harmonic-pin-sampling/spec.md
@@ -138,7 +138,7 @@ adjust the harmonic set as before.
 - **FR-001**: The system MUST limit the number of pins drawn for a single
   harmonic set within the visible frequency span to at most a defined
   maximum-pins limit.
-- **FR-002**: The default maximum-pins limit MUST be 50.
+- **FR-002**: The default maximum-pins limit MUST be 25.
 - **FR-003**: When the number of pins a harmonic set would place across the
   visible frequency span exceeds the limit, the system MUST draw a thinned
   subset by keeping every Nth pin (sampling by a regular step) rather than
@@ -179,14 +179,14 @@ adjust the harmonic set as before.
   the set's spacing drives how many pins would appear and therefore the sampling
   step.
 - **Maximum-pins limit**: The upper bound on how many pins one harmonic set may
-  draw within the visible span (default 50).
+  draw within the visible span (default 25).
 
 ## Success Criteria *(mandatory)*
 
 ### Measurable Outcomes
 
 - **SC-001**: For any harmonic set at any zoom/pan, no more than the
-  maximum-pins limit (default 50) pins are drawn for that set within the visible
+  maximum-pins limit (default 25) pins are drawn for that set within the visible
   frequency span.
 - **SC-002**: For the reported case (a 0.5 Hz harmonic set over a wide span), the
   overlay renders as distinct, readable pins with non-overlapping labels rather
@@ -205,8 +205,9 @@ adjust the harmonic set as before.
 
 ## Assumptions
 
-- The default maximum-pins limit is 50, as suggested in the issue. It is a single
-  tunable value; changing it later does not change the feature's scope.
+- The default maximum-pins limit is 25 (lowered from the initial 50 after review
+  to widen pin separation for legibility). It is a single tunable value; changing
+  it later does not change the feature's scope.
 - "Skipping insignificant pins" means dropping whole pins (line and its label)
   by sampling, not merely hiding labels while keeping the lines. A solid block of
   unlabelled lines would be no more legible.

--- a/specs/158-harmonic-pin-sampling/tasks.md
+++ b/specs/158-harmonic-pin-sampling/tasks.md
@@ -39,7 +39,7 @@ Single-project front-end component: `src/` and `tests/` at repository root
 
 **⚠️ CRITICAL**: No user story can be completed until Phase 2 is done.
 
-- [X] T003 Create the pure sampling module `src/utils/harmonicSampling.js` exporting `MAX_VISIBLE_PINS = 50` and `NICE_STEPS = [1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000]`, per contracts/sampling-algorithm.md
+- [X] T003 Create the pure sampling module `src/utils/harmonicSampling.js` exporting `MAX_VISIBLE_PINS = 25` and `NICE_STEPS = [1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000]`, per contracts/sampling-algorithm.md
 - [X] T004 In `src/utils/harmonicSampling.js` implement `chooseSamplingStep(minHarmonic, maxHarmonic, max = MAX_VISIBLE_PINS)` returning the smallest `NICE_STEPS` member whose multiple-count `floor(maxHarmonic/S) − floor((minHarmonic−1)/S)` is ≤ `max` (returns 1 when the range already fits; returns the largest member if none fits)
 - [X] T005 In `src/utils/harmonicSampling.js` implement `sampledHarmonics(minHarmonic, maxHarmonic, max = MAX_VISIBLE_PINS)` returning `{ step, harmonics }`, generating only the in-range multiples of `step` (start at `ceil(minHarmonic/step)×step`), never allocating the full range, with a defensive length cap of `max` and `[]` when `maxHarmonic < minHarmonic`
 - [X] T006 [P] Add JSDoc typedefs for the helper's inputs/output (e.g. `SamplingResult`) in `src/utils/harmonicSampling.js` (and `src/types.js` if a shared type is warranted) so `yarn typecheck` stays clean
@@ -55,7 +55,7 @@ Single-project front-end component: `src/` and `tests/` at repository root
 **Goal**: A dense harmonic set (e.g. 0.5 Hz spacing) renders as a bounded,
 readable subset of pins instead of a solid block.
 
-**Independent Test**: Add a 0.5 Hz harmonic set over a wide span; assert ≤ 50
+**Independent Test**: Add a 0.5 Hz harmonic set over a wide span; assert ≤ 25
 pins are drawn, the drawn `data-harmonic-number`s are a regular series, and a
 sparse set still draws every pin.
 
@@ -67,9 +67,9 @@ sparse set still draws every pin.
 
 ### Tests
 
-- [X] T012 [P] [US1] In `tests/harmonic-pin-sampling.spec.js`, add a test: dense 0.5 Hz set over a wide span draws ≤ 50 `.gram-frame-harmonic-line` elements
+- [X] T012 [P] [US1] In `tests/harmonic-pin-sampling.spec.js`, add a test: dense 0.5 Hz set over a wide span draws ≤ 25 `.gram-frame-harmonic-line` elements
 - [X] T013 [P] [US1] In `tests/harmonic-pin-sampling.spec.js`, add a test: the drawn `data-harmonic-number`s form a constant-step arithmetic series whose step is a member of `NICE_STEPS`
-- [X] T014 [P] [US1] In `tests/harmonic-pin-sampling.spec.js`, add a test: a sparse set (large spacing, ≤ 50 harmonics in view) draws every pin (no thinning; step 1)
+- [X] T014 [P] [US1] In `tests/harmonic-pin-sampling.spec.js`, add a test: a sparse set (large spacing, ≤ 25 harmonics in view) draws every pin (no thinning; step 1)
 
 **Checkpoint**: US1 fully functional and independently testable — this is the MVP.
 
@@ -81,7 +81,7 @@ sparse set still draws every pin.
 / panning thins again, recomputed on every view change.
 
 **Independent Test**: With a dense set displayed, zoom in and assert the pin
-count increases (never decreases) and stays ≤ 50; zoom out/reset and assert it
+count increases (never decreases) and stays ≤ 25; zoom out/reset and assert it
 thins back.
 
 **Note**: The production behaviour is delivered by the US1 change (visible-range
@@ -95,9 +95,9 @@ is found in T015.
 
 ### Tests
 
-- [X] T016 [P] [US2] In `tests/harmonic-pin-sampling.spec.js`, add a test: zooming in on a dense set increases the drawn pin count (≥ pre-zoom count) while staying ≤ 50
-- [X] T017 [P] [US2] In `tests/harmonic-pin-sampling.spec.js`, add a test: zooming in far enough that ≤ 50 harmonics remain in view shows every pin (step 1)
-- [X] T018 [P] [US2] In `tests/harmonic-pin-sampling.spec.js`, add a test: zoom out / reset returns the overlay to the thinned (≤ 50) state; a pan at fixed zoom keeps the same step
+- [X] T016 [P] [US2] In `tests/harmonic-pin-sampling.spec.js`, add a test: zooming in on a dense set increases the drawn pin count (≥ pre-zoom count) while staying ≤ 25
+- [X] T017 [P] [US2] In `tests/harmonic-pin-sampling.spec.js`, add a test: zooming in far enough that ≤ 25 harmonics remain in view shows every pin (step 1)
+- [X] T018 [P] [US2] In `tests/harmonic-pin-sampling.spec.js`, add a test: zoom out / reset returns the overlay to the thinned (≤ 25) state; a pan at fixed zoom keeps the same step
 
 **Checkpoint**: US2 independently testable; progressive disclosure verified.
 
@@ -171,7 +171,7 @@ chiefly guard-rail coverage; add code only if T019 reveals a mismatch.
 
 ```bash
 # After the production change (T009–T011) lands, launch US1 tests together:
-Task: "Dense set draws <= 50 lines in tests/harmonic-pin-sampling.spec.js"          # T012
+Task: "Dense set draws <= 25 lines in tests/harmonic-pin-sampling.spec.js"          # T012
 Task: "Drawn harmonic numbers form a NICE_STEPS series in ...spec.js"               # T013
 Task: "Sparse set draws every pin (step 1) in ...spec.js"                           # T014
 ```
@@ -185,7 +185,7 @@ Task: "Sparse set draws every pin (step 1) in ...spec.js"                       
 1. Phase 1: Setup (baseline green)
 2. Phase 2: Foundational (pure helper + unit test + test helpers) — CRITICAL
 3. Phase 3: US1 — wire helper into `getVisibleHarmonics` via the visible range
-4. **STOP and VALIDATE**: dense 0.5 Hz set renders ≤ 50 evenly-spaced, legible pins
+4. **STOP and VALIDATE**: dense 0.5 Hz set renders ≤ 25 evenly-spaced, legible pins
 5. Demo the fix for issue #183
 
 ### Incremental Delivery

--- a/specs/158-harmonic-pin-sampling/tasks.md
+++ b/specs/158-harmonic-pin-sampling/tasks.md
@@ -28,8 +28,8 @@ Single-project front-end component: `src/` and `tests/` at repository root
 
 **Purpose**: Establish a known-good baseline before changing behaviour
 
-- [ ] T001 Confirm baseline is green: run `yarn typecheck` and `yarn test` and record that the current `harmonics-mode` suite passes, so regressions from this feature are attributable
-- [ ] T002 Re-read the current pin path in `src/modes/harmonics/HarmonicsMode.js` (`getVisibleHarmonics` ≈L634, `renderHarmonicSet` ≈L714) and confirm `calculateVisibleDataRange` is exported from `src/components/table.js` for import
+- [X] T001 Confirm baseline is green: run `yarn typecheck` and `yarn test` and record that the current `harmonics-mode` suite passes, so regressions from this feature are attributable
+- [X] T002 Re-read the current pin path in `src/modes/harmonics/HarmonicsMode.js` (`getVisibleHarmonics` ≈L634, `renderHarmonicSet` ≈L714) and confirm `calculateVisibleDataRange` is exported from `src/components/table.js` for import
 
 ---
 
@@ -39,12 +39,12 @@ Single-project front-end component: `src/` and `tests/` at repository root
 
 **⚠️ CRITICAL**: No user story can be completed until Phase 2 is done.
 
-- [ ] T003 Create the pure sampling module `src/utils/harmonicSampling.js` exporting `MAX_VISIBLE_PINS = 50` and `NICE_STEPS = [1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000]`, per contracts/sampling-algorithm.md
-- [ ] T004 In `src/utils/harmonicSampling.js` implement `chooseSamplingStep(minHarmonic, maxHarmonic, max = MAX_VISIBLE_PINS)` returning the smallest `NICE_STEPS` member whose multiple-count `floor(maxHarmonic/S) − floor((minHarmonic−1)/S)` is ≤ `max` (returns 1 when the range already fits; returns the largest member if none fits)
-- [ ] T005 In `src/utils/harmonicSampling.js` implement `sampledHarmonics(minHarmonic, maxHarmonic, max = MAX_VISIBLE_PINS)` returning `{ step, harmonics }`, generating only the in-range multiples of `step` (start at `ceil(minHarmonic/step)×step`), never allocating the full range, with a defensive length cap of `max` and `[]` when `maxHarmonic < minHarmonic`
-- [ ] T006 [P] Add JSDoc typedefs for the helper's inputs/output (e.g. `SamplingResult`) in `src/utils/harmonicSampling.js` (and `src/types.js` if a shared type is warranted) so `yarn typecheck` stays clean
-- [ ] T007 [P] Add a Playwright unit-style spec `tests/harmonic-sampling-unit.spec.js` that imports the pure helper directly (no browser) and asserts: count == cap → step 1 (all pins); count == cap+1 → step advances; every result is a multiple of `step`; results are within range; anchor-on-multiples is stable when the range is shifted (pan); empty range → `[]`
-- [ ] T008 [P] Extend `tests/helpers/gram-frame-page.js` with helpers to (a) count `.gram-frame-harmonic-line` elements for a set and (b) read their `data-harmonic-number` values in order, for use by all story specs
+- [X] T003 Create the pure sampling module `src/utils/harmonicSampling.js` exporting `MAX_VISIBLE_PINS = 50` and `NICE_STEPS = [1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000]`, per contracts/sampling-algorithm.md
+- [X] T004 In `src/utils/harmonicSampling.js` implement `chooseSamplingStep(minHarmonic, maxHarmonic, max = MAX_VISIBLE_PINS)` returning the smallest `NICE_STEPS` member whose multiple-count `floor(maxHarmonic/S) − floor((minHarmonic−1)/S)` is ≤ `max` (returns 1 when the range already fits; returns the largest member if none fits)
+- [X] T005 In `src/utils/harmonicSampling.js` implement `sampledHarmonics(minHarmonic, maxHarmonic, max = MAX_VISIBLE_PINS)` returning `{ step, harmonics }`, generating only the in-range multiples of `step` (start at `ceil(minHarmonic/step)×step`), never allocating the full range, with a defensive length cap of `max` and `[]` when `maxHarmonic < minHarmonic`
+- [X] T006 [P] Add JSDoc typedefs for the helper's inputs/output (e.g. `SamplingResult`) in `src/utils/harmonicSampling.js` (and `src/types.js` if a shared type is warranted) so `yarn typecheck` stays clean
+- [X] T007 [P] Add a Playwright unit-style spec `tests/harmonic-sampling-unit.spec.js` that imports the pure helper directly (no browser) and asserts: count == cap → step 1 (all pins); count == cap+1 → step advances; every result is a multiple of `step`; results are within range; anchor-on-multiples is stable when the range is shifted (pan); empty range → `[]`
+- [X] T008 [P] Extend `tests/helpers/gram-frame-page.js` with helpers to (a) count `.gram-frame-harmonic-line` elements for a set and (b) read their `data-harmonic-number` values in order, for use by all story specs
 
 **Checkpoint**: Pure sampling logic exists, is unit-tested, and test helpers are ready.
 
@@ -61,15 +61,15 @@ sparse set still draws every pin.
 
 ### Implementation
 
-- [ ] T009 [US1] Rewrite `getVisibleHarmonics()` in `src/modes/harmonics/HarmonicsMode.js` to import `sampledHarmonics` (from `../../utils/harmonicSampling.js`) and `calculateVisibleDataRange` (from `../../components/table.js`), derive `{freqMin, freqMax}` from `calculateVisibleDataRange(this.instance)`, compute `minHarmonic`/`maxHarmonic`, and return `sampledHarmonics(minHarmonic, maxHarmonic).harmonics`
-- [ ] T010 [US1] Update the caller in `renderHarmonicSet()` (`src/modes/harmonics/HarmonicsMode.js` ≈L720) so it no longer passes `state.config` to `getVisibleHarmonics`; confirm labels are still created per drawn harmonic (one label per drawn line)
-- [ ] T011 [US1] Run `yarn typecheck` and fix any JSDoc/param signature fallout from the changed `getVisibleHarmonics` signature
+- [X] T009 [US1] Rewrite `getVisibleHarmonics()` in `src/modes/harmonics/HarmonicsMode.js` to import `sampledHarmonics` (from `../../utils/harmonicSampling.js`) and `calculateVisibleDataRange` (from `../../components/table.js`), derive `{freqMin, freqMax}` from `calculateVisibleDataRange(this.instance)`, compute `minHarmonic`/`maxHarmonic`, and return `sampledHarmonics(minHarmonic, maxHarmonic).harmonics`
+- [X] T010 [US1] Update the caller in `renderHarmonicSet()` (`src/modes/harmonics/HarmonicsMode.js` ≈L720) so it no longer passes `state.config` to `getVisibleHarmonics`; confirm labels are still created per drawn harmonic (one label per drawn line)
+- [X] T011 [US1] Run `yarn typecheck` and fix any JSDoc/param signature fallout from the changed `getVisibleHarmonics` signature
 
 ### Tests
 
-- [ ] T012 [P] [US1] In `tests/harmonic-pin-sampling.spec.js`, add a test: dense 0.5 Hz set over a wide span draws ≤ 50 `.gram-frame-harmonic-line` elements
-- [ ] T013 [P] [US1] In `tests/harmonic-pin-sampling.spec.js`, add a test: the drawn `data-harmonic-number`s form a constant-step arithmetic series whose step is a member of `NICE_STEPS`
-- [ ] T014 [P] [US1] In `tests/harmonic-pin-sampling.spec.js`, add a test: a sparse set (large spacing, ≤ 50 harmonics in view) draws every pin (no thinning; step 1)
+- [X] T012 [P] [US1] In `tests/harmonic-pin-sampling.spec.js`, add a test: dense 0.5 Hz set over a wide span draws ≤ 50 `.gram-frame-harmonic-line` elements
+- [X] T013 [P] [US1] In `tests/harmonic-pin-sampling.spec.js`, add a test: the drawn `data-harmonic-number`s form a constant-step arithmetic series whose step is a member of `NICE_STEPS`
+- [X] T014 [P] [US1] In `tests/harmonic-pin-sampling.spec.js`, add a test: a sparse set (large spacing, ≤ 50 harmonics in view) draws every pin (no thinning; step 1)
 
 **Checkpoint**: US1 fully functional and independently testable — this is the MVP.
 
@@ -91,13 +91,13 @@ is found in T015.
 
 ### Implementation
 
-- [ ] T015 [US2] Verify in `src/components/table.js` / `src/core/viewport.js` that `applyZoomTransform()` (both the `level === 1.0` reset branch and the zoomed branch) and `handleResize()` call `featureRenderer.renderAllPersistentFeatures()`; if any zoom/pan path does not re-render harmonic pins, add the missing re-render call
+- [X] T015 [US2] Verify in `src/components/table.js` / `src/core/viewport.js` that `applyZoomTransform()` (both the `level === 1.0` reset branch and the zoomed branch) and `handleResize()` call `featureRenderer.renderAllPersistentFeatures()`; if any zoom/pan path does not re-render harmonic pins, add the missing re-render call
 
 ### Tests
 
-- [ ] T016 [P] [US2] In `tests/harmonic-pin-sampling.spec.js`, add a test: zooming in on a dense set increases the drawn pin count (≥ pre-zoom count) while staying ≤ 50
-- [ ] T017 [P] [US2] In `tests/harmonic-pin-sampling.spec.js`, add a test: zooming in far enough that ≤ 50 harmonics remain in view shows every pin (step 1)
-- [ ] T018 [P] [US2] In `tests/harmonic-pin-sampling.spec.js`, add a test: zoom out / reset returns the overlay to the thinned (≤ 50) state; a pan at fixed zoom keeps the same step
+- [X] T016 [P] [US2] In `tests/harmonic-pin-sampling.spec.js`, add a test: zooming in on a dense set increases the drawn pin count (≥ pre-zoom count) while staying ≤ 50
+- [X] T017 [P] [US2] In `tests/harmonic-pin-sampling.spec.js`, add a test: zooming in far enough that ≤ 50 harmonics remain in view shows every pin (step 1)
+- [X] T018 [P] [US2] In `tests/harmonic-pin-sampling.spec.js`, add a test: zoom out / reset returns the overlay to the thinned (≤ 50) state; a pan at fixed zoom keeps the same step
 
 **Checkpoint**: US2 independently testable; progressive disclosure verified.
 
@@ -117,12 +117,12 @@ chiefly guard-rail coverage; add code only if T019 reveals a mismatch.
 
 ### Implementation
 
-- [ ] T019 [US3] Confirm `findHarmonicSetAtFrequency()` (`src/modes/harmonics/HarmonicsMode.js` ≈L436) still operates over the full harmonic series so a set remains selectable in sampling gaps; leave behaviour unchanged (record the optional O(1) nearest-harmonic optimisation from research §6 as out of scope)
+- [X] T019 [US3] Confirm `findHarmonicSetAtFrequency()` (`src/modes/harmonics/HarmonicsMode.js` ≈L436) still operates over the full harmonic series so a set remains selectable in sampling gaps; leave behaviour unchanged (record the optional O(1) nearest-harmonic optimisation from research §6 as out of scope)
 
 ### Tests
 
-- [ ] T020 [P] [US3] In `tests/harmonic-pin-sampling.spec.js`, add a test: on a thinned overlay every `.gram-frame-harmonic-number` label matches the `data-harmonic-number` of a rendered line (no orphan labels)
-- [ ] T021 [P] [US3] In `tests/harmonic-pin-sampling.spec.js`, add a test: on a thinned dense set, selecting the set and adjusting its spacing behaves as before (set stays selectable/draggable)
+- [X] T020 [P] [US3] In `tests/harmonic-pin-sampling.spec.js`, add a test: on a thinned overlay every `.gram-frame-harmonic-number` label matches the `data-harmonic-number` of a rendered line (no orphan labels)
+- [X] T021 [P] [US3] In `tests/harmonic-pin-sampling.spec.js`, add a test: on a thinned dense set, selecting the set and adjusting its spacing behaves as before (set stays selectable/draggable)
 
 **Checkpoint**: US3 independently testable; no interaction regression.
 
@@ -132,9 +132,9 @@ chiefly guard-rail coverage; add code only if T019 reveals a mismatch.
 
 **Purpose**: Final validation across all stories
 
-- [ ] T022 Run the full gate: `yarn typecheck`, `yarn test`, and `yarn build` — all must be clean/green (constitution Quality Gates)
-- [ ] T023 [P] Execute the manual verification steps in `specs/158-harmonic-pin-sampling/quickstart.md` against `yarn dev` (0.5 Hz dense set → thinned; zoom reveals; second sparse set unaffected; selection works)
-- [ ] T024 [P] Confirm no unrelated regressions in `tests/harmonics-mode.spec.js` and that the new specs are named/located consistently with the suite
+- [X] T022 Run the full gate: `yarn typecheck`, `yarn test`, and `yarn build` — all must be clean/green (constitution Quality Gates)
+- [X] T023 [P] Execute the manual verification steps in `specs/158-harmonic-pin-sampling/quickstart.md` against `yarn dev` (0.5 Hz dense set → thinned; zoom reveals; second sparse set unaffected; selection works)
+- [X] T024 [P] Confirm no unrelated regressions in `tests/harmonics-mode.spec.js` and that the new specs are named/located consistently with the suite
 
 ---
 

--- a/src/modes/harmonics/HarmonicsMode.js
+++ b/src/modes/harmonics/HarmonicsMode.js
@@ -6,6 +6,8 @@ import { notifyStateListeners } from '../../core/state.js'
 import { calculateZoomAwarePosition, getImageBounds } from '../../utils/coordinateTransformations.js'
 import { BaseDragHandler } from '../shared/BaseDragHandler.js'
 import { getUniformTolerance } from '../../utils/tolerance.js'
+import { sampledHarmonics } from '../../utils/harmonicSampling.js'
+import { calculateVisibleDataRange } from '../../components/table.js'
 
 /**
  * Harmonics mode implementation
@@ -626,21 +628,23 @@ export class HarmonicsMode extends BaseMode {
   }
 
   /**
-   * Get visible harmonics within frequency range
+   * Get the harmonic numbers to draw for a set within the currently visible
+   * frequency span, capped and regularly sampled so a dense set stays legible.
+   *
+   * The visible range comes from `calculateVisibleDataRange(instance)` (the same
+   * source the frequency axis uses), so pin density is viewport-aware: zooming
+   * in narrows the span and reveals more pins, zooming out / panning thins them.
+   * At zoom 1.0 the visible range equals the full data range.
+   *
    * @param {HarmonicSet} harmonicSet - Harmonic set configuration
-   * @param {Config} config - Configuration object
-   * @returns {number[]} Array of harmonic numbers to render
+   * @returns {number[]} Array of harmonic numbers to render (length <= cap)
    */
-  getVisibleHarmonics(harmonicSet, config) {
-    const { freqMin, freqMax } = config
+  getVisibleHarmonics(harmonicSet) {
+    const { freqMin, freqMax } = calculateVisibleDataRange(this.instance)
     const minHarmonic = Math.max(1, Math.ceil(freqMin / harmonicSet.spacing))
     const maxHarmonic = Math.floor(freqMax / harmonicSet.spacing)
-    
-    const harmonics = []
-    for (let h = minHarmonic; h <= maxHarmonic; h++) {
-      harmonics.push(h)
-    }
-    return harmonics
+
+    return sampledHarmonics(minHarmonic, maxHarmonic).harmonics
   }
 
   /**
@@ -717,7 +721,7 @@ export class HarmonicsMode extends BaseMode {
     }
     
     // Get visible harmonics and line dimensions
-    const visibleHarmonics = this.getVisibleHarmonics(harmonicSet, this.instance.state.config)
+    const visibleHarmonics = this.getVisibleHarmonics(harmonicSet)
     const { lineHeight, lineTop } = this.calculateHarmonicLineDimensions(harmonicSet)
     
     // Render each harmonic line in this set

--- a/src/utils/harmonicSampling.js
+++ b/src/utils/harmonicSampling.js
@@ -1,0 +1,99 @@
+/**
+ * Pure harmonic-pin sampling utilities.
+ *
+ * When a harmonic set is placed with a small spacing (e.g. 0.5 Hz) over a wide
+ * frequency span, drawing one pin per harmonic produces an illegible solid
+ * block. These helpers cap the number of pins drawn per set to a maximum and,
+ * when a set would exceed that cap, select a regularly-spaced subset (every Nth
+ * harmonic, N chosen from a "nice" step series).
+ *
+ * The module is intentionally dependency-free (no DOM, no zoom, no state) so it
+ * is trivially unit-testable in isolation. `HarmonicsMode` supplies the visible
+ * harmonic range and renders whatever these functions return.
+ *
+ * @see specs/158-harmonic-pin-sampling/contracts/sampling-algorithm.md
+ */
+
+/**
+ * Maximum number of harmonic pins drawn per set within the visible span.
+ * @type {number}
+ */
+export const MAX_VISIBLE_PINS = 50
+
+/**
+ * Ascending "nice" step series (1-2-5 progression with the 25/250/2500 members
+ * the feature explicitly calls out). A step of 1 means "show every pin".
+ * @type {number[]}
+ */
+export const NICE_STEPS = [1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000]
+
+/**
+ * @typedef {Object} SamplingResult
+ * @property {number} step - Chosen nice-series step S (1 when no thinning needed)
+ * @property {number[]} harmonics - Ascending harmonic numbers to draw (length <= max)
+ */
+
+/**
+ * Count the multiples of `step` in the inclusive range [minHarmonic, maxHarmonic].
+ * @param {number} minHarmonic - Lowest harmonic number in view (>= 1)
+ * @param {number} maxHarmonic - Highest harmonic number in view
+ * @param {number} step - Candidate step
+ * @returns {number} Number of multiples of `step` within the range
+ */
+function countMultiples(minHarmonic, maxHarmonic, step) {
+  return Math.floor(maxHarmonic / step) - Math.floor((minHarmonic - 1) / step)
+}
+
+/**
+ * Choose the smallest step from NICE_STEPS whose multiple-count in the inclusive
+ * range [minHarmonic, maxHarmonic] is <= max.
+ *
+ * - Returns 1 when the range already fits (count <= max).
+ * - Returns the largest NICE_STEPS member if none brings the count <= max
+ *   (the renderer still hard-caps the emitted length).
+ *
+ * @param {number} minHarmonic - Lowest harmonic number in view (>= 1)
+ * @param {number} maxHarmonic - Highest harmonic number in view
+ * @param {number} [max=MAX_VISIBLE_PINS] - Maximum pins allowed
+ * @returns {number} A member of NICE_STEPS
+ */
+export function chooseSamplingStep(minHarmonic, maxHarmonic, max = MAX_VISIBLE_PINS) {
+  for (const step of NICE_STEPS) {
+    if (countMultiples(minHarmonic, maxHarmonic, step) <= max) {
+      return step
+    }
+  }
+  return NICE_STEPS[NICE_STEPS.length - 1]
+}
+
+/**
+ * Compute the sampled harmonic numbers to draw for a visible harmonic range.
+ *
+ * Emits ascending harmonic numbers that are multiples of the chosen step and lie
+ * within [minHarmonic, maxHarmonic], anchored on multiples of the step (so pins
+ * stay stable while panning). Generates directly (<= max iterations) and never
+ * materialises the full range.
+ *
+ * @param {number} minHarmonic - Lowest harmonic number in view (>= 1)
+ * @param {number} maxHarmonic - Highest harmonic number in view
+ * @param {number} [max=MAX_VISIBLE_PINS] - Maximum pins allowed
+ * @returns {SamplingResult} The chosen step and the harmonic numbers to draw
+ */
+export function sampledHarmonics(minHarmonic, maxHarmonic, max = MAX_VISIBLE_PINS) {
+  if (maxHarmonic < minHarmonic) {
+    return { step: 1, harmonics: [] }
+  }
+
+  const step = chooseSamplingStep(minHarmonic, maxHarmonic, max)
+
+  // First multiple of `step` that is >= minHarmonic.
+  const first = Math.ceil(minHarmonic / step) * step
+
+  /** @type {number[]} */
+  const harmonics = []
+  for (let h = first; h <= maxHarmonic && harmonics.length < max; h += step) {
+    harmonics.push(h)
+  }
+
+  return { step, harmonics }
+}

--- a/src/utils/harmonicSampling.js
+++ b/src/utils/harmonicSampling.js
@@ -16,9 +16,11 @@
 
 /**
  * Maximum number of harmonic pins drawn per set within the visible span.
+ * Lower values force a coarser sampling step (wider pin separation), which keeps
+ * dense sets legible; raise it to show more pins.
  * @type {number}
  */
-export const MAX_VISIBLE_PINS = 50
+export const MAX_VISIBLE_PINS = 25
 
 /**
  * Ascending "nice" step series (1-2-5 progression with the 25/250/2500 members

--- a/tests/harmonic-pin-sampling.spec.js
+++ b/tests/harmonic-pin-sampling.spec.js
@@ -119,14 +119,22 @@ test.describe('Harmonic Pin Sampling (feature 158)', () => {
       const setId = await gramFramePage.addHarmonicSet(30, 0.5)
       await gramFramePage.page.waitForTimeout(100)
 
-      await gramFramePage.setZoom(8.0, 0.5, 0.5)
-      await gramFramePage.page.waitForTimeout(100)
-
-      const nums = await gramFramePage.getHarmonicNumbers(setId)
+      // Zoom in progressively until the visible span is small enough that every
+      // pin is shown (step 1). Robust to the configured cap value.
+      /** @type {number|null} */
+      let step = null
+      /** @type {number[]} */
+      let nums = []
+      for (const level of [4.0, 8.0, 16.0, 32.0]) {
+        await gramFramePage.setZoom(level, 0.5, 0.5)
+        await gramFramePage.page.waitForTimeout(100)
+        nums = await gramFramePage.getHarmonicNumbers(setId)
+        expect(nums.length).toBeLessThanOrEqual(MAX_VISIBLE_PINS)
+        step = arithmeticStep(nums)
+        if (step === 1) break
+      }
       expect(nums.length).toBeGreaterThan(0)
-      expect(nums.length).toBeLessThanOrEqual(MAX_VISIBLE_PINS)
       // Every consecutive harmonic present -> nothing thinned out
-      const step = arithmeticStep(nums)
       expect(step).toBe(1)
     })
 
@@ -135,10 +143,15 @@ test.describe('Harmonic Pin Sampling (feature 158)', () => {
       const setId = await gramFramePage.addHarmonicSet(30, 0.5)
       await gramFramePage.page.waitForTimeout(100)
 
-      // Zoom in to reveal every pin (step 1)
-      await gramFramePage.setZoom(8.0, 0.5, 0.5)
-      await gramFramePage.page.waitForTimeout(100)
-      expect(arithmeticStep(await gramFramePage.getHarmonicNumbers(setId))).toBe(1)
+      // Zoom in far enough to reveal every pin (step 1)
+      let zoomedStep = null
+      for (const level of [4.0, 8.0, 16.0, 32.0]) {
+        await gramFramePage.setZoom(level, 0.5, 0.5)
+        await gramFramePage.page.waitForTimeout(100)
+        zoomedStep = arithmeticStep(await gramFramePage.getHarmonicNumbers(setId))
+        if (zoomedStep === 1) break
+      }
+      expect(zoomedStep).toBe(1)
 
       // Reset -> thinned again, within cap, coarser step
       await gramFramePage.setZoom(1.0, 0.5, 0.5)

--- a/tests/harmonic-pin-sampling.spec.js
+++ b/tests/harmonic-pin-sampling.spec.js
@@ -1,0 +1,248 @@
+import { test, expect } from './helpers/fixtures.js'
+import { MAX_VISIBLE_PINS, NICE_STEPS } from '../src/utils/harmonicSampling.js'
+
+/**
+ * @fileoverview E2E tests for harmonic pin sampling (feature 158).
+ *
+ * The debug page config spans freq 0-100 Hz over time 0-60 s. A harmonic set
+ * with 0.5 Hz spacing would place 200 pins across that span; sampling caps the
+ * drawn pins at MAX_VISIBLE_PINS (50) and thins to a regular "nice" step. A
+ * sparse set (large spacing) is drawn in full.
+ *
+ * @see specs/158-harmonic-pin-sampling/spec.md
+ */
+
+/**
+ * Compute the constant step of an ascending arithmetic series, or null if the
+ * series is not perfectly arithmetic (or too short to have a step).
+ * @param {number[]} nums - Ascending harmonic numbers
+ * @returns {number|null} The constant step, or null
+ */
+function arithmeticStep(nums) {
+  if (nums.length < 2) return null
+  const step = nums[1] - nums[0]
+  for (let i = 1; i < nums.length; i++) {
+    if (nums[i] - nums[i - 1] !== step) return null
+  }
+  return step
+}
+
+test.describe('Harmonic Pin Sampling (feature 158)', () => {
+  test.beforeEach(async ({ gramFramePage }) => {
+    await gramFramePage.page.waitForTimeout(100)
+    await gramFramePage.clickMode('Harmonics')
+    await gramFramePage.waitForImageDimensions()
+  })
+
+  // ────────────────────────────────────────────────────────────────
+  // User Story 1 — Keep a dense harmonic set legible
+  // ────────────────────────────────────────────────────────────────
+  test.describe('US1: dense sets stay legible', () => {
+    // T012
+    test('a dense 0.5 Hz set over a wide span draws no more than the cap', async ({ gramFramePage }) => {
+      const setId = await gramFramePage.addHarmonicSet(30, 0.5)
+      await gramFramePage.page.waitForTimeout(100)
+
+      const count = await gramFramePage.getHarmonicLineCount(setId)
+      expect(count).toBeGreaterThan(0)
+      expect(count).toBeLessThanOrEqual(MAX_VISIBLE_PINS)
+    })
+
+    // T013
+    test('drawn harmonic numbers form a constant-step series from NICE_STEPS', async ({ gramFramePage }) => {
+      const setId = await gramFramePage.addHarmonicSet(30, 0.5)
+      await gramFramePage.page.waitForTimeout(100)
+
+      const nums = await gramFramePage.getHarmonicNumbers(setId)
+      // Ascending order
+      for (let i = 1; i < nums.length; i++) {
+        expect(nums[i]).toBeGreaterThan(nums[i - 1])
+      }
+      const step = arithmeticStep(nums)
+      expect(step).not.toBeNull()
+      // Dense set is thinned, so the step is a NICE_STEPS member greater than 1
+      expect(NICE_STEPS).toContain(step)
+      expect(step).toBeGreaterThan(1)
+      // Every drawn number is a multiple of the step (anchored on multiples)
+      for (const n of nums) {
+        expect(n % (/** @type {number} */ (step))).toBe(0)
+      }
+    })
+
+    // T014
+    test('a sparse set draws every pin (no thinning, step 1)', async ({ gramFramePage }) => {
+      // spacing 20 Hz over 0-100 Hz -> harmonics 1..5, well under the cap
+      const setId = await gramFramePage.addHarmonicSet(30, 20)
+      await gramFramePage.page.waitForTimeout(100)
+
+      const nums = await gramFramePage.getHarmonicNumbers(setId)
+      expect(nums).toEqual([1, 2, 3, 4, 5])
+      expect(nums.length).toBeLessThanOrEqual(MAX_VISIBLE_PINS)
+    })
+  })
+
+  // ────────────────────────────────────────────────────────────────
+  // User Story 2 — Reveal finer detail by zooming in
+  // ────────────────────────────────────────────────────────────────
+  //
+  // NOTE: FR-007 / SC-003 require that zooming in never *decreases the density*
+  // (never coarsens the sampling step) and never exceeds the cap. The absolute
+  // count of drawn pins is intentionally NOT asserted to increase monotonically:
+  // narrowing the visible span shrinks the harmonic population, so with a fixed
+  // cap the raw count can fall even as the step refines. The step (density) is
+  // the invariant the spec guarantees, so that is what we assert.
+  test.describe('US2: progressive disclosure on zoom/pan', () => {
+    // T016
+    test('zooming in yields the same or a finer step and stays within the cap', async ({ gramFramePage }) => {
+      const setId = await gramFramePage.addHarmonicSet(30, 0.5)
+      await gramFramePage.page.waitForTimeout(100)
+
+      /** @type {number|null} */
+      let prevStep = null
+      for (const level of [1.0, 2.0, 4.0, 8.0]) {
+        await gramFramePage.setZoom(level, 0.5, 0.5)
+        await gramFramePage.page.waitForTimeout(100)
+
+        const nums = await gramFramePage.getHarmonicNumbers(setId)
+        expect(nums.length).toBeLessThanOrEqual(MAX_VISIBLE_PINS)
+        const step = arithmeticStep(nums) ?? 1
+        if (prevStep !== null) {
+          // density never decreases when zooming in -> step never coarsens
+          expect(step).toBeLessThanOrEqual(prevStep)
+        }
+        prevStep = step
+      }
+    })
+
+    // T017
+    test('zooming in far enough shows every pin in view (step 1)', async ({ gramFramePage }) => {
+      const setId = await gramFramePage.addHarmonicSet(30, 0.5)
+      await gramFramePage.page.waitForTimeout(100)
+
+      await gramFramePage.setZoom(8.0, 0.5, 0.5)
+      await gramFramePage.page.waitForTimeout(100)
+
+      const nums = await gramFramePage.getHarmonicNumbers(setId)
+      expect(nums.length).toBeGreaterThan(0)
+      expect(nums.length).toBeLessThanOrEqual(MAX_VISIBLE_PINS)
+      // Every consecutive harmonic present -> nothing thinned out
+      const step = arithmeticStep(nums)
+      expect(step).toBe(1)
+    })
+
+    // T018
+    test('zoom out/reset returns to a thinned state; a pan keeps the same step', async ({ gramFramePage }) => {
+      const setId = await gramFramePage.addHarmonicSet(30, 0.5)
+      await gramFramePage.page.waitForTimeout(100)
+
+      // Zoom in to reveal every pin (step 1)
+      await gramFramePage.setZoom(8.0, 0.5, 0.5)
+      await gramFramePage.page.waitForTimeout(100)
+      expect(arithmeticStep(await gramFramePage.getHarmonicNumbers(setId))).toBe(1)
+
+      // Reset -> thinned again, within cap, coarser step
+      await gramFramePage.setZoom(1.0, 0.5, 0.5)
+      await gramFramePage.page.waitForTimeout(100)
+      const resetNums = await gramFramePage.getHarmonicNumbers(setId)
+      expect(resetNums.length).toBeLessThanOrEqual(MAX_VISIBLE_PINS)
+      const resetStep = arithmeticStep(resetNums)
+      expect(resetStep).toBeGreaterThan(1)
+
+      // Pan at a fixed zoom (with comfortable margin from the cap threshold):
+      // the step is unchanged, only which multiples are in view shifts.
+      await gramFramePage.setZoom(3.0, 0.5, 0.5)
+      await gramFramePage.page.waitForTimeout(100)
+      const before = await gramFramePage.getHarmonicNumbers(setId)
+      const stepBefore = arithmeticStep(before)
+
+      await gramFramePage.setZoom(3.0, 0.6, 0.5)
+      await gramFramePage.page.waitForTimeout(100)
+      const after = await gramFramePage.getHarmonicNumbers(setId)
+      const stepAfter = arithmeticStep(after)
+
+      expect(stepAfter).toBe(stepBefore)
+      // Panning shifted the window -> the specific pins in view changed
+      expect(after[0]).not.toBe(before[0])
+    })
+  })
+
+  // ────────────────────────────────────────────────────────────────
+  // User Story 3 — Consistent labels and interaction on shown pins
+  // ────────────────────────────────────────────────────────────────
+  test.describe('US3: label and interaction consistency', () => {
+    // T020
+    test('every label corresponds to a drawn line (no orphan labels)', async ({ gramFramePage }) => {
+      await gramFramePage.addHarmonicSet(30, 0.5)
+      await gramFramePage.page.waitForTimeout(100)
+
+      const lineNums = await gramFramePage.getHarmonicNumbers()
+      const labelNums = await gramFramePage.getHarmonicLabelNumbers()
+
+      // One label per drawn line, and each label's number is a drawn line number
+      expect(labelNums.length).toBe(lineNums.length)
+      const lineSet = new Set(lineNums)
+      for (const label of labelNums) {
+        expect(lineSet.has(label)).toBe(true)
+      }
+      expect([...labelNums].sort((a, b) => a - b)).toEqual([...lineNums].sort((a, b) => a - b))
+    })
+
+    // T021
+    test('a thinned set stays selectable in a sampling gap and adjustable', async ({ gramFramePage }) => {
+      const setId = await gramFramePage.addHarmonicSet(30, 0.5)
+      await gramFramePage.page.waitForTimeout(100)
+
+      // Confirm the overlay is genuinely thinned (a real sampling gap exists)
+      const nums = await gramFramePage.getHarmonicNumbers(setId)
+      const step = arithmeticStep(nums)
+      expect(step).toBeGreaterThan(1)
+
+      // Harmonic 7 (freq 3.5 Hz) is a real harmonic that is NOT drawn (step is a
+      // multiple > 1 anchored on multiples of the step). Hit-testing runs over
+      // the FULL series, so the set is still selectable in that gap.
+      const gapFreq = 7 * 0.5
+      const result = await gramFramePage.page.evaluate(([id, freq]) => {
+        // @ts-ignore - test-only global
+        const instance = window.GramFrame.__test__getInstances()[0]
+        const harmonics = instance.modes['harmonics']
+        // Cursor must be within the pin's vertical range (anchorTime = 30)
+        instance.state.cursorPosition = {
+          freq, time: 30, x: 0, y: 0, svgX: 0, svgY: 0, imageX: 0, imageY: 0
+        }
+        const found = harmonics.findHarmonicSetAtFrequency(freq)
+        const target = harmonics.findHarmonicSetTarget({ freq, time: 30 })
+
+        // Simulate a spacing adjustment via the drag seam (data coordinates),
+        // exactly as the event layer would drive it.
+        let spacingChanged = false
+        if (target) {
+          const original = instance.state.harmonics.harmonicSets.find((s) => s.id === id).spacing
+          harmonics.onHarmonicSetDragStart(target, { freq, time: 30 })
+          harmonics.onHarmonicSetDragUpdate(target, { freq: freq + 5, time: 30 }, { freq, time: 30 })
+          harmonics.onHarmonicSetDragEnd(target, { freq: freq + 5, time: 30 })
+          const updated = instance.state.harmonics.harmonicSets.find((s) => s.id === id).spacing
+          spacingChanged = updated !== original
+        }
+
+        return {
+          foundId: found ? found.id : null,
+          hasTarget: !!target,
+          spacingChanged
+        }
+      }, [setId, gapFreq])
+
+      // Selectable in the sampling gap
+      expect(result.foundId).toBe(setId)
+      expect(result.hasTarget).toBe(true)
+      // Adjustment took effect
+      expect(result.spacingChanged).toBe(true)
+
+      // After adjustment the overlay is still bounded and consistent
+      await gramFramePage.page.waitForTimeout(100)
+      const afterNums = await gramFramePage.getHarmonicNumbers(setId)
+      expect(afterNums.length).toBeLessThanOrEqual(MAX_VISIBLE_PINS)
+      const afterLabels = await gramFramePage.getHarmonicLabelNumbers()
+      expect(afterLabels.length).toBe(afterNums.length)
+    })
+  })
+})

--- a/tests/harmonic-pin-sampling.spec.js
+++ b/tests/harmonic-pin-sampling.spec.js
@@ -6,7 +6,7 @@ import { MAX_VISIBLE_PINS, NICE_STEPS } from '../src/utils/harmonicSampling.js'
  *
  * The debug page config spans freq 0-100 Hz over time 0-60 s. A harmonic set
  * with 0.5 Hz spacing would place 200 pins across that span; sampling caps the
- * drawn pins at MAX_VISIBLE_PINS (50) and thins to a regular "nice" step. A
+ * drawn pins at MAX_VISIBLE_PINS (25) and thins to a regular "nice" step. A
  * sparse set (large spacing) is drawn in full.
  *
  * @see specs/158-harmonic-pin-sampling/spec.md

--- a/tests/harmonic-sampling-unit.spec.js
+++ b/tests/harmonic-sampling-unit.spec.js
@@ -16,7 +16,7 @@ import {
 
 test.describe('harmonicSampling pure helper', () => {
   test('exposes the documented constants', () => {
-    expect(MAX_VISIBLE_PINS).toBe(50)
+    expect(MAX_VISIBLE_PINS).toBe(25)
     expect(NICE_STEPS).toEqual([1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000])
   })
 

--- a/tests/harmonic-sampling-unit.spec.js
+++ b/tests/harmonic-sampling-unit.spec.js
@@ -1,0 +1,99 @@
+import { test, expect } from '@playwright/test'
+import {
+  MAX_VISIBLE_PINS,
+  NICE_STEPS,
+  chooseSamplingStep,
+  sampledHarmonics
+} from '../src/utils/harmonicSampling.js'
+
+/**
+ * @fileoverview Unit-style tests for the pure harmonic sampling helper.
+ * These import the module directly and run in Node (no browser / no dev server),
+ * exercising the boundary counts, step progression, multiple-anchoring, range
+ * bounds, and pan stability described in
+ * specs/158-harmonic-pin-sampling/contracts/sampling-algorithm.md.
+ */
+
+test.describe('harmonicSampling pure helper', () => {
+  test('exposes the documented constants', () => {
+    expect(MAX_VISIBLE_PINS).toBe(50)
+    expect(NICE_STEPS).toEqual([1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000])
+  })
+
+  test('count exactly at the cap returns step 1 (all pins drawn)', () => {
+    // Range [1, 50] contains exactly 50 harmonics == cap.
+    const step = chooseSamplingStep(1, MAX_VISIBLE_PINS)
+    expect(step).toBe(1)
+
+    const { step: s, harmonics } = sampledHarmonics(1, MAX_VISIBLE_PINS)
+    expect(s).toBe(1)
+    expect(harmonics.length).toBe(MAX_VISIBLE_PINS)
+    expect(harmonics[0]).toBe(1)
+    expect(harmonics[harmonics.length - 1]).toBe(MAX_VISIBLE_PINS)
+  })
+
+  test('count one past the cap advances the step', () => {
+    // Range [1, 51] contains 51 harmonics == cap + 1 -> step must advance.
+    const step = chooseSamplingStep(1, MAX_VISIBLE_PINS + 1)
+    expect(step).toBeGreaterThan(1)
+    expect(NICE_STEPS).toContain(step)
+
+    const { harmonics } = sampledHarmonics(1, MAX_VISIBLE_PINS + 1)
+    expect(harmonics.length).toBeLessThanOrEqual(MAX_VISIBLE_PINS)
+  })
+
+  test('every drawn harmonic is a multiple of the chosen step and within range', () => {
+    const minHarmonic = 1
+    const maxHarmonic = 400 // 400 > cap -> thinning required
+    const { step, harmonics } = sampledHarmonics(minHarmonic, maxHarmonic)
+
+    expect(step).toBeGreaterThan(1)
+    expect(harmonics.length).toBeLessThanOrEqual(MAX_VISIBLE_PINS)
+    for (const h of harmonics) {
+      expect(h % step).toBe(0)
+      expect(h).toBeGreaterThanOrEqual(minHarmonic)
+      expect(h).toBeLessThanOrEqual(maxHarmonic)
+    }
+  })
+
+  test('drawn harmonics form a constant-step arithmetic series', () => {
+    const { step, harmonics } = sampledHarmonics(1, 1000)
+    expect(harmonics.length).toBeGreaterThan(1)
+    for (let i = 1; i < harmonics.length; i++) {
+      expect(harmonics[i] - harmonics[i - 1]).toBe(step)
+    }
+  })
+
+  test('anchoring on multiples is pan-stable across a shifted range', () => {
+    // Two ranges wide enough to force the same step; the retained pins in their
+    // overlap must be identical (they are anchored on multiples of the step, not
+    // on the range start), so panning does not shuffle the pins.
+    const a = sampledHarmonics(1, 500)
+    const b = sampledHarmonics(101, 600)
+    expect(a.step).toBe(b.step)
+
+    const overlapLow = 101
+    const overlapHigh = 500
+    const inOverlap = (h) => h >= overlapLow && h <= overlapHigh
+    const aOverlap = a.harmonics.filter(inOverlap)
+    const bOverlap = b.harmonics.filter(inOverlap)
+    expect(aOverlap).toEqual(bOverlap)
+  })
+
+  test('empty range returns no harmonics', () => {
+    const { harmonics } = sampledHarmonics(5, 4)
+    expect(harmonics).toEqual([])
+  })
+
+  test('a sparse range under the cap draws every harmonic (no thinning)', () => {
+    // [3, 12] -> 10 harmonics, well under the cap.
+    const { step, harmonics } = sampledHarmonics(3, 12)
+    expect(step).toBe(1)
+    expect(harmonics).toEqual([3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+  })
+
+  test('length never exceeds the cap even for an enormous range', () => {
+    const { harmonics } = sampledHarmonics(1, 1_000_000)
+    expect(harmonics.length).toBeLessThanOrEqual(MAX_VISIBLE_PINS)
+  })
+})

--- a/tests/helpers/gram-frame-page.js
+++ b/tests/helpers/gram-frame-page.js
@@ -450,6 +450,81 @@ class GramFramePage {
       return keys
     }, storageType)
   }
+
+  /**
+   * Build a CSS selector for harmonic lines, optionally scoped to one set.
+   * @param {string} [setId] - Restrict to a single harmonic set's lines
+   * @returns {string} Selector string
+   */
+  harmonicLineSelector(setId) {
+    return setId
+      ? `.gram-frame-harmonic-line[data-harmonic-set-id="${setId}"]`
+      : '.gram-frame-harmonic-line'
+  }
+
+  /**
+   * Count the rendered harmonic pin lines, optionally for a single set.
+   * @param {string} [setId] - Restrict the count to one harmonic set
+   * @returns {Promise<number>} Number of `.gram-frame-harmonic-line` elements
+   */
+  async getHarmonicLineCount(setId) {
+    return this.page.locator(this.harmonicLineSelector(setId)).count()
+  }
+
+  /**
+   * Read the `data-harmonic-number` of each rendered harmonic line, in document
+   * order, optionally for a single set.
+   * @param {string} [setId] - Restrict to one harmonic set
+   * @returns {Promise<number[]>} Harmonic numbers in order
+   */
+  async getHarmonicNumbers(setId) {
+    return this.page.evaluate((selector) => {
+      const lines = Array.from(document.querySelectorAll(selector))
+      return lines.map((line) => Number(line.getAttribute('data-harmonic-number')))
+    }, this.harmonicLineSelector(setId))
+  }
+
+  /**
+   * Read the numeric text of every harmonic number label currently rendered.
+   * @returns {Promise<number[]>} Label numbers in document order
+   */
+  async getHarmonicLabelNumbers() {
+    return this.page.evaluate(() => {
+      const labels = Array.from(document.querySelectorAll('.gram-frame-harmonic-number'))
+      return labels.map((label) => Number(label.textContent))
+    })
+  }
+
+  /**
+   * Programmatically add a harmonic set via the test instance API.
+   * @param {number} anchorTime - Time position in seconds
+   * @param {number} spacing - Frequency spacing in Hz
+   * @returns {Promise<string>} The created harmonic set's id
+   */
+  async addHarmonicSet(anchorTime, spacing) {
+    return this.page.evaluate(([time, space]) => {
+      // @ts-ignore - test-only global
+      const instances = window.GramFrame.__test__getInstances()
+      const instance = instances[0]
+      const set = instance.modes['harmonics'].addHarmonicSet(time, space)
+      return set.id
+    }, [anchorTime, spacing])
+  }
+
+  /**
+   * Programmatically set the zoom level/centre via the test instance API.
+   * @param {number} level - Zoom level (1.0 = no zoom)
+   * @param {number} [centerX=0.5] - Normalised horizontal centre (0-1)
+   * @param {number} [centerY=0.5] - Normalised vertical centre (0-1)
+   * @returns {Promise<void>}
+   */
+  async setZoom(level, centerX = 0.5, centerY = 0.5) {
+    await this.page.evaluate(([lvl, cx, cy]) => {
+      // @ts-ignore - test-only global
+      const instances = window.GramFrame.__test__getInstances()
+      instances[0]._setZoom(lvl, cx, cy)
+    }, [level, centerX, centerY])
+  }
 }
 
 export { GramFramePage }


### PR DESCRIPTION
## Summary

Closes the core of #183. A harmonic set placed with a small spacing (e.g. **0.5 Hz**) over a wide frequency span previously drew **one pin per harmonic with no cap**, producing an illegible solid block of overlapping lines and number labels.

Pin generation is now **viewport-aware and sampled**: at most `MAX_VISIBLE_PINS` (**25**) pins are drawn per set within the *currently visible* span, and a set that would exceed the cap is thinned to a regularly-spaced subset (every Nth harmonic, N from a &#34;nice&#34; step series `1, 2, 5, 10, 25, 50, 100, 250, …`).

> Note: the cap was lowered from an initial **50** to **25** after review to widen pin separation and improve legibility. It remains a single named constant (`MAX_VISIBLE_PINS`).

## Changes

- **New** `src/utils/harmonicSampling.js` — a pure, dependency-free module:
  - `chooseSamplingStep(min, max, cap)` returns the smallest `NICE_STEPS` member whose in-range multiple-count fits the cap.
  - `sampledHarmonics(min, max, cap)` emits only the in-range multiples of that step (anchored on multiples of the step so pins stay stable while panning), never materialising the full range, with a defensive length cap.
  - Exports `MAX_VISIBLE_PINS = 25` and `NICE_STEPS`.
- **Edit** `src/modes/harmonics/HarmonicsMode.js` — `getVisibleHarmonics()` now derives `{freqMin, freqMax}` from `calculateVisibleDataRange(instance)` (the same source the frequency axis uses) instead of the full `state.config` range, and returns `sampledHarmonics(...).harmonics`. Its one caller no longer passes `state.config`.
- Re-rendering on zoom/pan/reset/resize already flows through `FeatureRenderer.renderAllPersistentFeatures()`, so **no new event wiring** was needed (verified). Hit-testing (`findHarmonicSetAtFrequency`) is intentionally left over the **full** harmonic series, so a set stays selectable in sampling gaps and selection/adjustment behave exactly as before.

**No state, persistence, or `gram-config` changes** — the feature is purely presentational and recomputed on each render.

## Tests

- **`tests/harmonic-sampling-unit.spec.js`** — unit-style coverage of the pure helper (boundary counts at cap / cap+1, step progression, multiples-of-step, in-range, pan-stability under a shifted range, empty range, sparse pass-through, hard cap).
- **`tests/harmonic-pin-sampling.spec.js`** — Playwright E2E across the three user stories:
  - **US1**: dense 0.5 Hz set draws ≤ 25 lines; drawn `data-harmonic-number`s form a constant-step `NICE_STEPS` series; a sparse set draws every pin (step 1).
  - **US2**: zooming in yields a same-or-finer step and stays ≤ 25; zoom in far → step 1 (every pin in view); zoom out/reset returns to a thinned state; a pan at fixed zoom keeps the same step.
  - **US3**: every label corresponds to a drawn line (no orphans); a thinned set stays selectable in a sampling gap and remains adjustable.
- New `GramFramePage` helpers to count/read `.gram-frame-harmonic-line` numbers, read label numbers, and drive `addHarmonicSet` / `setZoom` programmatically.

### Note on US2 assertions (count vs. density)

FR-007 / SC-003 require that zooming in never **coarsens the sampling step** (density never decreases) and never exceeds the cap. The absolute *count* of drawn pins is intentionally **not** asserted to increase monotonically: narrowing the visible span shrinks the harmonic population, so with a fixed cap the raw count can fall even as the step refines (empirically the count fluctuates while the step is monotone non-increasing). The **step (density)** is the invariant the spec actually guarantees, so that is what the US2 tests assert.

## Verification

- `yarn typecheck` — clean
- `yarn build` — clean
- `yarn test` — full suite green (141 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvpN7BEuGamZeR5FNtZXdp)_