### PR TITLE
feat(harmonics): symbols on harmonic pins (#185)

### DIFF
--- a/specs/157-harmonic-pin-symbols/tasks.md
+++ b/specs/157-harmonic-pin-symbols/tasks.md
@@ -28,7 +28,7 @@ Single-project front-end component: `src/` and `tests/` at repository root
 **Purpose**: No project initialization needed (existing repo, zero runtime
 deps). Establish the shared type vocabulary the whole feature uses.
 
-- [ ] T001 Add `SymbolType` JSDoc typedef (`'circle'|'square'|'diamond'|'triangle'|'triangle-down'|'star'`) in `src/types.js`, and extend `HarmonicSet` with `symbol: SymbolType`, `StoredHarmonicSet` with optional `symbol?: SymbolType`, and the `GramFrameState` typedef with `selectedSymbol: SymbolType` (see contracts/state-shape.md)
+- [X] T001 Add `SymbolType` JSDoc typedef (`'circle'|'square'|'diamond'|'triangle'|'triangle-down'|'star'`) in `src/types.js`, and extend `HarmonicSet` with `symbol: SymbolType`, `StoredHarmonicSet` with optional `symbol?: SymbolType`, and the `GramFrameState` typedef with `selectedSymbol: SymbolType` (see contracts/state-shape.md)
 
 **Checkpoint**: Types compile — `yarn typecheck` still clean.
 
@@ -41,8 +41,8 @@ selected-symbol state and the shared SVG mark factory.
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete.
 
-- [ ] T002 Add `selectedSymbol: 'circle'` default to the initial state in `src/core/state.js` (mirrors `selectedColor`)
-- [ ] T003 [P] Create shared pure SVG mark factory `src/rendering/symbols.js` exporting `createSymbolMark(symbolType, cx, cy, size, color) → SVGElement` for all catalogue shapes (circle, square, diamond, triangle, triangle-down, star), defaulting unknown/absent values to `circle`, with class `gram-frame-harmonic-symbol` and `fill = color` (see contracts/symbol-catalog.md)
+- [X] T002 Add `selectedSymbol: 'circle'` default to the initial state in `src/core/state.js` (mirrors `selectedColor`)
+- [X] T003 [P] Create shared pure SVG mark factory `src/rendering/symbols.js` exporting `createSymbolMark(symbolType, cx, cy, size, color) → SVGElement` for all catalogue shapes (circle, square, diamond, triangle, triangle-down, star), defaulting unknown/absent values to `circle`, with class `gram-frame-harmonic-symbol` and `fill = color` (see contracts/symbol-catalog.md)
 
 **Checkpoint**: Factory returns a correct detached SVG element for every symbol
 id; state exposes `selectedSymbol`.
@@ -62,19 +62,19 @@ harmonics-table row; verify the pin label is not obscured.
 
 ### Tests for User Story 1 ⚠️ (write first, ensure they fail before implementation)
 
-- [ ] T004 [P] [US1] Add Playwright test: symbol drop-down is present in the control panel and offers circle/square/diamond (plus the additional shapes) in `tests/harmonic-symbols.spec.js`
-- [ ] T005 [P] [US1] Add Playwright test: selecting a symbol + colour then creating a harmonic set by click/drag renders a filled symbol of that shape and colour at the top of each pin, and the pin-number label remains readable (right of the line) in `tests/harmonic-symbols.spec.js`
-- [ ] T006 [P] [US1] Add Playwright test: creating a harmonic set via the manual add dialog uses the currently selected symbol in `tests/harmonic-symbols.spec.js`
-- [ ] T007 [P] [US1] Add Playwright test: each harmonics-table row shows the set's symbol rendered in the set's colour in `tests/harmonic-symbols.spec.js`
+- [X] T004 [P] [US1] Add Playwright test: symbol drop-down is present in the control panel and offers circle/square/diamond (plus the additional shapes) in `tests/harmonic-symbols.spec.js`
+- [X] T005 [P] [US1] Add Playwright test: selecting a symbol + colour then creating a harmonic set by click/drag renders a filled symbol of that shape and colour at the top of each pin, and the pin-number label remains readable (right of the line) in `tests/harmonic-symbols.spec.js`
+- [X] T006 [P] [US1] Add Playwright test: creating a harmonic set via the manual add dialog uses the currently selected symbol in `tests/harmonic-symbols.spec.js`
+- [X] T007 [P] [US1] Add Playwright test: each harmonics-table row shows the set's symbol rendered in the set's colour in `tests/harmonic-symbols.spec.js`
 
 ### Implementation for User Story 1
 
-- [ ] T008 [P] [US1] Create `src/components/SymbolPicker.js` exporting `createSymbolPicker(state)` — a native `<select>` drop-down listing the catalogue shapes (optionally with inline-SVG previews) that writes the chosen value to `state.selectedSymbol` (follow the `src/components/ColorPicker.js` pattern)
-- [ ] T009 [US1] Re-export `createSymbolPicker` from `src/components/UIComponents.js` (mirrors the `createColorPicker` re-export)
-- [ ] T010 [US1] Mount the symbol picker in the controls column immediately after the colour picker in `src/components/MainUI.js`, label it "Symbol", and store `instance.symbolPicker` reference
-- [ ] T011 [US1] In `HarmonicsMode.addHarmonicSet` (`src/modes/harmonics/HarmonicsMode.js`), assign `symbol = this.instance.state.selectedSymbol || 'circle'` and include `symbol` in the created `harmonicSet` object (covers both click/drag and manual-add, which call this function)
-- [ ] T012 [US1] In `HarmonicsMode.renderHarmonicSet` (`src/modes/harmonics/HarmonicsMode.js`), draw the set's symbol via `createSymbolMark` at the top of each pin (centred on `lineX`, at/just above `lineTop`), filled with `harmonicSet.color`, appended to `cursorGroup` with `data-harmonic-set-id`; nudge downward if it would clip the top edge; ensure `renderPersistentFeatures` clears prior symbol marks alongside the harmonic lines
-- [ ] T013 [US1] In `src/components/HarmonicPanel.js`, render the set's symbol as an inline SVG mark (from `createSymbolMark`) filled with the set's colour in the row's colour cell, for both `createHarmonicRow` and the row-update path
+- [X] T008 [P] [US1] Create `src/components/SymbolPicker.js` exporting `createSymbolPicker(state)` — a native `<select>` drop-down listing the catalogue shapes (optionally with inline-SVG previews) that writes the chosen value to `state.selectedSymbol` (follow the `src/components/ColorPicker.js` pattern)
+- [X] T009 [US1] Re-export `createSymbolPicker` from `src/components/UIComponents.js` (mirrors the `createColorPicker` re-export)
+- [X] T010 [US1] Mount the symbol picker in the controls column immediately after the colour picker in `src/components/MainUI.js`, label it "Symbol", and store `instance.symbolPicker` reference
+- [X] T011 [US1] In `HarmonicsMode.addHarmonicSet` (`src/modes/harmonics/HarmonicsMode.js`), assign `symbol = this.instance.state.selectedSymbol || 'circle'` and include `symbol` in the created `harmonicSet` object (covers both click/drag and manual-add, which call this function)
+- [X] T012 [US1] In `HarmonicsMode.renderHarmonicSet` (`src/modes/harmonics/HarmonicsMode.js`), draw the set's symbol via `createSymbolMark` at the top of each pin (centred on `lineX`, at/just above `lineTop`), filled with `harmonicSet.color`, appended to `cursorGroup` with `data-harmonic-set-id`; nudge downward if it would clip the top edge; ensure `renderPersistentFeatures` clears prior symbol marks alongside the harmonic lines
+- [X] T013 [US1] In `src/components/HarmonicPanel.js`, render the set's symbol as an inline SVG mark (from `createSymbolMark`) filled with the set's colour in the row's colour cell, for both `createHarmonicRow` and the row-update path
 
 **Checkpoint**: US1 fully functional — symbol selectable, drawn on pins and in
 the table, label unobstructed. MVP deliverable.
@@ -93,12 +93,12 @@ field with **no** `SCHEMA_VERSION` bump (see contracts/persistence-schema.md).
 
 ### Tests for User Story 2 ⚠️
 
-- [ ] T014 [P] [US2] Add Playwright test: create harmonic sets with different symbols, trigger save, reload the instance, and assert each set's symbol (on pins and in the table) is preserved in `tests/harmonic-symbols.spec.js`
+- [X] T014 [P] [US2] Add Playwright test: create harmonic sets with different symbols, trigger save, reload the instance, and assert each set's symbol (on pins and in the table) is preserved in `tests/harmonic-symbols.spec.js`
 
 ### Implementation for User Story 2
 
-- [ ] T015 [US2] In `saveAnnotations` (`src/core/storage.js`), include `symbol: hs.symbol || 'circle'` in the persisted harmonic-set mapping; keep `SCHEMA_VERSION = 1` (additive field, no bump)
-- [ ] T016 [US2] In `_restoreAnnotations` (`src/main.js`), map restored harmonic sets to carry their persisted `symbol` (preserving explicit values)
+- [X] T015 [US2] In `saveAnnotations` (`src/core/storage.js`), include `symbol: hs.symbol || 'circle'` in the persisted harmonic-set mapping; keep `SCHEMA_VERSION = 1` (additive field, no bump)
+- [X] T016 [US2] In `_restoreAnnotations` (`src/main.js`), map restored harmonic sets to carry their persisted `symbol` (preserving explicit values)
 
 **Checkpoint**: US1 + US2 work — symbols persist across reload.
 
@@ -119,12 +119,12 @@ means the version MUST stay `1` so legacy data is not discarded.
 
 ### Tests for User Story 3 ⚠️
 
-- [ ] T017 [P] [US3] Add Playwright test: seed storage with a legacy `version: 1` annotations blob whose harmonic sets have no `symbol`, reload, and assert every pin and table swatch renders `circle` with no console error in `tests/harmonic-symbols.spec.js`
+- [X] T017 [P] [US3] Add Playwright test: seed storage with a legacy `version: 1` annotations blob whose harmonic sets have no `symbol`, reload, and assert every pin and table swatch renders `circle` with no console error in `tests/harmonic-symbols.spec.js`
 
 ### Implementation for User Story 3
 
-- [ ] T018 [US3] In `_restoreAnnotations` (`src/main.js`), apply `symbol: hs.symbol || 'circle'` when mapping restored harmonic sets so legacy sets default to circle (extends the T016 mapping)
-- [ ] T019 [US3] Verify `loadAnnotations`/`SCHEMA_VERSION` remain unchanged so legacy v1 blobs are not discarded; add an inline note in `src/core/storage.js` documenting that `symbol` is additive and must not trigger a version bump
+- [X] T018 [US3] In `_restoreAnnotations` (`src/main.js`), apply `symbol: hs.symbol || 'circle'` when mapping restored harmonic sets so legacy sets default to circle (extends the T016 mapping)
+- [X] T019 [US3] Verify `loadAnnotations`/`SCHEMA_VERSION` remain unchanged so legacy v1 blobs are not discarded; add an inline note in `src/core/storage.js` documenting that `symbol` is additive and must not trigger a version bump
 
 **Checkpoint**: All three stories work — new symbols, persistence, and legacy
 fallback.
@@ -135,12 +135,12 @@ fallback.
 
 **Purpose**: Styling, helpers, and quality gates.
 
-- [ ] T020 [P] Add any needed CSS for the symbol picker and table swatch alignment in `src/gramframe.css` (match colour-picker/lozenge styling)
-- [ ] T021 [P] Add `GramFramePage` helper methods for symbol assertions (e.g. read a pin's symbol shape/fill and a table row's swatch) in `tests/helpers/`
-- [ ] T022 Run `yarn typecheck` — resolve all JSDoc type errors
-- [ ] T023 Run `yarn test` — all Playwright tests green (including `tests/harmonic-symbols.spec.js`)
-- [ ] T024 Run `yarn build` — clean production build
-- [ ] T025 [P] Verify the manual walkthrough in `specs/157-harmonic-pin-symbols/quickstart.md` matches actual behavior (selector, pins, table, reload, legacy)
+- [X] T020 [P] Add any needed CSS for the symbol picker and table swatch alignment in `src/gramframe.css` (match colour-picker/lozenge styling)
+- [X] T021 [P] Add `GramFramePage` helper methods for symbol assertions (e.g. read a pin's symbol shape/fill and a table row's swatch) in `tests/helpers/`
+- [X] T022 Run `yarn typecheck` — resolve all JSDoc type errors
+- [X] T023 Run `yarn test` — all Playwright tests green (including `tests/harmonic-symbols.spec.js`)
+- [X] T024 Run `yarn build` — clean production build
+- [X] T025 [P] Verify the manual walkthrough in `specs/157-harmonic-pin-symbols/quickstart.md` matches actual behavior (selector, pins, table, reload, legacy)
 
 ---
 

--- a/src/components/HarmonicPanel.js
+++ b/src/components/HarmonicPanel.js
@@ -4,6 +4,26 @@
 
 /// <reference path="../types.js" />
 
+import { createSymbolMark } from '../rendering/symbols.js'
+
+/**
+ * Build a small inline SVG swatch showing a harmonic set's symbol in its colour.
+ * Used in the harmonics-table colour cell as a colour-blind-friendly affordance.
+ * @param {HarmonicSet} harmonicSet - The harmonic set data
+ * @returns {SVGSVGElement} The swatch SVG element
+ */
+function createSymbolSwatch(harmonicSet) {
+  const swSize = 16
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+  svg.setAttribute('class', 'gram-frame-harmonic-symbol-swatch')
+  svg.setAttribute('width', String(swSize))
+  svg.setAttribute('height', String(swSize))
+  svg.setAttribute('viewBox', `0 0 ${swSize} ${swSize}`)
+  const mark = createSymbolMark(harmonicSet.symbol, swSize / 2, swSize / 2, 12, harmonicSet.color)
+  svg.appendChild(mark)
+  return svg
+}
+
 /**
  * Create harmonic management panel
  * @param {HTMLElement} container - Container element to append the panel to
@@ -76,6 +96,14 @@ export function updateHarmonicPanelContent(panel, instance) {
  * @param {GramFrame} instance - GramFrame instance
  */
 function updateHarmonicRow(row, harmonicSet, instance) {
+  // Update the colour/symbol swatch in case colour or symbol changed
+  const colorCell = row.cells[0]
+  const colorDiv = colorCell && /** @type {HTMLElement} */ (colorCell.querySelector('.gram-frame-harmonic-color'))
+  if (colorDiv) {
+    colorDiv.style.color = harmonicSet.color
+    colorDiv.replaceChildren(createSymbolSwatch(harmonicSet))
+  }
+
   // Update spacing cell if changed
   const spacingCell = row.cells[1]
   if (spacingCell) {
@@ -138,11 +166,12 @@ function createHarmonicRow(harmonicSet, instance, index) {
   row.setAttribute('data-harmonic-id', harmonicSet.id)
   row.className = 'gram-frame-harmonic-row'
   
-  // Color cell
+  // Color/symbol cell — the set's symbol rendered in the set's colour
   const colorCell = document.createElement('td')
   const colorDiv = document.createElement('div')
   colorDiv.className = 'gram-frame-harmonic-color'
-  colorDiv.style.backgroundColor = harmonicSet.color
+  colorDiv.style.color = harmonicSet.color
+  colorDiv.appendChild(createSymbolSwatch(harmonicSet))
   colorCell.appendChild(colorDiv)
   row.appendChild(colorCell)
   

--- a/src/components/MainUI.js
+++ b/src/components/MainUI.js
@@ -7,11 +7,12 @@
 
 /// <reference path="../types.js" />
 
-import { 
-  createLEDDisplay, 
-  createColorPicker, 
-  createFullFlexLayout, 
-  createFlexColumn 
+import {
+  createLEDDisplay,
+  createColorPicker,
+  createSymbolPicker,
+  createFullFlexLayout,
+  createFlexColumn
 } from './UIComponents.js'
 import { formatTime } from '../utils/timeFormatter.js'
 
@@ -67,7 +68,11 @@ export function createUnifiedLayout(instance) {
   const colorPicker = createColorPicker(instance.state)
   colorPicker.querySelector('.gram-frame-color-picker-label').textContent = 'Color'
   controlsColumn.appendChild(colorPicker)
-  
+
+  // Create symbol picker immediately after the colour picker
+  const symbolPicker = createSymbolPicker(instance.state)
+  controlsColumn.appendChild(symbolPicker)
+
   // Add columns to left panel
   leftColumn.appendChild(modeColumn)
   leftColumn.appendChild(guidanceColumn)
@@ -111,7 +116,8 @@ export function createUnifiedLayout(instance) {
   instance.freqLED = freqLED
   instance.speedLED = speedLED
   instance.colorPicker = colorPicker
-  
+  instance.symbolPicker = symbolPicker
+
   return unifiedLayoutContainer
 }
 

--- a/src/components/SymbolPicker.js
+++ b/src/components/SymbolPicker.js
@@ -1,0 +1,69 @@
+/**
+ * Symbol Picker Component for GramFrame
+ *
+ * Provides symbol selection for harmonic overlays as a native drop-down list,
+ * mirroring the ColorPicker pattern. The chosen symbol is written to
+ * `state.selectedSymbol` and applied to the next created harmonic set.
+ */
+
+/// <reference path="../types.js" />
+
+import { SYMBOL_CATALOG, SYMBOL_DISPLAY_NAMES } from '../rendering/symbols.js'
+
+/**
+ * Unicode glyph previews shown alongside each option name in the drop-down, so
+ * the shape is recognisable without rendering inline SVG inside <option>.
+ * @type {Record<SymbolType, string>}
+ */
+const SYMBOL_GLYPHS = {
+  'circle': '●',
+  'square': '■',
+  'diamond': '◆',
+  'triangle': '▲',
+  'triangle-down': '▼',
+  'star': '★'
+}
+
+/**
+ * Create a symbol picker component for harmonic selection.
+ * @param {GramFrameState} state - Current state object
+ * @returns {HTMLDivElement} The symbol picker element
+ */
+export function createSymbolPicker(state) {
+  const container = document.createElement('div')
+  container.className = 'gram-frame-symbol-picker'
+  container.style.display = 'block'
+
+  // Label
+  const label = document.createElement('div')
+  label.className = 'gram-frame-symbol-picker-label'
+  label.textContent = 'Symbol'
+  container.appendChild(label)
+
+  // Initialise default symbol if unset
+  if (!state.selectedSymbol) {
+    state.selectedSymbol = 'circle'
+  }
+
+  // Native drop-down of catalogue shapes
+  const select = document.createElement('select')
+  select.className = 'gram-frame-symbol-select'
+
+  SYMBOL_CATALOG.forEach(symbolId => {
+    const option = document.createElement('option')
+    option.value = symbolId
+    option.textContent = `${SYMBOL_GLYPHS[symbolId]}  ${SYMBOL_DISPLAY_NAMES[symbolId]}`
+    if (symbolId === state.selectedSymbol) {
+      option.selected = true
+    }
+    select.appendChild(option)
+  })
+
+  select.addEventListener('change', () => {
+    state.selectedSymbol = /** @type {SymbolType} */ (select.value)
+  })
+
+  container.appendChild(select)
+
+  return container
+}

--- a/src/components/UIComponents.js
+++ b/src/components/UIComponents.js
@@ -8,6 +8,7 @@
 /// <reference path="../types.js" />
 
 import { createColorPicker } from './ColorPicker.js'
+import { createSymbolPicker } from './SymbolPicker.js'
 import { createLEDDisplay, updateLEDDisplays } from './LEDDisplay.js'
 import { createModeSwitchingUI } from './ModeButtons.js'
 
@@ -25,6 +26,9 @@ export { createModeSwitchingUI }
 
 // Re-export color picker function from ColorPicker module
 export { createColorPicker }
+
+// Re-export symbol picker function from SymbolPicker module
+export { createSymbolPicker }
 
 
 /**

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -42,6 +42,7 @@ export const initialState = {
   previousMode: null, // Previous mode for switching back
   rate: 1,
   selectedColor: '#ff6b6b', // Currently selected color for new features across all modes
+  selectedSymbol: 'circle', // Currently selected symbol applied to the next created harmonic set (mirrors selectedColor)
   cursorPosition: null,
   cursors: [],
   imageDetails: {

--- a/src/core/storage.js
+++ b/src/core/storage.js
@@ -181,7 +181,12 @@ export function saveAnnotations(state, instanceIndex) {
           id: hs.id,
           color: hs.color,
           anchorTime: hs.anchorTime,
-          spacing: hs.spacing
+          spacing: hs.spacing,
+          // `symbol` is an ADDITIVE field (feature 157-harmonic-pin-symbols). It
+          // MUST NOT trigger a SCHEMA_VERSION bump: the strict version guard in
+          // loadAnnotations would otherwise discard all pre-existing v1 records.
+          // Legacy records simply lack this key and default to 'circle' on restore.
+          symbol: hs.symbol || 'circle'
         }))
       },
       doppler: {

--- a/src/gramframe.css
+++ b/src/gramframe.css
@@ -334,6 +334,41 @@
   position: relative;
 }
 
+.gram-frame-symbol-picker {
+  margin-top: 6px;
+  padding: 8px;
+  background: linear-gradient(135deg, #1a1a1a 0%, #000 50%, #0a0a0a 100%);
+  border: 2px solid #333;
+  border-radius: 4px;
+  box-shadow:
+    inset 0 2px 6px rgba(0,0,0,0.8),
+    inset 0 -1px 2px rgba(255,255,255,0.05),
+    0 2px 4px rgba(0,0,0,0.5);
+  max-width: 200px;
+  flex-shrink: 0;
+}
+
+.gram-frame-symbol-picker-label {
+  font-size: 10px;
+  color: #00ff00;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-weight: bold;
+  text-align: center;
+}
+
+.gram-frame-symbol-select {
+  width: 100%;
+  padding: 4px;
+  background: #0a0a0a;
+  color: #00ff00;
+  border: 1px solid #555;
+  border-radius: 2px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
 .gram-frame-color-canvas {
   width: 140px;
   max-width: 140px;
@@ -810,11 +845,15 @@
 }
 
 .gram-frame-harmonic-color {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 20px;
-  height: 12px;
-  border: 1px solid #555;
-  border-radius: 2px;
-  display: inline-block;
+  height: 16px;
+}
+
+.gram-frame-harmonic-symbol-swatch {
+  display: block;
 }
 
 .gram-frame-harmonic-delete {

--- a/src/main.js
+++ b/src/main.js
@@ -329,9 +329,13 @@ export class GramFrame {
       this.state.analysis.markers = saved.analysis.markers
     }
 
-    // Merge harmonic sets
+    // Merge harmonic sets. Legacy records (persisted before feature
+    // 157-harmonic-pin-symbols) have no `symbol`; default those to 'circle'.
     if (saved.harmonics && Array.isArray(saved.harmonics.harmonicSets)) {
-      this.state.harmonics.harmonicSets = saved.harmonics.harmonicSets
+      this.state.harmonics.harmonicSets = saved.harmonics.harmonicSets.map(hs => ({
+        ...hs,
+        symbol: hs.symbol || 'circle'
+      }))
     }
 
     // Merge doppler state

--- a/src/modes/harmonics/HarmonicsMode.js
+++ b/src/modes/harmonics/HarmonicsMode.js
@@ -7,6 +7,7 @@ import { calculateZoomAwarePosition, getImageBounds } from '../../utils/coordina
 import { BaseDragHandler } from '../shared/BaseDragHandler.js'
 import { getUniformTolerance } from '../../utils/tolerance.js'
 import { sampledHarmonics } from '../../utils/harmonicSampling.js'
+import { createSymbolMark } from '../../rendering/symbols.js'
 import { calculateVisibleDataRange } from '../../components/table.js'
 
 /**
@@ -336,12 +337,16 @@ export class HarmonicsMode extends BaseMode {
       color = HarmonicsMode.harmonicColors[colorIndex]
     }
     
+    // Use selected symbol from global state, defaulting to circle
+    const symbol = this.instance.state.selectedSymbol || 'circle'
+
     /** @type {HarmonicSet} */
     const harmonicSet = {
       id,
       color,
       anchorTime,
-      spacing
+      spacing,
+      symbol
     }
     
     this.instance.state.harmonics.harmonicSets.push(harmonicSet)
@@ -617,9 +622,11 @@ export class HarmonicsMode extends BaseMode {
       return
     }
     
-    // Clear existing harmonic lines
+    // Clear existing harmonic lines and their symbol marks
     const existingHarmonics = this.instance.cursorGroup.querySelectorAll('.gram-frame-harmonic-line')
     existingHarmonics.forEach(line => line.remove())
+    const existingSymbols = this.instance.cursorGroup.querySelectorAll('.gram-frame-harmonic-symbol')
+    existingSymbols.forEach(symbol => symbol.remove())
     
     // Render all harmonic sets
     this.instance.state.harmonics.harmonicSets.forEach(harmonicSet => {
@@ -712,6 +719,34 @@ export class HarmonicsMode extends BaseMode {
   }
 
   /**
+   * Create the filled symbol mark drawn at the top of a pin.
+   *
+   * Centred horizontally on the pin line and placed just above the line's top
+   * endpoint so it caps the pin without obscuring the number label (which is
+   * drawn to the right of, and below, the line top). Nudged downward if it would
+   * otherwise clip the top edge of the spectrogram image.
+   *
+   * @param {HarmonicSet} harmonicSet - Harmonic set configuration
+   * @param {number} lineX - X position of the pin line
+   * @param {number} lineTop - Top Y position of the pin line
+   * @param {number} imageTop - Top edge of the spectrogram image in SVG coords
+   * @returns {SVGElement} SVG symbol element
+   */
+  createHarmonicSymbol(harmonicSet, lineX, lineTop, imageTop) {
+    const size = 10
+    const r = size / 2
+    // Cap the pin: sit the symbol just above the line's top endpoint.
+    let cy = lineTop - r
+    // Nudge downward if the symbol would clip the top edge of the image.
+    if (cy - r < imageTop) {
+      cy = imageTop + r
+    }
+    const symbol = createSymbolMark(harmonicSet.symbol, lineX, cy, size, harmonicSet.color)
+    symbol.setAttribute('data-harmonic-set-id', harmonicSet.id)
+    return symbol
+  }
+
+  /**
    * Render a single harmonic set as vertical lines
    * @param {HarmonicSet} harmonicSet - Harmonic set to render
    */
@@ -719,26 +754,29 @@ export class HarmonicsMode extends BaseMode {
     if (!this.instance.cursorGroup) {
       return
     }
-    
+
     // Get visible harmonics and line dimensions
     const visibleHarmonics = this.getVisibleHarmonics(harmonicSet)
     const { lineHeight, lineTop } = this.calculateHarmonicLineDimensions(harmonicSet)
-    
+    const imageTop = getImageBounds(this.getViewport(), this.instance.spectrogramImage).top
+
     // Render each harmonic line in this set
     visibleHarmonics.forEach(harmonicNumber => {
       const harmonicFreq = harmonicNumber * harmonicSet.spacing
-      
+
       // Calculate X position using coordinate transformation utility
       const harmonicPoint = { freq: harmonicFreq, time: harmonicSet.anchorTime }
       const harmonicSVG = calculateZoomAwarePosition(harmonicPoint, this.getViewport(), this.instance.spectrogramImage)
       const lineX = harmonicSVG.x
-      
-      // Create and append line and label elements
+
+      // Create and append line, label, and symbol elements
       const line = this.createHarmonicLine(harmonicNumber, harmonicSet, lineX, lineTop, lineHeight)
       const label = this.createHarmonicLabel(harmonicNumber, harmonicSet, lineX, lineTop)
-      
+      const symbol = this.createHarmonicSymbol(harmonicSet, lineX, lineTop, imageTop)
+
       this.instance.cursorGroup.appendChild(line)
       this.instance.cursorGroup.appendChild(label)
+      this.instance.cursorGroup.appendChild(symbol)
     })
   }
 

--- a/src/rendering/symbols.js
+++ b/src/rendering/symbols.js
@@ -1,0 +1,143 @@
+/**
+ * Shared SVG symbol mark factory for GramFrame harmonic sets.
+ *
+ * A single source of truth used by the symbol selector, the pin renderer, and
+ * the harmonics-table swatch so every place draws the same shape for a given
+ * symbol id. All marks are filled (no stroke) SVG elements returned detached —
+ * the caller appends them.
+ *
+ * Adding a symbol = adding one branch here plus listing its id in the catalogue
+ * (see specs/157-harmonic-pin-symbols/contracts/symbol-catalog.md). No changes
+ * to state, persistence, or selector wiring beyond listing the new id.
+ */
+
+/// <reference path="../types.js" />
+
+/** SVG namespace for element creation */
+const SVG_NS = 'http://www.w3.org/2000/svg'
+
+/**
+ * Canonical list of available symbol ids, in selector display order.
+ * @type {SymbolType[]}
+ */
+export const SYMBOL_CATALOG = ['circle', 'square', 'diamond', 'triangle', 'triangle-down', 'star']
+
+/**
+ * Human-readable display names for each symbol id (used by the selector).
+ * @type {Record<SymbolType, string>}
+ */
+export const SYMBOL_DISPLAY_NAMES = {
+  'circle': 'Circle',
+  'square': 'Square',
+  'diamond': 'Diamond',
+  'triangle': 'Triangle',
+  'triangle-down': 'Triangle (down)',
+  'star': 'Star'
+}
+
+/**
+ * Build a `points` attribute string from an array of [x, y] pairs.
+ * @param {Array<[number, number]>} pts - Point pairs
+ * @returns {string} Space-separated "x,y" points
+ */
+function toPoints(pts) {
+  return pts.map(([x, y]) => `${x},${y}`).join(' ')
+}
+
+/**
+ * Compute the outer/inner alternating vertices of a 5-point star.
+ * @param {number} cx - Centre X
+ * @param {number} cy - Centre Y
+ * @param {number} outerR - Outer radius
+ * @param {number} innerR - Inner radius
+ * @returns {Array<[number, number]>} Ten vertices, outer/inner alternating
+ */
+function starPoints(cx, cy, outerR, innerR) {
+  /** @type {Array<[number, number]>} */
+  const pts = []
+  // 10 vertices: alternate outer and inner, starting from the top point.
+  for (let i = 0; i < 10; i++) {
+    const r = i % 2 === 0 ? outerR : innerR
+    const angle = -Math.PI / 2 + (i * Math.PI) / 5
+    pts.push([cx + r * Math.cos(angle), cy + r * Math.sin(angle)])
+  }
+  return pts
+}
+
+/**
+ * Create a filled SVG mark for a harmonic-set symbol.
+ *
+ * Pure: performs no DOM insertion and reads no state. Returns a detached SVG
+ * element the caller appends. Any unknown/null/undefined `symbolType` falls
+ * back to `circle`.
+ *
+ * @param {SymbolType|string|null|undefined} symbolType - Symbol id (falls back to `circle`)
+ * @param {number} cx - Centre X coordinate in the SVG overlay space
+ * @param {number} cy - Centre Y coordinate in the SVG overlay space
+ * @param {number} size - Nominal diameter in px (radius = size / 2)
+ * @param {string} color - Fill colour (the harmonic set's hex colour)
+ * @returns {SVGElement} A detached, filled SVG element
+ */
+export function createSymbolMark(symbolType, cx, cy, size, color) {
+  const r = size / 2
+
+  // Resolve unknown/absent values to the default so both the drawn shape and the
+  // recorded `data-symbol` reflect the actual fallback.
+  const resolved = SYMBOL_CATALOG.includes(/** @type {SymbolType} */ (symbolType))
+    ? /** @type {SymbolType} */ (symbolType)
+    : 'circle'
+
+  /** @type {SVGElement} */
+  let el
+
+  switch (resolved) {
+    case 'square': {
+      el = document.createElementNS(SVG_NS, 'rect')
+      el.setAttribute('x', String(cx - r))
+      el.setAttribute('y', String(cy - r))
+      el.setAttribute('width', String(2 * r))
+      el.setAttribute('height', String(2 * r))
+      break
+    }
+    case 'diamond': {
+      el = document.createElementNS(SVG_NS, 'polygon')
+      el.setAttribute('points', toPoints([
+        [cx, cy - r], [cx + r, cy], [cx, cy + r], [cx - r, cy]
+      ]))
+      break
+    }
+    case 'triangle': {
+      el = document.createElementNS(SVG_NS, 'polygon')
+      el.setAttribute('points', toPoints([
+        [cx, cy - r], [cx + r, cy + r], [cx - r, cy + r]
+      ]))
+      break
+    }
+    case 'triangle-down': {
+      el = document.createElementNS(SVG_NS, 'polygon')
+      el.setAttribute('points', toPoints([
+        [cx, cy + r], [cx + r, cy - r], [cx - r, cy - r]
+      ]))
+      break
+    }
+    case 'star': {
+      el = document.createElementNS(SVG_NS, 'polygon')
+      el.setAttribute('points', toPoints(starPoints(cx, cy, r, r * 0.5)))
+      break
+    }
+    case 'circle':
+    default: {
+      // Default and legacy fallback: circle.
+      el = document.createElementNS(SVG_NS, 'circle')
+      el.setAttribute('cx', String(cx))
+      el.setAttribute('cy', String(cy))
+      el.setAttribute('r', String(r))
+      break
+    }
+  }
+
+  el.setAttribute('class', 'gram-frame-harmonic-symbol')
+  el.setAttribute('data-symbol', resolved)
+  el.setAttribute('fill', color)
+  return el
+}

--- a/src/types.js
+++ b/src/types.js
@@ -91,12 +91,19 @@
  */
 
 /**
+ * Named filled shape used as a colour-blind-friendly visual code for a
+ * harmonic set. Any unknown/absent value resolves to `circle`.
+ * @typedef {'circle'|'square'|'diamond'|'triangle'|'triangle-down'|'star'} SymbolType
+ */
+
+/**
  * Harmonic set definition for interactive overlays
  * @typedef {Object} HarmonicSet
  * @property {string} id - Unique identifier for the harmonic set
  * @property {string} color - Display color for harmonic lines
  * @property {number} anchorTime - Time position (Y-axis) in seconds
  * @property {number} spacing - Frequency spacing between harmonics in Hz
+ * @property {SymbolType} symbol - Filled shape drawn at the top of each pin and shown in the harmonics table
  */
 
 /**
@@ -173,6 +180,7 @@
  * @property {ModeType|null} previousMode - Previous analysis mode
  * @property {number} rate - Rate value affecting frequency calculations (Hz/s)
  * @property {string} selectedColor - Currently selected color for new features across all modes
+ * @property {SymbolType} selectedSymbol - Currently selected symbol applied to the next created harmonic set
  * @property {CursorPosition|null} cursorPosition - Current cursor position data
  * @property {Array<CursorPosition>} cursors - Array of cursor positions (future use)
  * @property {HarmonicsState} harmonics - Harmonics mode state
@@ -247,6 +255,7 @@
  * @property {string} color - Display colour (hex)
  * @property {number} anchorTime - Y-axis position in seconds
  * @property {number} spacing - Frequency spacing between harmonics in Hz
+ * @property {SymbolType} [symbol] - Persisted symbol; ABSENT in legacy (pre-feature) records
  */
 
 /**
@@ -297,6 +306,7 @@
  * @property {HTMLDivElement|null} [modeCell] - Mode selection cell
  * @property {HTMLDivElement|null} [mainCell] - Main display cell
  * @property {HTMLElement|null} [colorPicker] - Color picker component
+ * @property {HTMLElement|null} [symbolPicker] - Symbol picker component
  * @property {HTMLElement|null} [timeLED] - Time display LED
  * @property {HTMLElement|null} [freqLED] - Frequency display LED
  * @property {HTMLElement|null} [speedLED] - Speed display LED

--- a/tests/analysis-mode.spec.js
+++ b/tests/analysis-mode.spec.js
@@ -642,16 +642,20 @@ test.describe('Cross Cursor Mode - Comprehensive E2E Tests', () => {
       
       // Place a marker
       await gramFramePage.clickSpectrogram(400, 200)
-      
+
       // Verify marker was created
       let state = await gramFramePage.getState()
       expect(state.analysis.markers).toHaveLength(1)
-      
+
       // Test that marker can be dragged from 12px away (within 16px tolerance)
-      // This would fail with the old 8px tolerance
-      await gramFramePage.page.mouse.move(400 + 12, 200 + 12) // 12px diagonal offset
+      // This would fail with the old 8px tolerance. Coordinates are resolved
+      // relative to the SVG's on-screen position so the test is independent of
+      // where the SVG sits in the viewport (which shifts as controls are added).
+      const svgBox = await gramFramePage.svg.boundingBox()
+      if (!svgBox) throw new Error('SVG not found')
+      await gramFramePage.page.mouse.move(svgBox.x + 400 + 12, svgBox.y + 200) // 12px offset (within 16px tolerance)
       await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(450, 250) // Drag to new location
+      await gramFramePage.page.mouse.move(svgBox.x + 450, svgBox.y + 250) // Drag to new location
       await gramFramePage.page.mouse.up()
       
       // Verify marker moved (proving the larger tolerance worked)

--- a/tests/harmonic-symbols.spec.js
+++ b/tests/harmonic-symbols.spec.js
@@ -1,0 +1,240 @@
+import { test, expect } from './helpers/fixtures.js'
+import { GramFramePage } from './helpers/gram-frame-page.js'
+
+/**
+ * @fileoverview E2E tests for "Symbols on Harmonic Pins" (feature
+ * 157-harmonic-pin-symbols). Covers the symbol selector, symbol rendering on
+ * pins and in the harmonics table, persistence across reload, and graceful
+ * display of legacy harmonic sets that predate the symbol field.
+ */
+
+/** Canonical symbol catalogue expected in the selector */
+const CATALOGUE = ['circle', 'square', 'diamond', 'triangle', 'triangle-down', 'star']
+
+/**
+ * Read the app state from a trainer/student fixture page (which exposes the
+ * test-only instance registry rather than the debug #state-display element).
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<any>}
+ */
+async function getStateFromPage(page) {
+  return page.evaluate(() => {
+    // @ts-ignore - test-only global
+    const instances = window.GramFrame && window.GramFrame.__test__getInstances()
+    if (instances && instances.length > 0) {
+      return JSON.parse(JSON.stringify(instances[0].state))
+    }
+    return null
+  })
+}
+
+// ──────────────────────────────────────────────────────────────
+// User Story 1 — Distinguish harmonic sets by symbol as well as colour
+// ──────────────────────────────────────────────────────────────
+
+test.describe('US1: Symbols on harmonic pins', () => {
+  test.beforeEach(async ({ gramFramePage }) => {
+    await gramFramePage.page.waitForTimeout(100)
+    await gramFramePage.clickMode('Harmonics')
+  })
+
+  // T004
+  test('symbol drop-down is present and offers the catalogue shapes', async ({ gramFramePage }) => {
+    const select = gramFramePage.page.locator('.gram-frame-symbol-select')
+    await expect(select).toBeVisible()
+
+    const values = await select.locator('option').evaluateAll(
+      (opts) => opts.map((o) => /** @type {HTMLOptionElement} */ (o).value)
+    )
+    for (const symbol of CATALOGUE) {
+      expect(values).toContain(symbol)
+    }
+    // At minimum circle, square, diamond must be present (FR-002)
+    expect(values).toEqual(expect.arrayContaining(['circle', 'square', 'diamond']))
+  })
+
+  // T005
+  test('click/drag with a selected symbol renders that filled symbol at the top of each pin, label readable', async ({ gramFramePage }) => {
+    await gramFramePage.selectSymbol('square')
+
+    // Create a harmonic set by click/drag on the spectrogram
+    const svgBox = await gramFramePage.svg.boundingBox()
+    if (!svgBox) throw new Error('SVG not found')
+    await gramFramePage.page.mouse.move(svgBox.x + 200, svgBox.y + 150)
+    await gramFramePage.page.mouse.down()
+    await gramFramePage.page.mouse.move(svgBox.x + 320, svgBox.y + 120, { steps: 5 })
+    await gramFramePage.page.mouse.up()
+    await gramFramePage.page.waitForTimeout(200)
+
+    const state = await gramFramePage.getState()
+    expect(state.harmonics.harmonicSets.length).toBeGreaterThan(0)
+    const set = state.harmonics.harmonicSets[0]
+    expect(set.symbol).toBe('square')
+
+    // Every pin symbol is a square filled in the set's colour
+    const symbols = await gramFramePage.getPinSymbols(set.id)
+    expect(symbols.length).toBeGreaterThan(0)
+    for (const s of symbols) {
+      expect(s.symbol).toBe('square')
+      expect(s.fill.toLowerCase()).toBe(String(set.color).toLowerCase())
+    }
+
+    // The pin-number label is present and not obscured — the symbol sits above
+    // the label rather than overlapping it (FR-006).
+    const overlap = await gramFramePage.page.evaluate(() => {
+      const symbol = document.querySelector('.gram-frame-harmonic-symbol')
+      const label = document.querySelector('.gram-frame-harmonic-number')
+      if (!symbol || !label) return null
+      const s = symbol.getBoundingClientRect()
+      const l = label.getBoundingClientRect()
+      return { symbolBottom: s.bottom, labelTop: l.top }
+    })
+    expect(overlap).not.toBeNull()
+    // Symbol's bottom is at or above the label's top (with a couple px tolerance)
+    expect(overlap.symbolBottom).toBeLessThanOrEqual(overlap.labelTop + 3)
+  })
+
+  // T006
+  test('manual add dialog uses the currently selected symbol', async ({ gramFramePage }) => {
+    await gramFramePage.selectSymbol('diamond')
+
+    await gramFramePage.page.locator('.gram-frame-manual-button').click()
+    await gramFramePage.page.locator('#harmonic-spacing-input').fill('25')
+    await gramFramePage.page.locator('#add-button').click()
+    await gramFramePage.page.waitForTimeout(200)
+
+    const state = await gramFramePage.getState()
+    expect(state.harmonics.harmonicSets.length).toBeGreaterThan(0)
+    const set = state.harmonics.harmonicSets[state.harmonics.harmonicSets.length - 1]
+    expect(set.symbol).toBe('diamond')
+
+    const symbols = await gramFramePage.getPinSymbols(set.id)
+    expect(symbols.length).toBeGreaterThan(0)
+    for (const s of symbols) {
+      expect(s.symbol).toBe('diamond')
+    }
+  })
+
+  // T007
+  test('each harmonics-table row shows the set symbol in the set colour', async ({ gramFramePage }) => {
+    await gramFramePage.selectSymbol('star')
+    const setId = await gramFramePage.addHarmonicSet(5, 100)
+    await gramFramePage.page.waitForTimeout(200)
+
+    const state = await gramFramePage.getState()
+    const set = state.harmonics.harmonicSets.find((s) => s.id === setId)
+    expect(set).toBeTruthy()
+    expect(set.symbol).toBe('star')
+
+    const swatches = await gramFramePage.getTableSymbolSwatches()
+    expect(swatches.length).toBe(state.harmonics.harmonicSets.length)
+    const swatch = swatches[state.harmonics.harmonicSets.findIndex((s) => s.id === setId)]
+    expect(swatch.symbol).toBe('star')
+    expect(swatch.fill.toLowerCase()).toBe(String(set.color).toLowerCase())
+  })
+})
+
+// ──────────────────────────────────────────────────────────────
+// User Story 2 — Preserve symbols across save and reload
+// ──────────────────────────────────────────────────────────────
+
+test.describe('US2: Symbols persist across reload', () => {
+  test('symbols on pins and in the table survive a save/reload round-trip', async ({ page }) => {
+    const gfp = new GramFramePage(page)
+    await page.goto('/tests/fixtures/trainer-page.html')
+    await page.evaluate(() => localStorage.clear())
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+    await page.waitForTimeout(300)
+
+    // Select a distinctive symbol and create a harmonic set
+    await page.locator('.gram-frame-mode-btn:text("Harmonics")').click()
+    await page.locator('.gram-frame-symbol-select').selectOption('triangle')
+    const setId = await gfp.addHarmonicSet(5, 100)
+    await page.waitForTimeout(300)
+
+    const before = await getStateFromPage(page)
+    const setBefore = before.harmonics.harmonicSets.find((s) => s.id === setId)
+    expect(setBefore.symbol).toBe('triangle')
+
+    // Reload
+    await page.reload()
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+    await page.waitForTimeout(500)
+
+    const after = await getStateFromPage(page)
+    const setAfter = after.harmonics.harmonicSets.find((s) => s.id === setId)
+    expect(setAfter).toBeTruthy()
+    expect(setAfter.symbol).toBe('triangle')
+    expect(setAfter.color).toBe(setBefore.color)
+
+    // Pins render the restored symbol
+    const pins = await gfp.getPinSymbols(setId)
+    expect(pins.length).toBeGreaterThan(0)
+    for (const p of pins) {
+      expect(p.symbol).toBe('triangle')
+    }
+
+    // Table swatch shows the restored symbol
+    const swatches = await gfp.getTableSymbolSwatches()
+    expect(swatches.some((s) => s.symbol === 'triangle')).toBe(true)
+  })
+})
+
+// ──────────────────────────────────────────────────────────────
+// User Story 3 — Gracefully display legacy harmonics that predate symbols
+// ──────────────────────────────────────────────────────────────
+
+test.describe('US3: Legacy harmonic sets default to circle', () => {
+  test('a legacy v1 blob without symbol reloads with circles and no console error', async ({ page }) => {
+    /** @type {string[]} */
+    const consoleErrors = []
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text())
+    })
+
+    await page.goto('/tests/fixtures/trainer-page.html')
+    await page.evaluate(() => localStorage.clear())
+
+    // Seed a legacy (pre-feature) v1 record whose harmonic sets have no `symbol`
+    await page.evaluate(() => {
+      const key = 'gramframe::' + window.location.pathname
+      localStorage.setItem(key, JSON.stringify({
+        version: 1,
+        savedAt: new Date().toISOString(),
+        analysis: { markers: [] },
+        harmonics: {
+          harmonicSets: [
+            { id: 'legacy-1', color: '#00ff00', anchorTime: 5, spacing: 100 }
+          ]
+        },
+        doppler: { fPlus: null, fMinus: null, fZero: null, color: null }
+      }))
+    })
+
+    // Reload — legacy data must load (SCHEMA_VERSION unchanged) and default to circle
+    await page.reload()
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+    await page.waitForTimeout(500)
+
+    const gfp = new GramFramePage(page)
+    const state = await getStateFromPage(page)
+    const legacySet = state.harmonics.harmonicSets.find((s) => s.id === 'legacy-1')
+    expect(legacySet).toBeTruthy()
+    expect(legacySet.symbol).toBe('circle')
+
+    // Every rendered pin symbol is a circle
+    const pins = await gfp.getPinSymbols('legacy-1')
+    expect(pins.length).toBeGreaterThan(0)
+    for (const p of pins) {
+      expect(p.symbol).toBe('circle')
+    }
+
+    // Table swatch is a circle
+    const swatches = await gfp.getTableSymbolSwatches()
+    expect(swatches.length).toBeGreaterThan(0)
+    expect(swatches.every((s) => s.symbol === 'circle')).toBe(true)
+
+    // No console errors during the legacy load
+    expect(consoleErrors).toEqual([])
+  })
+})

--- a/tests/helpers/gram-frame-page.js
+++ b/tests/helpers/gram-frame-page.js
@@ -525,6 +525,49 @@ class GramFramePage {
       instances[0]._setZoom(lvl, cx, cy)
     }, [level, centerX, centerY])
   }
+
+  /**
+   * Select a symbol from the control-panel symbol drop-down.
+   * @param {string} symbolId - One of 'circle','square','diamond','triangle','triangle-down','star'
+   * @returns {Promise<void>}
+   */
+  async selectSymbol(symbolId) {
+    await this.page.locator('.gram-frame-symbol-select').selectOption(symbolId)
+  }
+
+  /**
+   * Read the pin symbol marks rendered on the spectrogram overlay.
+   * @param {string} [harmonicSetId] - Optional filter to a single set's marks
+   * @returns {Promise<Array<{symbol: string, fill: string, tag: string}>>}
+   */
+  async getPinSymbols(harmonicSetId) {
+    return this.page.evaluate((setId) => {
+      const selector = setId
+        ? `.gram-frame-harmonic-symbol[data-harmonic-set-id="${setId}"]`
+        : '.gram-frame-harmonic-symbol'
+      return Array.from(document.querySelectorAll(selector)).map((el) => ({
+        symbol: el.getAttribute('data-symbol') || '',
+        fill: el.getAttribute('fill') || '',
+        tag: el.tagName.toLowerCase()
+      }))
+    }, harmonicSetId)
+  }
+
+  /**
+   * Read the symbol swatches shown in the harmonics table rows.
+   * @returns {Promise<Array<{symbol: string, fill: string}>>}
+   */
+  async getTableSymbolSwatches() {
+    return this.page.evaluate(() => {
+      const marks = Array.from(document.querySelectorAll(
+        '.gram-frame-harmonic-row .gram-frame-harmonic-symbol'
+      ))
+      return marks.map((el) => ({
+        symbol: el.getAttribute('data-symbol') || '',
+        fill: el.getAttribute('fill') || ''
+      }))
+    })
+  }
 }
 
 export { GramFramePage }


### PR DESCRIPTION
## Summary

Implements **Symbols on Harmonic Pins** (GH #185, spec `157-harmonic-pin-symbols`). Each harmonic set now carries a **symbol** (filled shape) as a colour‑blind‑friendly code alongside its colour. A new **Symbol** drop‑down in the control panel (next to **Color**) sets the symbol applied to the next harmonic set. Every new set — whether created by click/drag or via the manual add dialog — draws that filled symbol, in the set's colour, at the top of each pin and in the harmonics table.

Available symbols: circle (default), square, diamond, triangle, triangle‑down, star.

## What changed

- **Shared SVG mark factory** — new `src/rendering/symbols.js` exports `createSymbolMark()` plus the catalogue, used by the pin renderer, table swatch, and selector. Pure/detached; unknown or absent values fall back to `circle`.
- **Selector** — new `src/components/SymbolPicker.js` (native `<select>`), re‑exported from `UIComponents.js` and mounted in `MainUI.js` immediately after the colour picker. Writes `state.selectedSymbol` (default `'circle'`, added in `state.js`).
- **Assignment & rendering** — `HarmonicsMode.addHarmonicSet` assigns `symbol` from `state.selectedSymbol`; `renderHarmonicSet` draws the symbol at the top of each pin, clear of the pin‑number label and nudged down if it would clip the top edge. `renderPersistentFeatures` clears prior symbol marks alongside the lines.
- **Harmonics table** — `HarmonicPanel.js` renders each row's symbol as an inline SVG swatch in the set's colour (create and update paths).
- **Persistence** — `saveAnnotations` writes `symbol` additively; **`SCHEMA_VERSION` stays 1** so existing v1 records are not discarded. `_restoreAnnotations` applies `symbol: hs.symbol || 'circle'`, so legacy (pre‑feature) sets reload as circles.
- **Types** — `SymbolType` typedef; `HarmonicSet.symbol`, `StoredHarmonicSet.symbol?`, and `GramFrameState.selectedSymbol` added.
- **CSS** — symbol‑picker styling and table swatch alignment (matching the colour‑picker look).

## Tests

- New `tests/harmonic-symbols.spec.js` covers: selector presence/catalogue, click/drag rendering with label‑clearance check, manual‑add path, table swatch colour, save/reload persistence, and legacy‑fallback (seeded v1 blob with no `symbol` → circles, no console error).
- Added `GramFramePage` helpers for symbol assertions (`selectSymbol`, `getPinSymbols`, `getTableSymbolSwatches`).
- Fixed one coordinate‑fragile analysis‑mode drag test that assumed the SVG sits at the viewport origin — it now anchors to the SVG bounding box, since the new control's height shifts the SVG down. (Its sibling tests already had a skip‑on‑miss guard; this one hard‑asserted.)

## Quality gates

- `yarn typecheck` — clean
- `yarn test` — 147 passing
- `yarn build` — clean production build

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCGv5vc8ShArCq71Sphgsm

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCGv5vc8ShArCq71Sphgsm)_