### PR TITLE
refactor(harmonics): merge colour and symbol into one "Symbol" panel

### DIFF
--- a/src/components/ColorPicker.js
+++ b/src/components/ColorPicker.js
@@ -1,10 +1,13 @@
 /**
- * Color Picker Component for GramFrame
- * 
- * Provides color selection functionality for harmonic overlays
+ * Combined colour + symbol picker for GramFrame
+ *
+ * Provides colour selection (gradient slider) and, alongside it, the symbol
+ * drop-down for harmonic overlays, under a single "Symbol" panel.
  */
 
 /// <reference path="../types.js" />
+
+import { createSymbolSelect } from './SymbolPicker.js'
 
 /**
  * Standard color palette used for color picker gradient and calculations
@@ -26,91 +29,89 @@ const COLOR_PALETTE = [
 ]
 
 /**
- * Create a color picker component for harmonic selection
+ * Create the combined "Symbol" control: a colour slider on the left and a
+ * symbol drop-down (tinted with the selected colour) on the right. Both the
+ * colour and symbol for the next harmonic set are chosen from this one panel.
  * @param {GramFrameState} state - Current state object
- * @returns {HTMLDivElement} The color picker element
+ * @returns {HTMLDivElement} The combined colour/symbol picker element
  */
 export function createColorPicker(state) {
   const container = document.createElement('div')
   container.className = 'gram-frame-color-picker'
   container.style.display = 'block'
-  
+
   // Label
   const label = document.createElement('div')
   label.className = 'gram-frame-color-picker-label'
-  label.textContent = 'Harmonic Color'
+  label.textContent = 'Symbol'
   container.appendChild(label)
-  
-  // Color palette container - now horizontal with slider and lozenge
+
+  // Palette container - horizontal row with the colour slider and symbol select
   const paletteContainer = document.createElement('div')
   paletteContainer.className = 'gram-frame-color-palette'
   paletteContainer.style.display = 'flex'
   paletteContainer.style.alignItems = 'center'
   paletteContainer.style.gap = '8px'
   container.appendChild(paletteContainer)
-  
+
   // Slider container for canvas and indicator
   const sliderContainer = document.createElement('div')
   sliderContainer.className = 'gram-frame-color-slider'
   sliderContainer.style.position = 'relative'
   sliderContainer.style.flex = '1'
   paletteContainer.appendChild(sliderContainer)
-  
+
   // Create continuous color palette using canvas
   const canvas = document.createElement('canvas')
   canvas.width = 140
   canvas.height = 20
   canvas.className = 'gram-frame-color-canvas'
   sliderContainer.appendChild(canvas)
-  
+
   // Initialize default color
   if (!state.selectedColor) {
     state.selectedColor = '#ff6b6b' // Default first color
   }
-  
+
   // Draw the color palette
   drawColorPalette(canvas)
-  
+
   // Color selection indicator
   const indicator = document.createElement('div')
   indicator.className = 'gram-frame-color-indicator'
   sliderContainer.appendChild(indicator)
-  
-  // Current color display - now a compact lozenge
-  const currentColor = document.createElement('div')
-  currentColor.className = 'gram-frame-current-color'
-  currentColor.style.backgroundColor = state.selectedColor
-  currentColor.style.width = '30px'
-  currentColor.style.height = '20px'
-  currentColor.style.borderRadius = '10px'
-  currentColor.style.flexShrink = '0'
-  paletteContainer.appendChild(currentColor)
-  
+
+  // Symbol drop-down on the right (where the colour swatch used to be); its
+  // glyphs are tinted with the currently selected colour, so it doubles as the
+  // colour readout.
+  const symbolSelect = createSymbolSelect(state)
+  paletteContainer.appendChild(symbolSelect)
+
   // Add click handler for color selection
   canvas.addEventListener('click', (event) => {
     const rect = canvas.getBoundingClientRect()
     const x = event.clientX - rect.left
-    
+
     // Scale x coordinate to canvas dimensions if CSS scaling differs
     const scaleX = canvas.width / rect.width
     const canvasX = x * scaleX
-    
+
     const color = getColorFromPosition(canvasX, canvas.width)
-    
+
     // Update state
     state.selectedColor = color
-    
-    // Update current color display
-    currentColor.style.backgroundColor = color
-    
+
+    // Tint the symbol drop-down with the newly selected colour
+    symbolSelect.style.color = color
+
     // Update indicator position using the same canvasX coordinate for consistency
     updateIndicatorPosition(indicator, canvasX, canvas.width)
   })
-  
+
   // Initialize indicator position (use canvas coordinates directly)
   const initialPosition = getPositionFromColor(state.selectedColor, canvas.width)
   updateIndicatorPosition(indicator, initialPosition, canvas.width)
-  
+
   return container
 }
 

--- a/src/components/MainUI.js
+++ b/src/components/MainUI.js
@@ -10,7 +10,6 @@
 import {
   createLEDDisplay,
   createColorPicker,
-  createSymbolPicker,
   createFullFlexLayout,
   createFlexColumn
 } from './UIComponents.js'
@@ -64,14 +63,9 @@ export function createUnifiedLayout(instance) {
   
   controlsColumn.appendChild(cursorContainer)
   
-  // Create color picker in controls column
+  // Combined colour + symbol control (labelled "Symbol") in controls column
   const colorPicker = createColorPicker(instance.state)
-  colorPicker.querySelector('.gram-frame-color-picker-label').textContent = 'Color'
   controlsColumn.appendChild(colorPicker)
-
-  // Create symbol picker immediately after the colour picker
-  const symbolPicker = createSymbolPicker(instance.state)
-  controlsColumn.appendChild(symbolPicker)
 
   // Add columns to left panel
   leftColumn.appendChild(modeColumn)
@@ -116,7 +110,6 @@ export function createUnifiedLayout(instance) {
   instance.freqLED = freqLED
   instance.speedLED = speedLED
   instance.colorPicker = colorPicker
-  instance.symbolPicker = symbolPicker
 
   return unifiedLayoutContainer
 }

--- a/src/components/SymbolPicker.js
+++ b/src/components/SymbolPicker.js
@@ -1,8 +1,10 @@
 /**
- * Symbol Picker Component for GramFrame
+ * Symbol selector for GramFrame harmonic overlays.
  *
- * Provides symbol selection for harmonic overlays as a native drop-down list,
- * mirroring the ColorPicker pattern. The chosen symbol is written to
+ * Renders a compact native drop-down of symbol glyphs. It is embedded in the
+ * combined "Symbol" panel (see ColorPicker.js) to the right of the colour
+ * slider, where the selected-colour swatch used to sit, and its glyphs are
+ * tinted with the currently selected colour. The chosen symbol is written to
  * `state.selectedSymbol` and applied to the next created harmonic set.
  */
 
@@ -11,8 +13,9 @@
 import { SYMBOL_CATALOG, SYMBOL_DISPLAY_NAMES } from '../rendering/symbols.js'
 
 /**
- * Unicode glyph previews shown alongside each option name in the drop-down, so
- * the shape is recognisable without rendering inline SVG inside <option>.
+ * Unicode glyph shown for each symbol id in the drop-down. The list is a
+ * compact "drop-down of symbols" (glyph only) so it fits beside the colour
+ * slider; the full name is kept on each option's tooltip for accessibility.
  * @type {Record<SymbolType, string>}
  */
 const SYMBOL_GLYPHS = {
@@ -25,34 +28,28 @@ const SYMBOL_GLYPHS = {
 }
 
 /**
- * Create a symbol picker component for harmonic selection.
+ * Create the symbol selector drop-down.
  * @param {GramFrameState} state - Current state object
- * @returns {HTMLDivElement} The symbol picker element
+ * @returns {HTMLSelectElement} The symbol `<select>` element
  */
-export function createSymbolPicker(state) {
-  const container = document.createElement('div')
-  container.className = 'gram-frame-symbol-picker'
-  container.style.display = 'block'
-
-  // Label
-  const label = document.createElement('div')
-  label.className = 'gram-frame-symbol-picker-label'
-  label.textContent = 'Symbol'
-  container.appendChild(label)
-
+export function createSymbolSelect(state) {
   // Initialise default symbol if unset
   if (!state.selectedSymbol) {
     state.selectedSymbol = 'circle'
   }
 
-  // Native drop-down of catalogue shapes
   const select = document.createElement('select')
   select.className = 'gram-frame-symbol-select'
+  select.title = 'Symbol'
+  select.setAttribute('aria-label', 'Symbol')
+  // Tint the glyphs with the currently selected colour
+  select.style.color = state.selectedColor
 
   SYMBOL_CATALOG.forEach(symbolId => {
     const option = document.createElement('option')
     option.value = symbolId
-    option.textContent = `${SYMBOL_GLYPHS[symbolId]}  ${SYMBOL_DISPLAY_NAMES[symbolId]}`
+    option.textContent = SYMBOL_GLYPHS[symbolId]
+    option.title = SYMBOL_DISPLAY_NAMES[symbolId]
     if (symbolId === state.selectedSymbol) {
       option.selected = true
     }
@@ -63,7 +60,5 @@ export function createSymbolPicker(state) {
     state.selectedSymbol = /** @type {SymbolType} */ (select.value)
   })
 
-  container.appendChild(select)
-
-  return container
+  return select
 }

--- a/src/components/UIComponents.js
+++ b/src/components/UIComponents.js
@@ -8,7 +8,7 @@
 /// <reference path="../types.js" />
 
 import { createColorPicker } from './ColorPicker.js'
-import { createSymbolPicker } from './SymbolPicker.js'
+import { createSymbolSelect } from './SymbolPicker.js'
 import { createLEDDisplay, updateLEDDisplays } from './LEDDisplay.js'
 import { createModeSwitchingUI } from './ModeButtons.js'
 
@@ -27,8 +27,8 @@ export { createModeSwitchingUI }
 // Re-export color picker function from ColorPicker module
 export { createColorPicker }
 
-// Re-export symbol picker function from SymbolPicker module
-export { createSymbolPicker }
+// Re-export symbol selector function from SymbolPicker module
+export { createSymbolSelect }
 
 
 /**

--- a/src/gramframe.css
+++ b/src/gramframe.css
@@ -334,38 +334,16 @@
   position: relative;
 }
 
-.gram-frame-symbol-picker {
-  margin-top: 6px;
-  padding: 8px;
-  background: linear-gradient(135deg, #1a1a1a 0%, #000 50%, #0a0a0a 100%);
-  border: 2px solid #333;
-  border-radius: 4px;
-  box-shadow:
-    inset 0 2px 6px rgba(0,0,0,0.8),
-    inset 0 -1px 2px rgba(255,255,255,0.05),
-    0 2px 4px rgba(0,0,0,0.5);
-  max-width: 200px;
-  flex-shrink: 0;
-}
-
-.gram-frame-symbol-picker-label {
-  font-size: 10px;
-  color: #00ff00;
-  margin-bottom: 6px;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  font-weight: bold;
-  text-align: center;
-}
-
+/* Symbol drop-down embedded to the right of the colour slider. Its `color` is
+   set inline to the selected colour so the glyphs render in that colour. */
 .gram-frame-symbol-select {
-  width: 100%;
-  padding: 4px;
+  flex-shrink: 0;
+  padding: 2px 4px;
   background: #0a0a0a;
-  color: #00ff00;
   border: 1px solid #555;
   border-radius: 2px;
-  font-size: 12px;
+  font-size: 14px;
+  line-height: 1;
   cursor: pointer;
 }
 
@@ -550,11 +528,6 @@
 
 .gram-frame-marker-point {
   opacity: 0.9;
-}
-
-.gram-frame-current-color {
-  border: 1px solid #555;
-  box-shadow: inset 0 1px 3px rgba(0,0,0,0.5);
 }
 
 /* Military-style mode selection header */

--- a/src/types.js
+++ b/src/types.js
@@ -305,8 +305,7 @@
  * @property {HTMLDivElement|null} [readoutPanel] - Container for readouts
  * @property {HTMLDivElement|null} [modeCell] - Mode selection cell
  * @property {HTMLDivElement|null} [mainCell] - Main display cell
- * @property {HTMLElement|null} [colorPicker] - Color picker component
- * @property {HTMLElement|null} [symbolPicker] - Symbol picker component
+ * @property {HTMLElement|null} [colorPicker] - Combined colour/symbol picker component
  * @property {HTMLElement|null} [timeLED] - Time display LED
  * @property {HTMLElement|null} [freqLED] - Frequency display LED
  * @property {HTMLElement|null} [speedLED] - Speed display LED


### PR DESCRIPTION
## Summary

Follow-up to #195. Consolidates the two separate control panels (**Color** and **Symbol**) into a **single panel titled "Symbol"** to save vertical space and leave room for future controls.

Layout is now a title with one row beneath it:
- **Colour slider** on the left
- **Symbol drop-down** on the right (where the colour swatch used to sit), with its glyphs tinted in the currently selected colour — so the drop-down doubles as the colour readout.

| Before | After |
| --- | --- |
| Two stacked panels: "Color" (slider + swatch) and "Symbol" (full-width select) | One "Symbol" panel: slider left, colour-tinted symbol drop-down right |

## What changed

- **`ColorPicker.js`** — `createColorPicker` now builds the combined panel: label "Symbol", colour slider, and an embedded symbol select. The select is retinted (`style.color`) whenever the colour changes, replacing the old colour swatch.
- **`SymbolPicker.js`** — now exposes `createSymbolSelect(state)`, a compact glyph-only, colourable `<select>` (full names kept as per-option tooltips for accessibility), replacing the standalone `createSymbolPicker` panel.
- **`MainUI.js`** — mounts the single combined control; removes the separate symbol-panel mount and the "Color" label override.
- **`UIComponents.js`** — re-exports `createSymbolSelect` instead of `createSymbolPicker`.
- **`gramframe.css`** — removes the standalone `.gram-frame-symbol-picker` / `.gram-frame-symbol-picker-label` and the unused `.gram-frame-current-color` swatch rules; styles the inline `.gram-frame-symbol-select`.
- **`types.js`** — drops the now-unused `symbolPicker` instance property; `colorPicker` documented as the combined control.

State, persistence, pin rendering, and the harmonics-table swatch are unchanged — `state.selectedSymbol` / `state.selectedColor` and the `.gram-frame-symbol-select` selector are all preserved, so existing behaviour and tests still hold.

## Verification

- Verified in the running app: panel is titled "Symbol", slider + colour-tinted symbol drop-down on one row, old separate panel gone, selecting a symbol/colour updates state and the glyph tint.
- `yarn typecheck` — clean
- `yarn build` — clean production build
- `yarn test` — full Playwright suite green (the only failure seen locally was a self-inflicted `version.js` HMR artifact during a mid-run file revert, which passes cleanly on its own).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCGv5vc8ShArCq71Sphgsm

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCGv5vc8ShArCq71Sphgsm)_