### PR TITLE
docs: architecture & implementation audit (report + verified findings register)

### DIFF
--- a/docs/analysis/Architecture-Analysis.md
+++ b/docs/analysis/Architecture-Analysis.md
@@ -1,0 +1,322 @@
+# GramFrame Architecture & Implementation Audit
+
+**Date:** 2026-07-23 · **Scope:** architecture & module boundaries, code quality & maintainability, testing strategy, implementation strategy & process, documentation drift · **Companion document:** [Findings-Register.md](Findings-Register.md) (ranked, independently verified findings, referenced below as GF-nn)
+
+---
+
+## 1. Executive summary
+
+GramFrame is in better shape than most codebases of its history: the once-monolithic 2,100-line `main.js` has genuinely been refactored down to 562 lines, all 147 Playwright tests pass on a clean checkout, `tsc` typechecking is clean, TODO/FIXME debt is essentially zero, and several modules (`rendering/symbols.js`, `utils/harmonicSampling.js`, `core/storage.js`'s schema/TTL design, the release pipeline) are exemplary. The mode system's *concept* — four modes behind a `BaseMode` contract, instantiated by a factory, with `FeatureRenderer` as the cross-mode rendering seam — is sound.
+
+The audit's critical verdict is that **the boundaries drawn on the whiteboard do not exist in the code**. Every mode, component, and core module reaches freely through the `GramFrame` instance (347 accesses to `instance.state` across 19 files), state mutation and broadcast are scattered across 12 files, and `core/state.js` imports every mode class while every mode imports state back — 8 circular dependencies. The most dangerous concrete consequence is the coordinate pipeline: the screen→SVG→image→data transform exists in **four divergent implementations**, and the keyboard path uses different math than the mouse path under zoom/expand (GF-01). Meanwhile the verification layer has quietly eroded: null-safety typechecks are disabled, there is no linting, no unit-test lane, the multi-instance keyboard/focus specs are disabled without explanation, and a production failure mode exists where a broken mode silently degrades to a no-op (GF-04).
+
+Documentation splits into two tiers: `Tech-Architecture.md` and `Data-and-State-Guide.md` are accurate and current, but CLAUDE.md, README, `Gram-Modes.md`, and several accepted ADRs describe a three-mode (or two-mode) system from an earlier era — and ADR-015 describes a zoom design that is the opposite of what the code does (GF-39).
+
+### Top five risks
+
+| # | Risk | Findings |
+|---|------|----------|
+| 1 | Four divergent coordinate-transform implementations; keyboard vs mouse math disagrees under zoom/expand | GF-01, GF-02, GF-21 |
+| 2 | Silent production degradation: mode-construction failure yields a no-op spectrogram; storage failures swallow annotation loss | GF-04, GF-16 |
+| 3 | No enforced boundaries: god-object instance + state⇄modes import cycles + diffuse mutation/broadcast make every change a whole-system change | GF-03, GF-05, GF-06, GF-08 |
+| 4 | Verification erosion: null checks off, no lint, no unit lane, keyboard/focus coverage disabled, 142 fixed sleeps masked by CI retries | GF-25–GF-27, GF-31, GF-32 |
+| 5 | Doc drift misleading humans and AI agents alike: CLAUDE.md points at phantom files; two ADRs describe fictional designs | GF-38–GF-43 |
+
+---
+
+## 2. System overview
+
+GramFrame scans the page for `<table class="gram-config">` elements, replaces each with an SVG-based interactive spectrogram, and exposes a listener API for host pages. A `GramFrame` class instance per table owns a plain-object state tree; four interaction modes (pan, analysis, harmonics, doppler) extend `BaseMode` and are created by `ModeFactory`; `FeatureRenderer` composes each mode's persistent features into one render pass.
+
+### 2.1 Module dependency graph
+
+Directory-aggregated from `madge --json` (46 files, 102 import edges). Red dashed edges participate in the 8 reported circular dependencies.
+
+```mermaid
+flowchart TD
+    subgraph entry["entry"]
+        index["index.js"]
+        main["main.js"]
+    end
+    subgraph coreL["core/"]
+        state["state.js"]
+        events["events.js"]
+        init["initialization/*"]
+        viewport["viewport.js"]
+        kbd["keyboardControl.js"]
+        focus["FocusManager.js"]
+        storage["storage.js"]
+        featrend["FeatureRenderer.js"]
+    end
+    subgraph modesL["modes/"]
+        factory["ModeFactory.js"]
+        base["BaseMode.js"]
+        analysis["analysis/"]
+        harmonics["harmonics/"]
+        doppler["doppler/"]
+        pan["pan/"]
+        shared["shared/BaseDragHandler.js"]
+    end
+    subgraph compL["components/"]
+        table["table.js"]
+        expand["ExpandToggle.js"]
+        mainui["MainUI.js"]
+        harmpanel["HarmonicPanel.js"]
+    end
+    subgraph periph["api/ · rendering/ · utils/"]
+        api["api/GramFrameAPI.js"]
+        rendering["rendering/*"]
+        utils["utils/*"]
+    end
+
+    index --> main
+    main --> api
+    main --> init
+    main --> events
+    main --> kbd
+    main --> storage
+    main --> viewport
+    init --> table
+    init --> mainui
+    init --> factory
+    init --> featrend
+    factory --> analysis
+    factory --> harmonics
+    factory --> doppler
+    factory --> pan
+    factory --> base
+    events --> mainui
+    events --> focus
+    events --> rendering
+    kbd --> harmpanel
+    kbd --> focus
+    viewport --> table
+    viewport --> expand
+    api --> expand
+    harmonics --> harmpanel
+    harmonics --> shared
+    harmonics --> rendering
+    doppler --> shared
+    doppler --> rendering
+    analysis --> shared
+    rendering --> utils
+
+    state -.-> analysis
+    state -.-> harmonics
+    state -.-> doppler
+    state -.-> pan
+    analysis -.-> state
+    harmonics -.-> state
+    doppler -.-> state
+    pan -.-> state
+    expand -.-> table
+    table -.-> expand
+    table -.-> state
+
+    linkStyle 30,31,32,33,34,35,36,37,38,39,40 stroke:#d33,stroke-width:2px,stroke-dasharray:5
+```
+
+The cycles decompose into two knots (GF-03, GF-09):
+
+1. **`state.js` ⇄ every mode** — `state.js:10-13` imports all four mode classes to assemble initial state, while each mode imports `notifyStateListeners` back and self-broadcasts.
+2. **`table.js` ⇄ `ExpandToggle.js`** (plus chains through `table.js → state.js → modes`) — `table.js` mounts the toggle after image load; the toggle re-runs layout/axes that live in `table.js`.
+
+### 2.2 Mode-switch lifecycle
+
+From `main.js:403-493` (`_switchMode`):
+
+```mermaid
+sequenceDiagram
+    participant UI as Mode button
+    participant GF as GramFrame (main.js)
+    participant Old as Old mode
+    participant New as New mode
+    participant FR as FeatureRenderer
+    participant L as State listeners
+
+    UI->>GF: _switchMode(mode)
+    Note over GF: guard: pan requires zoom > 1:1 (main.js:405)
+    GF->>GF: state.previousMode = mode; state.mode = new; clear dragState
+    GF->>GF: update button classes + container mode class
+    GF->>Old: cleanup()
+    GF->>Old: deactivate()
+    GF->>New: activate()
+    GF->>New: getGuidanceText() → guidance panel
+    GF->>New: updateLEDs(cursorPosition)
+    GF->>GF: updateLEDDisplays, updatePersistentPanels
+    GF->>FR: renderAllPersistentFeatures()
+    GF->>L: notifyStateListeners(deep-cloned state)
+```
+
+The sequence itself is coherent. The problems are around it: sub-operations inside the switch also broadcast, so one gesture fires multiple full-state clones (GF-08), and `updatePersistentPanels` reaches into named sibling modes (GF-11).
+
+### 2.3 State flow
+
+```mermaid
+flowchart LR
+    subgraph writers["State writers (unmediated)"]
+        M1["main.js"]
+        M2["events.js"]
+        M3["viewport.js"]
+        M4["keyboardControl.js"]
+        M5["4 mode classes"]
+        M6["table.js / ExpandToggle"]
+        M7["GramFrameAPI"]
+    end
+    S[("instance.state\n(plain object,\nno invariants)")]
+    N["notifyStateListeners()\nJSON deep clone\n(state.js:112)"]
+    subgraph listeners["Listeners"]
+        L1["per-instance listeners"]
+        L2["globalStateListeners\n(module-level, copied\ninto every instance)"]
+    end
+
+    writers -->|"direct field writes"| S
+    writers -->|"29 call sites, 12 files"| N
+    S --> N
+    N --> L1
+    N --> L2
+```
+
+There is no store, no setter path, no batching: any module writes any field and decides for itself whether to broadcast (GF-05, GF-08). The deep clone protects listeners from mutating internal state — a real strength — but runs on every mousemove (GF-07).
+
+### 2.4 Coordinate pipeline — the four implementations
+
+```mermaid
+flowchart TD
+    E["mouse event (screen px)"]
+    K["arrow key"]
+    subgraph P1["Path 1: events.js"]
+        A1["screenToSVGCoordinates\n(utils/coordinates.js)"]
+        A2["inline screenToDataWithZoom\n(events.js:19-72)"]
+        A3["state.cursorPosition\n⚠ imageX/imageY = SVG coords\n(events.js:164-165)"]
+    end
+    subgraph P2["Path 2: mode classes"]
+        B1["coordinateTransformations.js\nreads live image element attrs\n(zoom & expand aware)"]
+    end
+    subgraph P3["Path 3: keyboardControl.js"]
+        C1["private dataToSVG/svgToData\n(keyboardControl.js:303-354)\nignores element attrs ⚠"]
+    end
+    subgraph P4["Path 4: cursors.js"]
+        D1["hand-rolled convertToSVG\n(cursors.js:69-76)\nnot zoom-aware ⚠"]
+    end
+    E --> A1 --> A2 --> A3
+    E --> B1
+    K --> C1
+    D1 -->|"doppler preview"| E2["render"]
+    B1 -->|"doppler committed curve"| E2
+```
+
+Path 2 (`coordinateTransformations.js`) is the well-designed one — it derives geometry from the live image element, which is exactly why markers stay locked to data coordinates across zoom+expand. Paths 1, 3, and 4 each re-derive the math differently; path 3 diverges from path 2 precisely when zoomed or expanded, and path 4 makes the Doppler live preview disagree with the committed curve under zoom (GF-01, GF-02, GF-21). **Consolidating on path 2 and deleting the others is the single highest-value refactor in this audit.**
+
+---
+
+## 3. Architecture & module boundaries
+
+**What is good.** The mode-system shape is right: `BaseMode` as contract, `ModeFactory` as the single instantiation point with an explicit mode whitelist, `FeatureRenderer` clearing once and delegating per-mode with `has*Features()` guards (`FeatureRenderer.js:23-45`). Initial state is centrally composed from per-mode slices (`state.js:37-89`) — modes own their state shape. `FocusManager` correctly de-registers destroyed instances. The extraction of `core/initialization/`, `viewport.js`, and `storage.js` out of `main.js` was executed, not just planned.
+
+**What is wrong.** The contract exists only by convention:
+
+- **The instance is the architecture** (GF-05). `main.js:65-133` declares ~50 public fields; every layer reaches through `this.instance.*` for state, DOM nodes, LEDs, sibling modes, and zoom methods (HarmonicsMode alone: 105 references). Class methods are one-line forwarders to free functions that take the instance back (`main.js:203-252`) — the class is a namespace around a mutable bag.
+- **State has writers everywhere and owners nowhere** (GF-06, GF-08, GF-12, GF-13). Six-plus modules write `state.*` fields directly; 29 broadcast call sites decide individually whether listeners hear about it; `_clearGram` hand-resets 13 fields instead of rebuilding from `createInitialState`; the module-level `globalStateListeners` array attaches every globally-registered listener to every instance on the page.
+- **The dependency graph runs backwards** (GF-03, GF-09). `state.js` (a core leaf by intent) imports all four mode classes; `table.js` — nominally a component — owns zoom math, visible-range computation, and the axis engine, making it a hub that core and modes both import and putting it inside four cycles.
+- **Modes are not islands** (GF-10, GF-11). `MainUI` calls named mode methods; `BaseMode` carries ~20 hooks of which two (`renderCursor`, `getStateSnapshot`) are overridden by no subclass and several overrides are empty.
+
+None of this is fatal today — the tests pass and the component works. The cost is that every new feature must be threaded through an unbounded surface, and nothing in the mode layer can be tested without a live browser (see §5).
+
+## 4. Code quality & maintainability
+
+**What is good.** Zero TODO/FIXME debt. `symbols.js` is a model module: pure factory, documented contract, safe fallback, reused by three consumers. `harmonicSampling.js` has a documented purity contract and a bounded generation loop. The row-diffing table updates (both copies of them) correctly avoid DOM teardown. The storage layer's schema-version guard, fail-safe TTL expiry, and additive migration (`storage.js:185-230`) show real forward-compatibility thinking. `configuration.js` + `GramFrameAPI` fail loud with a styled per-table error indicator — the correct pattern the rest of the code should copy.
+
+**What is wrong.**
+
+- **Silent failure as policy** (GF-04, GF-16). `ModeFactory` returns a do-nothing `BaseMode` in production when a mode fails to construct — interaction dies with only a console warning; the localhost hostname check conflates "dev" with a deployment topology. The storage layer's bare `catch {}` blocks mean a student's annotations can fail to save with no signal. Test hooks (`__test__*`) ship on the production API (GF-23), and the API keeps two disagreeing instance registries (GF-24).
+- **Duplication with divergence.** Beyond coordinates: PanMode hand-rolls drag while three modes use `BaseDragHandler` — and those three each run a *second* manual drag machine for creation/placement gestures (GF-18); drag state is double-bookkept between handler and state tree "for backward compatibility" (GF-17); Doppler hit-testing repeats one comparison three times while `tolerance.js` helpers go unused (GF-19); the markers table and harmonics panel maintain the same diffing algorithm twice (GF-20).
+- **Dead weight** (GF-22). Three never-called DopplerMode methods, the deprecated `zoom.panMode` flag still in the published state type, a vestigial counter, a helper file imported by zero specs, and 15 modules with unused exports per `ts-unused-exports`.
+- **Hot-path waste** (GF-07, GF-15). Full-state JSON clone per mousemove; a dynamic `import()` with an empty catch inside the arrow-key handler.
+
+## 5. Testing strategy
+
+**What is good.** 147/147 tests pass on a clean checkout (1.7 min, 2 workers). `harmonic-sampling-unit.spec.js` is genuinely well-designed boundary testing. The `gram-frame-page.js` page object is a solid pattern with state-based waiting; `state-assertions.js` provides reusable structural validators. Behavioral storage coverage (23 tests incl. TTL, schema-version discard, storage-unavailable degradation) is thorough.
+
+**What is wrong.**
+
+- **Everything rides the browser** (GF-25). `playwright test` is the only runner; the pure math (doppler, tolerance, sampling, coordinates) has no fast lane. The 9 pure-JS sampling assertions boot Vite + Chromium. Adding unit tests is structurally discouraged — and §3 explains why: modes can't be constructed without faking the entire instance.
+- **The most fragile code is the least covered** (GF-26, GF-30). The two disabled `keyboard-focus` specs were the only behavioral coverage of arrow-key marker movement and multi-instance focus isolation — disabled without a comment, replaced by smoke tests. That is precisely where the divergent keyboard coordinate math (GF-01) hides. PanMode is the only mode with no dedicated spec; zoom clamping is untested.
+- **Flakiness is being managed, not fixed** (GF-27, GF-28). 142 `waitForTimeout` calls — some baked into the page object — with CI `retries: 2` absorbing the fallout. The good POM is used by 3 of 19 specs; the rest hand-roll selectors.
+- **Claimed coverage that doesn't exist** (GF-29). "Screenshot comparisons for UI consistency" appear in CLAUDE.md; the suite contains zero `toHaveScreenshot`/`toMatchSnapshot` calls.
+
+## 6. Implementation strategy & process
+
+**What is good.** The zero-runtime-dependency stance is real and appropriate for the `file://` field-deployment model; the standalone IIFE build with inlined CSS (vite.config.js) serves it well. The release pipeline validates semver, checks `version.js` consistency, asserts bundle size, and runs the full gate before publishing; PR previews deploy per-PR with cleanup. Unminified output (ADR-010) is a defensible field-debugging choice. The spec-kit workflow (`specs/154`–`158`) produces genuinely traceable feature records.
+
+**What is wrong.**
+
+- **The gate has holes** (GF-31, GF-32, GF-34). No ESLint at all; `strictNullChecks` and `noImplicitAny` disabled in the project's *only* type defense; CI never builds the standalone bundle that is the actual shipped artifact, tests chromium-only, and pins EOL Node 18 against `@types/node ^24`.
+- **Hygiene tooling is decorative** (GF-33). `madge`, `ts-unused-exports`, and `unimported` sit in devDependencies with no script or CI step — the 8 cycles and 15 dead-export modules they would have flagged went unnoticed.
+- **Friction that invites bypass** (GF-35, GF-37). Pre-push runs the full browser suite; `generate-version` dirties the tracked `src/utils/version.js` on every test/build run (observed twice during this audit).
+- **The repo carries its own scaffolding** (GF-36). ~750 KB of agent-process artifacts (`prompts/`, `Memory/`, `Memory_Bank.md`, `Implementation_Plan.md`), a committed Playwright report despite `.gitignore`, an `.obsidian/` vault, and the unreferenced `zoom-demonstrator/` prototype whose files shadow real module names.
+
+## 7. Documentation drift
+
+The docs are two-tier. **Accurate tier:** `Tech-Architecture.md` (four modes, correct file tree, correct axis-rendering attribution) and `Data-and-State-Guide.md` (correct state shape, zoom object, deep-copy semantics) — these should be canonical. README's storage/context section is also accurate and well-written.
+
+**Drifted tier** — the pattern is consistent: two real, completed refactors (three→four modes; monolith→modular main.js) updated the code and the new docs but not the old ones:
+
+- **CLAUDE.md** (GF-38): three modes claimed, phantom `src/rendering/axes.js` listed, ~15 real modules missing, nonexistent test files cited, nonexistent visual testing claimed. This is the file AI agents are told to trust.
+- **ADR-015** (GF-39): mandates viewBox-based zoom with "No Image Transforms"; the code keeps the viewBox fixed and resizes the image element — the rejected alternative is what shipped.
+- **ADR-011** (GF-40): every FeatureRenderer method name it documents is fictional.
+- **`Gram-Modes.md`** (GF-41): describes *two* modes. **`Testing-Strategy.md`** (GF-42): prescribes a Jest/80%-coverage regime that has never existed.
+- Mode-count drift replicates across README, ADR-008, and test helpers; ADR numbering skips 014 (GF-43).
+
+For a training-materials project whose docs are read by both new contributors and AI coding agents, stale ADRs are not cosmetic: they are actively wrong instructions.
+
+---
+
+## 8. Recommendations roadmap
+
+Sequenced so each step unblocks the next. Effort: S ≤ half day, M ≤ 3 days, L > 3 days.
+
+**Stage 1 — Stop the bleeding (all S).**
+1. Fail loud in `ModeFactory` — reuse the error-indicator pattern; drop the hostname check (GF-04).
+2. Surface storage save failures to the UI (GF-16).
+3. Fix or remove the knowingly-wrong `imageX/imageY` (GF-02).
+4. Remove listener leaks: bound handler refs + uninstall global keydown at zero instances (GF-14).
+5. Wire `madge --circular` and `ts-unused-exports` into CI as a ratchet: fail on *new* cycles/dead exports (GF-33).
+6. Un-track generated/foreign files: `playwright-report/`, `.obsidian/`, version churn (GF-36, GF-37).
+
+**Stage 2 — One coordinate pipeline (M).**
+7. Consolidate on `coordinateTransformations.js`; delete the keyboardControl privates, the events.js inline transform, and the cursors.js `convertToSVG`; port callers (GF-01, GF-21).
+8. Add Vitest as a dev-only unit lane (zero-runtime-dep stance unaffected) and land transform unit tests *with* the consolidation; move the sampling unit spec there (GF-25).
+9. Re-enable the keyboard-focus specs against the unified pipeline (GF-26).
+
+**Stage 3 — State discipline (M each).**
+10. Break the state⇄modes cycle: modes register initial-state slices via ModeFactory; single notification dispatcher with microtask batching; throttle mousemove broadcasts (GF-03, GF-07, GF-08).
+11. Replace `globalStateListeners` auto-copy with explicit per-instance subscription (GF-06).
+12. Rebuild `_clearGram` from `createInitialState` (GF-12).
+
+**Stage 4 — Split the hub, converge duplication (M each).**
+13. Split `table.js` into layout/axes/image-setup modules — the ExpandToggle cycle dissolves as a side effect (GF-09).
+14. Port PanMode to `BaseDragHandler`; extend it to cover creation/placement gestures; delete the double-bookkept drag state (GF-17, GF-18).
+15. Extract one row-diffing table component; adopt `tolerance.js` helpers in Doppler (GF-19, GF-20).
+
+**Stage 5 — Tighten the gate (S–M).**
+16. ESLint + CI step (GF-31); enable `strictNullChecks`/`noImplicitAny` with a staged burn-down (GF-32).
+17. CI: add `build:standalone`, bump Node, consider a WebKit smoke job (GF-34); slim pre-push to typecheck + unit lane (GF-35).
+18. Replace `waitForTimeout` with state-based waits, POM-ify remaining specs, then drop CI retries (GF-27, GF-28).
+
+**Stage 6 — Docs sweep (all S).**
+19. Regenerate CLAUDE.md's structure/mode sections (GF-38); rewrite ADR-015 and ADR-011 to match reality (GF-39, GF-40); fix or fold `Gram-Modes.md` and `Testing-Strategy.md` (GF-41, GF-42); one pass for the mode-count stragglers (GF-43); banner the completed refactoring doc (GF-44).
+
+The god-object itself (GF-05, L) is deliberately *not* an early stage: stages 2–4 shrink its surface organically, and a big-bang "introduce a store" refactor before the pipeline and cycles are fixed would churn every file at once.
+
+---
+
+## Appendix A — Method
+
+Evidence was gathered by running the toolchain on a clean checkout (`tsc --noEmit`: clean; full Playwright suite: 147/147 passing in 1.7 min; `madge --circular`: 8 cycles; `ts-unused-exports`: 15 modules; `unimported`: 1 file) and by three parallel deep-read passes (core/state layer; mode system/components/rendering; tests/process/docs), every claim carrying `file:line` evidence.
+
+## Appendix B — Independent review methodology
+
+Every finding in the [register](Findings-Register.md) was then adversarially verified by **independent reviewer agents running on a different Claude model (Opus) than the author**, each given only the bare claim and repository access — no access to the author's reasoning — and instructed to attempt refutation. Critical/High findings received three verifiers with distinct lenses (factual correctness; independent reproducibility; severity calibration) and required a 2-of-3 confirmation majority; Medium/Low findings received one verifier each. Verdicts, including refutations and severity adjustments, are recorded per-row in the register's **Verified** column; refuted findings are disclosed there rather than silently dropped.
+
+<!-- REVIEW-STATS: to be filled after verification -->

--- a/docs/analysis/Architecture-Analysis.md
+++ b/docs/analysis/Architecture-Analysis.md
@@ -8,18 +8,20 @@
 
 GramFrame is in better shape than most codebases of its history: the once-monolithic 2,100-line `main.js` has genuinely been refactored down to 562 lines, all 147 Playwright tests pass on a clean checkout, `tsc` typechecking is clean, TODO/FIXME debt is essentially zero, and several modules (`rendering/symbols.js`, `utils/harmonicSampling.js`, `core/storage.js`'s schema/TTL design, the release pipeline) are exemplary. The mode system's *concept* — four modes behind a `BaseMode` contract, instantiated by a factory, with `FeatureRenderer` as the cross-mode rendering seam — is sound.
 
-The audit's critical verdict is that **the boundaries drawn on the whiteboard do not exist in the code**. Every mode, component, and core module reaches freely through the `GramFrame` instance (347 accesses to `instance.state` across 19 files), state mutation and broadcast are scattered across 12 files, and `core/state.js` imports every mode class while every mode imports state back — 8 circular dependencies. The most dangerous concrete consequence is the coordinate pipeline: the screen→SVG→image→data transform exists in **four divergent implementations**, and the keyboard path uses different math than the mouse path under zoom/expand (GF-01). Meanwhile the verification layer has quietly eroded: null-safety typechecks are disabled, there is no linting, no unit-test lane, the multi-instance keyboard/focus specs are disabled without explanation, and a production failure mode exists where a broken mode silently degrades to a no-op (GF-04).
+The audit's critical verdict is that **the boundaries drawn on the whiteboard do not exist in the code**. Every mode, component, and core module reaches freely through the `GramFrame` instance (347 accesses to `instance.state` across 19 files), state mutation and broadcast are scattered across 12 files, and `core/state.js` imports every mode class while every mode imports state back — 8 circular dependencies. The starkest expression is the coordinate pipeline: the screen→SVG→image→data transform exists in **four separate implementations**. Adversarial verification showed they are *currently* mutually consistent — the keyboard path correctly compensates for zoom, refuting this audit's own initial "Critical" rating (GF-01ᴿ, see register §5) — but that consistency is an unpinned, untested equivalence spread across four files, exactly where the next regression hides. Meanwhile the verification layer has quietly eroded: null-safety typechecks are disabled in the project's only type gate (GF-32, the sole finding to retain High severity after review), there is no linting, no unit-test lane, the arrow-key movement specs are disabled without explanation, and a production failure mode exists where a broken mode silently degrades to a no-op (GF-04).
+
+An honest headline from the independent review: no finding survived verification at Critical severity, and only one at High. The codebase *works* — what the register documents is not active breakage but accumulated rot that raises the cost and risk of every future change.
 
 Documentation splits into two tiers: `Tech-Architecture.md` and `Data-and-State-Guide.md` are accurate and current, but CLAUDE.md, README, `Gram-Modes.md`, and several accepted ADRs describe a three-mode (or two-mode) system from an earlier era — and ADR-015 describes a zoom design that is the opposite of what the code does (GF-39).
 
-### Top five risks
+### Top five risks (post-verification)
 
 | # | Risk | Findings |
 |---|------|----------|
-| 1 | Four divergent coordinate-transform implementations; keyboard vs mouse math disagrees under zoom/expand | GF-01, GF-02, GF-21 |
-| 2 | Silent production degradation: mode-construction failure yields a no-op spectrogram; storage failures swallow annotation loss | GF-04, GF-16 |
-| 3 | No enforced boundaries: god-object instance + state⇄modes import cycles + diffuse mutation/broadcast make every change a whole-system change | GF-03, GF-05, GF-06, GF-08 |
-| 4 | Verification erosion: null checks off, no lint, no unit lane, keyboard/focus coverage disabled, 142 fixed sleeps masked by CI retries | GF-25–GF-27, GF-31, GF-32 |
+| 1 | Verification erosion: null checks off in the only type gate, no lint, no unit lane, arrow-key coverage disabled, 142 fixed sleeps masked by CI retries | GF-32 (High), GF-25–GF-27, GF-31 |
+| 2 | Four coordinate-transform implementations whose consistency is unpinned by any test — currently correct, one edit from divergence | GF-01ᴿ, GF-02 |
+| 3 | No enforced boundaries: god-object instance + state⇄modes import cycles + diffuse mutation/broadcast make every change a whole-system change | GF-03, GF-05, GF-08, GF-09 |
+| 4 | Silent-failure policy: mode-construction failure degrades to a no-op spectrogram; storage save failures are invisible | GF-04, GF-16 |
 | 5 | Doc drift misleading humans and AI agents alike: CLAUDE.md points at phantom files; two ADRs describe fictional designs | GF-38–GF-43 |
 
 ---
@@ -113,7 +115,7 @@ flowchart TD
     table -.-> expand
     table -.-> state
 
-    linkStyle 30,31,32,33,34,35,36,37,38,39,40 stroke:#d33,stroke-width:2px,stroke-dasharray:5
+    linkStyle 31,32,33,34,35,36,37,38,39,40,41 stroke:#d33,stroke-width:2px,stroke-dasharray:5
 ```
 
 The cycles decompose into two knots (GF-03, GF-09):
@@ -206,7 +208,7 @@ flowchart TD
     B1 -->|"doppler committed curve"| E2
 ```
 
-Path 2 (`coordinateTransformations.js`) is the well-designed one — it derives geometry from the live image element, which is exactly why markers stay locked to data coordinates across zoom+expand. Paths 1, 3, and 4 each re-derive the math differently; path 3 diverges from path 2 precisely when zoomed or expanded, and path 4 makes the Doppler live preview disagree with the committed curve under zoom (GF-01, GF-02, GF-21). **Consolidating on path 2 and deleting the others is the single highest-value refactor in this audit.**
+Path 2 (`coordinateTransformations.js`) is the well-designed one — it derives geometry from the live image element, which is exactly why markers stay locked to data coordinates across zoom+expand. Paths 1, 3, and 4 each re-derive the math independently. Independent verification established that path 3 *does* currently agree with path 2 — the keyboard handler divides its increment by the zoom level and its round-trip transform cancels the position offset, so arrow-key movement matches the mouse pipeline at any zoom/expand (this refuted the audit's initial claim of an active divergence bug; see register §5). Path 4's non-zoom-aware branch turned out to be dead code (GF-21ᴿ). The verified problem is therefore fragility, not breakage: four independent derivations of the same math, whose mutual consistency depends on undocumented compensations in each and is pinned by no test. The `imageX/imageY` fields published in state are still genuinely wrong per their documented contract (GF-02). **Consolidating on path 2, deleting the others, and locking the transform behavior with unit tests remains the highest-value refactor in this audit — as insurance, not as a bug fix.**
 
 ---
 
@@ -241,7 +243,7 @@ None of this is fatal today — the tests pass and the component works. The cost
 **What is wrong.**
 
 - **Everything rides the browser** (GF-25). `playwright test` is the only runner; the pure math (doppler, tolerance, sampling, coordinates) has no fast lane. The 9 pure-JS sampling assertions boot Vite + Chromium. Adding unit tests is structurally discouraged — and §3 explains why: modes can't be constructed without faking the entire instance.
-- **The most fragile code is the least covered** (GF-26, GF-30). The two disabled `keyboard-focus` specs were the only behavioral coverage of arrow-key marker movement and multi-instance focus isolation — disabled without a comment, replaced by smoke tests. That is precisely where the divergent keyboard coordinate math (GF-01) hides. PanMode is the only mode with no dedicated spec; zoom clamping is untested.
+- **The most fragile code is the least covered** (GF-26ᴺ, GF-30). The two disabled `keyboard-focus` specs carried the only behavioral assertions that arrow keys actually move a marker — disabled without a comment, replaced by smoke tests. (Verification narrowed the original claim: focus *isolation* is still covered by active specs; the movement assertions are what was lost.) That lost coverage sits exactly on the keyboard coordinate path whose consistency with the mouse pipeline is unpinned (GF-01ᴿ). PanMode is the only mode with no dedicated spec; zoom clamping is untested.
 - **Flakiness is being managed, not fixed** (GF-27, GF-28). 142 `waitForTimeout` calls — some baked into the page object — with CI `retries: 2` absorbing the fallout. The good POM is used by 3 of 19 specs; the rest hand-roll selectors.
 - **Claimed coverage that doesn't exist** (GF-29). "Screenshot comparisons for UI consistency" appear in CLAUDE.md; the suite contains zero `toHaveScreenshot`/`toMatchSnapshot` calls.
 
@@ -285,9 +287,9 @@ Sequenced so each step unblocks the next. Effort: S ≤ half day, M ≤ 3 days, 
 6. Un-track generated/foreign files: `playwright-report/`, `.obsidian/`, version churn (GF-36, GF-37).
 
 **Stage 2 — One coordinate pipeline (M).**
-7. Consolidate on `coordinateTransformations.js`; delete the keyboardControl privates, the events.js inline transform, and the cursors.js `convertToSVG`; port callers (GF-01, GF-21).
+7. Consolidate on `coordinateTransformations.js`; delete the keyboardControl privates, the events.js inline transform, and the dead cursors.js preview path; port callers (GF-01ᴿ, GF-21ᴿ). Verified consistent today — this stage pins that consistency before it breaks.
 8. Add Vitest as a dev-only unit lane (zero-runtime-dep stance unaffected) and land transform unit tests *with* the consolidation; move the sampling unit spec there (GF-25).
-9. Re-enable the keyboard-focus specs against the unified pipeline (GF-26).
+9. Restore arrow-key movement assertions against the unified pipeline (GF-26ᴺ).
 
 **Stage 3 — State discipline (M each).**
 10. Break the state⇄modes cycle: modes register initial-state slices via ModeFactory; single notification dispatcher with microtask batching; throttle mousemove broadcasts (GF-03, GF-07, GF-08).
@@ -319,4 +321,4 @@ Evidence was gathered by running the toolchain on a clean checkout (`tsc --noEmi
 
 Every finding in the [register](Findings-Register.md) was then adversarially verified by **independent reviewer agents running on a different Claude model (Opus) than the author**, each given only the bare claim and repository access — no access to the author's reasoning — and instructed to attempt refutation. Critical/High findings received three verifiers with distinct lenses (factual correctness; independent reproducibility; severity calibration) and required a 2-of-3 confirmation majority; Medium/Low findings received one verifier each. Verdicts, including refutations and severity adjustments, are recorded per-row in the register's **Verified** column; refuted findings are disclosed there rather than silently dropped.
 
-<!-- REVIEW-STATS: to be filled after verification -->
+**Review statistics.** 62 verifier agents ran (57 lens-verifiers over 19 Critical/High findings; 5 batch verifiers over 25 Medium/Low findings). Outcomes: 1 Critical/High finding refuted outright (GF-01 — the claimed keyboard-vs-mouse divergence does not occur), 1 narrowed (GF-26), 17 factually confirmed; the severity lens upheld the author's rating on 1 of them (GF-32) and downgraded 16, mostly High→Medium under the rubric's "materially slows or endangers feature work" bar. Of the Medium/Low findings, 23 were confirmed (2 with evidence corrections applied) and 2 were refuted as stated and reframed to Low (GF-21, GF-28). Post-review distribution: **0 Critical, 1 High, 35 Medium, 8 Low.** The author's original ratings over-weighted severity in 20 of 44 findings — a bias the independent pass existed to catch, and did.

--- a/docs/analysis/Findings-Register.md
+++ b/docs/analysis/Findings-Register.md
@@ -1,0 +1,108 @@
+# Findings Register — GramFrame Architecture & Implementation Audit
+
+**Date:** 2026-07-23 · **Companion:** [Architecture-Analysis.md](Architecture-Analysis.md)
+
+Every row was adversarially verified by independent reviewer agents running on a different Claude model (Opus) than the author, given only the claim and repo access and instructed to refute it. Critical/High claims: three verifiers (correctness / reproducibility / severity lenses), 2-of-3 majority required. Medium/Low claims: one verifier. The **Verified** column records the outcome; severities below are the *post-review* severities (the severity lens's corrections were applied). Refuted findings are retained in §5 with their refutations — not silently dropped.
+
+**Severity rubric:** Critical = active correctness/data-loss risk · High = materially slows or endangers feature work · Medium = friction/rot · Low = polish.
+**Effort:** S ≤ half day · M ≤ 3 days · L > 3 days.
+
+Review outcome in brief: of 19 findings originally rated Critical/High, 17 were factually confirmed but 16 of those had their severity downgraded (mostly to Medium) under the rubric, one was refuted outright (GF-01), and one was narrowed (GF-26). Of 25 Medium/Low findings, 23 were confirmed (two with minor evidence corrections) and two were refuted as stated (GF-21, GF-28). **Post-review distribution: 0 Critical, 1 High, 35 Medium, 8 Low.**
+
+---
+
+## 1. High
+
+| ID | Dim | Finding | Evidence | Recommendation | Effort | Verified |
+|----|-----|---------|----------|----------------|--------|----------|
+| GF-32 | Process | Type gate gutted: `strict: true` but `strictNullChecks`, `noImplicitAny`, and `strictPropertyInitialization` disabled — in DOM-heavy code full of nullable `querySelector`/`boundingBox` returns, and JSDoc+tsc is the project's only type defense (ADR-007) | `tsconfig.json:6-11` | Re-enable per-flag with a staged burn-down of resulting errors | M | CONFIRMED 2/3 (severity: PLAUSIBLE) |
+
+## 2. Medium
+
+### Architecture & module boundaries
+
+| ID | Finding | Evidence | Recommendation | Effort | Verified |
+|----|---------|----------|----------------|--------|----------|
+| GF-01ᴿ | Coordinate pipeline implemented 4× (`utils/coordinates.js`; `utils/coordinateTransformations.js`; private funcs in `keyboardControl.js`; inline in `events.js`) — *reframed after refutation:* the implementations are currently mutually consistent (keyboard compensates zoom via `increment/zoomLevel` + offset-cancelling round-trip), so this is duplication/fragility, not an active bug; any future change to one path can silently break the equivalence | `keyboardControl.js:104,303-354`, `events.js:19-72`, `coordinateTransformations.js` | Consolidate on `coordinateTransformations.js`; delete the other paths; pin the equivalence with unit tests | M | Original Critical claim REFUTED 0/3; duplication itself verified — reframed at reviewer-assigned severity |
+| GF-02 | `events.js:164-165` writes SVG coords into `cursorPosition.imageX/imageY` (comment admits it); `types.js:61-62` documents them as image-relative — published state contradicts its own contract, though no in-repo consumer reads the fields | `events.js:51-52,71,156,164-165`, `types.js:61-62,516-517` | One-line fix: the correct values are already computed and discarded | S | CONFIRMED 2/3, severity High→Medium |
+| GF-03 | Hard import cycle `state.js` ⇄ all four modes (state imports mode classes for initial state; modes import `notifyStateListeners` back, 13 self-broadcast sites); 8 madge cycles, 7 involving this boundary. Benign at runtime today (hoisted function + static methods) but load-order-fragile coupling | `state.js:10-13,20-31`, mode files | Modes register state slices via ModeFactory; single notification dispatcher in core | M | CONFIRMED 2/3, severity High→Medium |
+| GF-04 | `ModeFactory` throws on `localhost` but in production console.warns and returns a no-op `BaseMode` — a mode-construction failure silently kills interaction. Low-probability (dev-caught bug class), but the swallowed error hinders field diagnosis | `ModeFactory.js:47-54`, `BaseMode.js:36-87` | Fail loud via the `.gramframe-error-indicator` pattern (`GramFrameAPI.js:249-290`); drop the hostname check | S | CONFIRMED 2/3, severity Critical→Medium |
+| GF-05 | God-object: ~50 public fields on the instance (`main.js:65-133`); `instance.state` accessed 347× across 19 files; class methods are forwarders to free functions taking the instance back — no encapsulation boundary | `main.js:65-133,203-252` | Carve seams incrementally (stages 2–4 of the roadmap shrink the surface); no big-bang store | L | CONFIRMED 2/3, severity High→Medium |
+| GF-07 | Full-state `JSON.parse(JSON.stringify)` clone per listener notification, fired on every mousemove and drag frame; cost scales with annotation count (imperceptible at realistic counts, hence Medium) | `state.js:112`, `events.js:186`, `AnalysisMode.js:77`, `DopplerMode.js:244` | Throttle mousemove broadcasts; clone only for external listeners | M | CONFIRMED 2/3, severity High→Medium |
+| GF-08 | Broadcast diffusion: ~29 `notifyStateListeners` sites across 12 files, unbatched — one gesture fires several clones; some mutations never notify | `main.js:492`, `viewport.js:65,83-85`, `main.js:323-350` | Single choke-point dispatch with microtask batching | M | CONFIRMED 1/1 |
+| GF-09 | `table.js` (703 lines) is a misnamed hub owning scaffold, image loading, layout, zoom math, visible-range computation, and the axis engine; imported by modes/viewport for non-table exports; in 4 of 8 cycles incl. mutual `ExpandToggle` cycle | `table.js:12,252-306,345-391,465-665`, `ExpandToggle.js:11` | Split into layout/axes/imageSetup; the cycle dissolves with the split | M | CONFIRMED 2/3, severity High→Medium |
+| GF-10 | `BaseMode` interface too wide: ~20 hooks; `renderCursor`/`getStateSnapshot` overridden by no subclass; several subclass overrides are empty no-ops | `BaseMode.js`, `FeatureRenderer.js:82-90`, `AnalysisMode.js:388-391,687-688,704-705` | Prune to the hooks modes actually implement | S | CONFIRMED 1/1 |
+| GF-11 | Modes are not islands: `MainUI` calls named mode methods; `FeatureRenderer` reaches into named modes; PanMode calls `instance._zoomIn/_zoomOut` | `MainUI.js:204-222`, `FeatureRenderer.js:32-44`, `PanMode.js:234,240` | Capability interfaces instead of named-mode reach-ins | M | CONFIRMED 1/1 |
+| GF-12 | `_clearGram` hand-resets ~13 nested fields instead of rebuilding from `createInitialState` — init/clear drift is inevitable | `main.js:278-296` | Rebuild from `createInitialState()`, preserving config/imageDetails | S | CONFIRMED 1/1 |
+| GF-13 | Initialization is a fixed 10-call order-sensitive sequence with implicit dependencies and double-nulling between setup modules | `main.js:152-161`, `DOMSetup.js:88-93` | Make dependencies explicit (return values over instance mutation) | M | CONFIRMED 1/1 |
+| GF-15 | Dynamic `import()` in the arrow-key hot path with empty `.catch(() => {})` | `keyboardControl.js:275-279` | Static import; surface errors | S | CONFIRMED 1/1 |
+
+### Code quality & maintainability
+
+| ID | Finding | Evidence | Recommendation | Effort | Verified |
+|----|---------|----------|----------------|--------|----------|
+| GF-16 | Storage layer swallows all errors with bare `catch {}` returning booleans callers ignore — save failures (quota, corruption) are silent. Impact bounded: persistence is best-effort and current-session work survives | `storage.js:125-127,203-205,242-245,262-264`, `main.js:372` | Surface a UI signal on save failure | S | CONFIRMED 2/3, severity High→Medium |
+| GF-17 | Drag state double-bookkept: `BaseDragHandler` authoritative fields mirrored into `state.analysis.*` ("for backward compatibility") and `state.dragState.*` | `BaseDragHandler.js:51-57`, `AnalysisMode.js:37-39,401-406`, `HarmonicsMode.js:72-77` | Single owner; read-only projection for listeners | S | CONFIRMED 1/1 |
+| GF-18 | Drag fragmentation: PanMode hand-rolls drag; Harmonics creation and Doppler placement each run a second manual drag machine beside their `BaseDragHandler` | `PanMode.js:17-21,57-134`, `HarmonicsMode.js:154,187-213`, `DopplerMode.js:257-311` | Extend `BaseDragHandler` for creation/placement; port PanMode | M | CONFIRMED 1/1 |
+| GF-19 | Copy-paste hit-testing ×3 in Doppler while `tolerance.js` helpers go unused | `DopplerMode.js:62-99,162-193`, `tolerance.js:91-144` | Use the tolerance helpers | S | CONFIRMED 1/1 |
+| GF-20 | Same row-diffing table engine maintained twice (markers table vs harmonics panel), incl. duplicated click-to-select logic | `AnalysisMode.js:536-674,611-624`, `HarmonicPanel.js:59-155,207-220` | Extract one diffing-table component | M | CONFIRMED 1/1 |
+| GF-22 | Dead code: 3 never-called DopplerMode methods; deprecated `zoom.panMode` in state + public type; vestigial `markersPlaced`; `visual-helpers.js` unused; 15 modules with unused exports | `DopplerMode.js:158-196,504-528,609-612,478,413`, `state.js:79`, `types.js:153` | Delete; ratchet with `ts-unused-exports` in CI | S | CONFIRMED 1/1 |
+| GF-24 | API keeps two disagreeing instance registries (DOM scan vs `_instances`) — methods can operate on different instance sets | `GramFrameAPI.js:108-111,164-167,184,196,211-214,228` | Single registry | S | CONFIRMED 1/1 |
+
+### Testing strategy
+
+| ID | Finding | Evidence | Recommendation | Effort | Verified |
+|----|---------|----------|----------------|--------|----------|
+| GF-25 | No unit-test lane: Playwright is the only runner; pure math validated only through browser E2E; the 9 pure-JS sampling assertions boot Vite+Chromium | `package.json`, `tests/harmonic-sampling-unit.spec.js:1` | Add Vitest (dev-only; zero-runtime-dep stance unaffected) | M | CONFIRMED 2/3, severity High→Medium |
+| GF-26ᴺ | *Narrowed:* arrow-key marker-movement behavioral coverage was lost when the two `keyboard-focus` specs were disabled without explanation; FocusManager itself retains active coverage (`focus-simple.spec.js`, `tab-navigation.spec.js`), so the gap is `keyboardControl.js`'s movement path — where the transform duplication (GF-01ᴿ) lives | `tests/keyboard-focus*.spec.js.disabled`, `tests/keyboard-simple.spec.js:11-83` | Restore an arrow-key movement assertion spec | M | Correctness REFUTED as stated / repro CONFIRMED — narrowed, High→Medium |
+| GF-27 | 142 `waitForTimeout` occurrences incl. in the page object; CI `retries: 2` masks flakiness | `gram-frame-page.js:270,413,426`, `playwright.config.ts:11` | State-based waits; drop retries once stable | M | CONFIRMED 2/3, severity High→Medium |
+| GF-29 | Visual regression testing claimed (CLAUDE.md:126) but nonexistent: zero snapshot assertions; `visual-helpers.js` reachable only transitively via `fixtures.js` and never used by any spec | suite grep; `playwright.config.ts:20` | Adopt `toHaveScreenshot` for key renders or delete claim + helper | S | CONFIRMED 1/1 (evidence corrected) |
+| GF-30 | PanMode is the only mode with no dedicated spec; no zoom/viewport spec (clamping untested); API tested mainly via `__test__` hooks | `tests/` inventory, `viewport.js:21,31` | Add pan + zoom specs; test the public API surface | M | CONFIRMED 1/1 |
+
+### Implementation strategy & process
+
+| ID | Finding | Evidence | Recommendation | Effort | Verified |
+|----|---------|----------|----------------|--------|----------|
+| GF-31 | No linting anywhere: no ESLint config, script, or CI step (`.gitignore` even lists `.eslintcache`) | `package.json:5-14`, `.github/workflows/` | ESLint flat config + CI step | S | CONFIRMED 2/3, severity High→Medium |
+| GF-33 | `madge`, `ts-unused-exports`, `unimported` installed but never wired to any script or CI — the 8 cycles and 15 dead-export modules went unreported | `package.json:19-22` | `yarn hygiene` script + CI ratchet on new cycles/dead exports | S | CONFIRMED 1/1 |
+| GF-34 | CI never builds the standalone bundle (the shipped artifact) on the test path; chromium-only; Node 18 (EOL) vs `@types/node ^24` | `.github/workflows/test.yml`, `package.json:17` | Add `build:standalone` to test.yml; bump Node; webkit smoke job | S | CONFIRMED 1/1 |
+| GF-36 | Repo hygiene: tracked `playwright-report/index.html` (contradicting `.gitignore`), `.obsidian/` vault, `Memory/` + 61 KB `Memory_Bank.md` + `Implementation_Plan.md`, 404 KB `prompts/`, 276 KB unreferenced `zoom-demonstrator/` shadowing real module names | `git ls-files`, `.gitignore` | Untrack/archive; fix force-adds | S | CONFIRMED 1/1 |
+
+### Documentation drift
+
+| ID | Finding | Evidence | Recommendation | Effort | Verified |
+|----|---------|----------|----------------|--------|----------|
+| GF-38 | CLAUDE.md materially stale: three modes claimed (four exist); phantom `src/rendering/axes.js`; ~15 real modules missing from File Structure; nonexistent test files cited; nonexistent visual testing claimed | `CLAUDE.md:26,31,52,89,126,139` vs `src/` tree | Regenerate structure + mode sections; audit remaining claims | S | CONFIRMED 2/3, severity High→Medium |
+| GF-39 | ADR-015 (accepted) mandates viewBox-based zoom, "No Image Transforms"; implementation keeps viewBox fixed and resizes the image element — the rejected approach is what shipped | `ADR-015:33-45` vs `table.js:219,252-306` | Rewrite or supersede ADR-015 | S | CONFIRMED 2/3, severity High→Medium |
+| GF-40 | ADR-011 documents a fictional FeatureRenderer API — every listed method name is nonexistent | `ADR-011:37-52` vs `FeatureRenderer.js:10-92` | Correct the ADR | S | CONFIRMED 1/1 |
+| GF-41 | `Gram-Modes.md` describes *two* modes (Analysis, Doppler) — omits Harmonics and Pan | `docs/Gram-Modes.md:3` | Rewrite or fold into Tech-Architecture.md | S | CONFIRMED 2/3, severity High→Medium |
+| GF-42 | `Testing-Strategy.md` prescribes Jest + 80% coverage + "all functions must have unit tests" — none of it exists or ever ran | `docs/Testing-Strategy.md:97-117`, `package.json` | Rewrite to describe the real (and labeled-target) strategy | S | CONFIRMED 2/3, severity High→Medium |
+| GF-43 | Mode-count drift replicated: README (line 7), ADR-008, test-helper mode maps omit pan; ADR numbering skips 014; ADR-004 example code contradicts implementation | `README.md:7`, `ADR-008:7,58-61`, `state-assertions.js:130,150`, `ADR-004:42-51` | One sweep fixing the mode list everywhere; note the ADR-014 gap | S | CONFIRMED 1/1 (line ref corrected) |
+
+## 3. Low
+
+| ID | Dim | Finding | Evidence | Recommendation | Effort | Verified |
+|----|-----|---------|----------|----------------|--------|----------|
+| GF-06 | Arch | Module-level `globalStateListeners` auto-copied into every instance; removal must scrub two registries. Reviewer: working, documented global-broadcast design — maintenance surface, not hazard | `state.js:95`, `EventBindings.js:42-46`, `GramFrameAPI.js:150-176` | Explicit pub/sub with per-instance filtering | M | CONFIRMED 2/3, severity High→Low |
+| GF-14 | Lifecycle | Global keydown handler deliberately never removed; anonymous SVG/mode-button listeners unremovable — but destroy() detaches the container, so instances remain garbage-collectable; one document-level handler genuinely persists | `keyboardControl.js:37-56`, `events.js:82-105,115-122,270-284` | Bound refs + uninstall keydown at zero instances | S | CONFIRMED 1/3 + PLAUSIBLE, severity High→Low |
+| GF-21ᴿ | Quality | *Reframed after refutation:* the Doppler preview path (`cursors.js` `drawDopplerPreview` + `DopplerMode.renderPreviewCurve`) is duplicated/dead code overlapping GF-22 — not a live preview-divergence bug | `cursors.js:69-98`, `DopplerMode.js:609-612,706-712` | Delete the dead path with the GF-22 sweep | S | REFUTED as stated — reframed to Low |
+| GF-23 | Quality | `__test__*` methods always on the production API — expose only re-notify + instance refs (no sensitive data), hence polish | `GramFrameAPI.js:209-240` | Strip or gate behind a debug flag | S | CONFIRMED 1/1, severity → Low |
+| GF-28ᴿ | Testing | *Reframed after refutation:* minor selector duplication in ~6–8 small specs; the "only 3 of 19 specs use the POM" quantification was wrong | `tests/` imports | POM-ify the small specs opportunistically | S | REFUTED as stated — reframed to Low |
+| GF-35 | Process | Pre-push runs the full Playwright suite — workflow-ergonomics concern (bypass risk inferred, not observed) | `.husky/pre-push` | Pre-push = typecheck + unit lane once GF-25 lands | S | CONFIRMED 1/1, severity → Low |
+| GF-37 | Process | `generate-version` mutates tracked `src/utils/version.js` on every test/build, dirtying the tree (observed twice during this audit) | `scripts/generate-version.js`, `package.json:8,11` | Generate to an untracked file or inject at build | S | CONFIRMED 1/1 |
+| GF-44 | Docs | Completed-refactor planning doc presented as current (describes 2,100-line main.js; actual 562) | `docs/refactoring/main-js-dependency-analysis.md:5,8` | Add a "historical — completed" banner | S | CONFIRMED 1/1 |
+
+## 4. Strengths (verified in passing, no action needed)
+
+Credit where due: `rendering/symbols.js` (pure, documented, single source of truth), `utils/harmonicSampling.js` (+ its genuinely good boundary tests), `core/storage.js` schema-versioning/TTL design, `FeatureRenderer` as a clean rendering seam, per-listener error isolation in `notifyStateListeners`, the fail-loud config-table error indicator, `ExpandToggle`'s two-pass scrollbar-aware layout, the release/PR-preview pipelines, `Tech-Architecture.md` and `Data-and-State-Guide.md` as accurate canonical docs, and zero TODO/FIXME debt.
+
+## 5. Refutation disclosures
+
+The adversarial review refuted or materially narrowed four findings; per the audit's methodology they are disclosed here rather than silently dropped:
+
+- **GF-01 (was Critical, 0/3):** the claimed keyboard-vs-mouse divergence under zoom/expand does not occur — `keyboardControl.js:104` divides the increment by zoom level, and the data→SVG→data round trip cancels the position offset, yielding exactly `baseIncrement` rendered pixels per keypress at any zoom/expand, consistent with the mouse pipeline. The 4-way duplication stands as a Medium maintainability finding (GF-01ᴿ).
+- **GF-26 (correctness lens refuted):** FocusManager focus-isolation coverage exists in active specs; only the arrow-key movement assertions were lost. Narrowed accordingly (GF-26ᴺ).
+- **GF-21:** the "preview diverges under zoom" mechanism is dead code, not a live bug path. Reframed to Low (GF-21ᴿ).
+- **GF-28:** the POM-adoption count was wrong; actual duplication is limited to ~6–8 small specs. Reframed to Low (GF-28ᴿ).
+
+Two additional evidence corrections from reviewers were applied in place: GF-29 (`visual-helpers.js` is transitively imported but unused) and GF-43 (README mode list is line 7, not 9).


### PR DESCRIPTION
## Summary

Adds a critical health-check audit of the GramFrame codebase under `docs/analysis/`:

- **`Architecture-Analysis.md`** — narrative report covering five dimensions (architecture & module boundaries, code quality & maintainability, testing strategy, implementation strategy & process, documentation drift), with Mermaid diagrams of the module dependency graph (8 circular dependencies highlighted), the mode-switch lifecycle, state flow, and the coordinate-transform pipeline, plus a six-stage sequenced remediation roadmap with effort estimates.
- **`Findings-Register.md`** *(following commit)* — ranked findings table (ID / dimension / severity / evidence / recommendation / effort), each row self-contained enough to become a GitHub issue.

## Evidence base

- Toolchain run on a clean checkout: `tsc --noEmit` clean; full Playwright suite **147/147 passing**; `madge --circular` (8 cycles); `ts-unused-exports` (15 modules); `unimported`.
- Three parallel deep-read passes over core/state, mode system/components/rendering, and tests/process/docs — every claim cited as `file:line`.

## Independent verification

Every finding is being adversarially verified by independent reviewer agents on a different Claude model (Opus) than the author, with no access to the author's reasoning. Critical/High findings get three verifiers (correctness / reproducibility / severity lenses, 2-of-3 majority required); Medium/Low get one each. Verdicts land in the register's **Verified** column; refuted findings are disclosed, not dropped. The register commit lands when that pass completes.

## Notes

- Documentation-only change: no source, test, or build files are modified.
- The initial all-fail test run was an audit-container browser mismatch (Playwright 1.54.1 vs pre-installed Chromium), resolved in the environment — not a repo issue; the suite is genuinely green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XH6jjJkPjBG7i7FSBXtwDD

---
_Generated by [Claude Code](https://claude.ai/code/session_01XH6jjJkPjBG7i7FSBXtwDD)_