### PR TITLE
docs: SpecKit specs for issue #198 review feedback

### DIFF
--- a/specs/159-harmonic-pin-labels/spec.md
+++ b/specs/159-harmonic-pin-labels/spec.md
@@ -1,0 +1,207 @@
+# Feature Specification: Show All Harmonic Pins, Label Only the Major Subset
+
+**Feature Branch**: `159-harmonic-pin-labels`  
+**Created**: 2026-07-24  
+**Status**: Draft  
+**Input**: GH issue #198 (Review feedback) — bullets 1 & 2: "For harmonics, show all pins, but infrequent labels" and "Move harmonic label vertically above symbol/pin".
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  Background: A "harmonic set" places a series of vertical "pins" (one per
+  harmonic, at n × spacing). A prior feature (spec 158) kept dense sets legible
+  by SAMPLING pins — drawing only every Nth pin (default max 25) and dropping the
+  rest entirely (line + label + symbol). Review feedback is that dropping the
+  lines loses information analysts need: they want to see the full harmonic
+  structure. This feature keeps the sampling idea but applies it only to labels
+  and symbols, while every pin LINE is drawn.
+-->
+
+### User Story 1 - See every harmonic pin, even at high density (Priority: P1)
+
+An analyst places a harmonic set with a small spacing over a wide frequency span.
+This would produce hundreds of pins. Today the overlay thins the set down to a
+sampled subset and draws only those, so the analyst cannot see the full harmonic
+structure. Instead, the analyst now sees **every** pin line drawn — even where
+they crowd together into a near-solid block of colour — because the complete
+harmonic structure is itself the information the analyst is reading. Only the
+number labels and symbols are thinned, so the overlay stays readable without
+hiding any pins.
+
+**Why this priority**: This is the core correction requested in the review. The
+current behaviour discards pin lines that analysts rely on. Drawing all pins
+while thinning only the labels/symbols restores the lost information and is
+independently demonstrable on its own.
+
+**Independent Test**: Add a harmonic set whose spacing would place far more than
+the label limit across the visible span, and confirm that a pin line is drawn for
+every harmonic in the visible span (no lines are dropped), while only a bounded
+subset of pins carry a number label and symbol.
+
+**Acceptance Scenarios**:
+
+1. **Given** a harmonic set whose pins across the visible frequency span number
+   more than the label limit, **When** the overlay renders, **Then** a pin line
+   is drawn for every harmonic in the visible span (none are dropped), even if
+   the lines visually merge into a solid block.
+2. **Given** that same dense harmonic set, **When** the overlay renders, **Then**
+   number labels and symbols are drawn only on a thinned "major" subset of the
+   pins, at most the label limit (default 25).
+3. **Given** a harmonic set whose pins across the visible span already number at
+   or below the label limit, **When** the overlay renders, **Then** every pin is
+   drawn AND every pin carries a label and symbol (no thinning of labels).
+4. **Given** any dense overlay, **When** the analyst zooms in so fewer pins are in
+   view, **Then** more pins gain labels/symbols (down to all pins labelled once
+   the count drops to or below the limit); zooming out or panning to a wider span
+   thins the labels/symbols again.
+5. **Given** a thinned overlay, **When** the labels/symbols are sampled, **Then**
+   they fall on a regular, predictable step (every Nth pin) rather than an
+   arbitrary selection, and each drawn label matches an actual pin's harmonic
+   number.
+
+---
+
+### User Story 2 - Read labels clearly above the pins (Priority: P2)
+
+With every pin now drawn, the pins sit close together and the current label
+position — offset to the top-right of each pin's line, just beneath the symbol —
+is easily obscured by neighbouring pins. Instead, each labelled pin shows its
+number label **centred horizontally above its symbol**, stacked vertically over
+the pin (label on top, then symbol, then the pin line). This vertical stack keeps
+the label clear of adjacent pins and clear of the pin's own line.
+
+**Why this priority**: This directly follows Story 1 — once all pins are drawn,
+the old top-right label position is prone to being covered. Repositioning the
+label above the symbol keeps the thinned labels readable, which is the point of
+thinning them. It has value only in combination with Story 1, so it is P2.
+
+**Independent Test**: Display a labelled pin and confirm its number label is
+centred horizontally on the pin line and rendered above the symbol (not to the
+right of the line), with the vertical order label → symbol → pin line.
+
+**Acceptance Scenarios**:
+
+1. **Given** a labelled pin, **When** the overlay renders, **Then** the pin's
+   number label is horizontally centred on the pin's vertical line.
+2. **Given** a labelled pin with a symbol, **When** the overlay renders, **Then**
+   the label sits above the symbol, which sits above the top of the pin line
+   (top-to-bottom order: label, symbol, line).
+3. **Given** a labelled pin whose stack would extend above the top edge of the
+   spectrogram image, **When** the overlay renders, **Then** the label and symbol
+   are kept within the visible area and remain legible.
+
+---
+
+### Edge Cases
+
+- **Extremely dense set (e.g. 0.5 Hz over a wide span)**: every pin line is drawn
+  (a solid block is acceptable and expected), while labels/symbols stay at or
+  below the limit so the numbers remain readable.
+- **Set already within the limit**: every pin is drawn and every pin is labelled;
+  no thinning of labels is applied.
+- **Deep zoom-in on a narrow slice**: once the number of pins in view drops to or
+  below the limit, all visible pins are labelled at the finest step.
+- **Panning without zooming**: the visible-span width is unchanged, so the number
+  of labelled pins is unchanged, but which specific pins are labelled is
+  recomputed for the new position; every pin line in the new view is still drawn.
+- **Pins near the top edge**: the label/symbol stack is nudged to stay on-screen
+  rather than being clipped.
+- **Multiple harmonic sets on screen**: the label limit applies to each set
+  independently; every set draws all its pin lines and thins only its own labels.
+- **A labelled subset that omits the fundamental/first pin**: the labelled pins
+  still form a regular series the analyst can extrapolate, and every pin line
+  (including the fundamental) is still drawn.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST draw a pin line for every harmonic of a set that
+  falls within the visible frequency span, regardless of how many that is — pin
+  lines MUST NOT be dropped to keep the overlay legible.
+- **FR-002**: The system MUST draw number labels and symbols only on a thinned
+  "major" subset of the pins, never exceeding the label limit within the visible
+  span.
+- **FR-003**: The label limit MUST reuse the existing maximum (default 25); this
+  feature changes what the limit governs (labels/symbols) but not its value.
+- **FR-004**: The subset of pins that receive labels/symbols MUST be selected by
+  a regular sampling step (every Nth pin), consistent with the existing sampling
+  behaviour, so the labelled pins are evenly spaced and predictable.
+- **FR-005**: When the number of pins in the visible span is at or below the
+  label limit, the system MUST label and symbol every drawn pin (no label
+  thinning).
+- **FR-006**: The system MUST recompute both the set of drawn pin lines and the
+  subset of labelled/symbolled pins whenever the zoom level or pan position
+  changes, based on the frequency span visible after the change.
+- **FR-007**: As the visible span narrows (zoom in) the labelled subset MUST grow
+  (or stay equal); as it widens (zoom out) it MUST shrink (or stay equal) —
+  labelling density MUST never decrease when zooming in.
+- **FR-008**: A label MUST only be drawn for a pin that is actually drawn, and its
+  text MUST correctly identify that pin's harmonic number (no orphan or
+  mismatched labels).
+- **FR-009**: Each drawn label MUST be positioned horizontally centred on its
+  pin's vertical line (rather than offset to the right of the line).
+- **FR-010**: Each drawn label MUST be positioned above the pin's symbol, so the
+  vertical order over the pin is label, then symbol, then the pin line.
+- **FR-011**: When the label/symbol stack would fall outside the top of the
+  spectrogram image, the system MUST keep it within the visible area so it stays
+  legible.
+- **FR-012**: This feature MUST NOT change the underlying harmonic set data
+  (spacing, anchor, colour, symbol, identity) — it affects only which pins are
+  drawn and which carry labels/symbols, and where labels sit.
+- **FR-013**: Selecting and adjusting a harmonic set MUST continue to work as
+  before with the full set of pin lines drawn.
+
+### Key Entities *(include if data involved)*
+
+- **Harmonic Set**: A series of pins the analyst places on the spectrogram,
+  defined by spacing, anchor, colour, and symbol. Unchanged by this feature.
+- **Pin**: The vertical line for one harmonic (at n × spacing). This feature draws
+  a line for every pin in the visible span and, for a subset, additionally a
+  number label and a symbol.
+- **Major (labelled) subset**: The evenly-sampled set of pins — at most the label
+  limit — that receive a number label and symbol. Recomputed per view.
+- **Label limit**: The upper bound on how many pins in the visible span carry a
+  label/symbol (default 25). Formerly the cap on pins drawn; now the cap on
+  labels/symbols.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For any harmonic set at any zoom/pan, a pin line is drawn for 100%
+  of harmonics that fall in the visible frequency span (zero dropped lines).
+- **SC-002**: For any harmonic set at any zoom/pan, no more than the label limit
+  (default 25) pins carry a number label/symbol within the visible span.
+- **SC-003**: For the dense case (e.g. a 0.5 Hz set over a wide span), the analyst
+  can see the full block of pin lines while reading a bounded set of
+  non-overlapping labels.
+- **SC-004**: When zooming in on a dense set, the number of labelled pins
+  increases at each step until, at a small enough span, every visible pin is
+  labelled; zooming out thins the labels again.
+- **SC-005**: 100% of drawn labels sit centred above their pin's symbol, with none
+  offset to the right of the line.
+- **SC-006**: Every drawn label matches an actual drawn pin and its harmonic
+  number (no orphan or mismatched labels).
+- **SC-007**: The drawn pins and labelled subset update on every zoom/pan change
+  with no perceptible lag.
+
+## Assumptions
+
+- This feature supersedes the pin-dropping behaviour introduced in spec 158
+  (Sample Harmonic Pins). The sampling calculation (regular step, "nice"
+  step series, default max 25) is retained but now decides which pins are
+  *labelled/symbolled*, not which pins are *drawn*.
+- "Show all pins" means all pin lines within the visible frequency span; the
+  system still only renders harmonics that fall inside the current view, so
+  off-screen harmonics are not drawn.
+- The label limit remains a single tunable value (default 25). Changing it later
+  does not change this feature's scope.
+- A "solid block" of overlapping pin lines is an acceptable and intended visual
+  outcome at extreme density — legibility is preserved through the thinned labels,
+  not by hiding lines.
+- The symbol shown on a labelled pin is the harmonic set's assigned symbol; this
+  feature does not change the symbol catalogue or the default symbol (covered by
+  other specs).
+- Existing harmonic-set creation, colour/symbol assignment, persistence, and
+  selection behaviours are unchanged except for pin/label rendering.

--- a/specs/160-mouse-wheel-navigation/spec.md
+++ b/specs/160-mouse-wheel-navigation/spec.md
@@ -1,0 +1,239 @@
+# Feature Specification: Mouse-Wheel Pan and Zoom
+
+**Feature Branch**: `160-mouse-wheel-navigation`  
+**Created**: 2026-07-24  
+**Status**: Draft  
+**Input**: GH issue #198 (Review feedback) — bullet 3: "Introduce mouse wheel support ... scroll to pan horizontally, ctrl-scroll to zoom in/out in both directions, wheel-click drag to pan ... we'll also need to add guidance for this."
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  Today GramFrame supports zoom (via + / − buttons in Pan mode) and pan (via
+  click-and-drag, only when zoomed in). There is NO mouse-wheel or middle-button
+  handling anywhere. Mouse-wheel input is therefore unused across every mode, so
+  it can be adopted globally without conflicting with existing interactions. The
+  behaviour should follow familiar browser/map conventions.
+-->
+
+### User Story 1 - Zoom in and out with Ctrl-scroll (Priority: P1)
+
+An analyst wants to zoom into a feature without moving the mouse to the Pan-mode
+buttons. Holding Ctrl and scrolling the mouse wheel zooms the spectrogram in and
+out around the pointer, in any interaction mode. Scrolling up (away) zooms in;
+scrolling down (toward) zooms out. Zoom affects both the frequency (horizontal)
+and time (vertical) directions together, consistent with the existing zoom
+behaviour, and stays within the existing zoom limits.
+
+**Why this priority**: Zoom is the most valuable wheel interaction and the entry
+point for the others — panning is only meaningful once zoomed in. Ctrl-scroll
+zoom works on its own and delivers immediate value in every mode.
+
+**Independent Test**: In any mode, hold Ctrl and scroll up over the spectrogram
+and confirm it zooms in; scroll down and confirm it zooms out, both bounded by
+the existing min/max zoom.
+
+**Acceptance Scenarios**:
+
+1. **Given** the spectrogram at any zoom level in any mode, **When** the analyst
+   holds Ctrl and scrolls the wheel up, **Then** the view zooms in (up to the
+   existing maximum) and the browser page does not scroll.
+2. **Given** a zoomed-in spectrogram, **When** the analyst holds Ctrl and scrolls
+   the wheel down, **Then** the view zooms out (down to the existing minimum, no
+   further).
+3. **Given** any Ctrl-scroll zoom, **When** the view changes, **Then** the zoom is
+   applied to both the frequency and time directions together, and the axes and
+   any overlays update to match the new visible range.
+4. **Given** Ctrl-scroll zoom, **When** the analyst zooms, **Then** the zoom is
+   centred on the pointer location so the feature under the cursor stays roughly
+   under the cursor.
+
+---
+
+### User Story 2 - Pan horizontally by scrolling (Priority: P2)
+
+Once zoomed in, an analyst wants to move forward and back through frequency
+without dragging. Scrolling the mouse wheel (without Ctrl) pans the view
+horizontally along the frequency axis — scrolling in one direction moves forward
+in frequency, the other moves back. This works in any mode. When the view is not
+zoomed in (nothing is off-screen to pan to), plain scroll does nothing.
+
+**Why this priority**: Horizontal scroll-pan is a convenience over the existing
+drag-pan and only applies once zoomed (Story 1). It is valuable but secondary to
+zoom, so it is P2.
+
+**Independent Test**: Zoom in, then scroll the wheel (no Ctrl) and confirm the
+view pans horizontally along frequency; verify that at zoom level 1 (not zoomed)
+plain scroll has no effect.
+
+**Acceptance Scenarios**:
+
+1. **Given** a zoomed-in spectrogram, **When** the analyst scrolls the wheel
+   without Ctrl, **Then** the view pans horizontally along the frequency axis and
+   the browser page does not scroll.
+2. **Given** a spectrogram at zoom level 1 (fully zoomed out), **When** the
+   analyst scrolls the wheel without Ctrl, **Then** nothing pans (there is
+   nothing off-screen to reveal).
+3. **Given** a horizontal scroll-pan, **When** the view reaches the edge of the
+   available data, **Then** panning stops at the edge and does not reveal empty
+   space beyond the data.
+4. **Given** scroll-pan in any mode, **When** the analyst pans, **Then** the
+   current mode's other interactions (cursor, markers, harmonics, doppler) are
+   unaffected by the pan itself.
+
+---
+
+### User Story 3 - Pan by dragging with the wheel button (Priority: P3)
+
+An analyst wants to reposition a zoomed-in view quickly by grabbing it. Pressing
+and holding the mouse wheel button (middle button) and dragging pans the view in
+the direction of the drag, in any mode. As with scroll-pan, this only does
+something once zoomed in. Releasing the wheel button ends the pan. The wheel-drag
+pan does not trigger the mode's normal left-button actions (placing a cursor,
+marker, or harmonic set).
+
+**Why this priority**: Wheel-click drag is a third, familiar way to pan and
+overlaps in value with scroll-pan. It is the least essential of the three wheel
+interactions, so it is P3.
+
+**Independent Test**: Zoom in, press and hold the middle (wheel) button, drag, and
+confirm the view pans following the drag; release and confirm the pan ends and no
+marker/cursor was placed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a zoomed-in spectrogram in any mode, **When** the analyst presses the
+   wheel button and drags, **Then** the view pans following the drag direction.
+2. **Given** a wheel-button drag-pan in progress, **When** the analyst releases the
+   wheel button, **Then** the pan ends and the view holds its new position.
+3. **Given** a wheel-button drag, **When** it starts and ends, **Then** the active
+   mode's left-button action (place cursor / marker / harmonic / doppler point) is
+   NOT triggered.
+4. **Given** the spectrogram at zoom level 1, **When** the analyst wheel-drags,
+   **Then** nothing pans.
+
+---
+
+### User Story 4 - Discover the wheel interactions from guidance (Priority: P2)
+
+An analyst who does not know GramFrame supports the mouse wheel needs to be told.
+The on-screen guidance describes the wheel interactions — scroll to pan, Ctrl+scroll
+to zoom, wheel-drag to pan — so analysts can discover them without documentation.
+
+**Why this priority**: Undocumented interactions are effectively invisible.
+Guidance is required for the feature to be usable in practice, but it depends on
+the interactions existing, so it is P2.
+
+**Independent Test**: Open the guidance panel and confirm it lists the mouse-wheel
+interactions in plain language.
+
+**Acceptance Scenarios**:
+
+1. **Given** the guidance panel, **When** the analyst reads it, **Then** it
+   describes scroll-to-pan, Ctrl+scroll-to-zoom, and wheel-drag-to-pan.
+2. **Given** the guidance describes wheel interactions, **When** the analyst reads
+   it, **Then** it makes clear that scroll-pan and wheel-drag-pan only take effect
+   once zoomed in.
+
+---
+
+### Edge Cases
+
+- **Wheel used while not zoomed in**: Ctrl+scroll still zooms (from level 1);
+  plain scroll and wheel-drag do nothing because there is nothing off-screen.
+- **Zoom at the min/max limit**: further Ctrl+scroll in that direction has no
+  effect and does not error.
+- **Pan at the data edge**: scroll-pan and wheel-drag-pan clamp at the edge of the
+  available data rather than revealing blank space.
+- **Page scrolling**: wheel actions over the spectrogram must not scroll the host
+  web page; the component consumes the wheel event.
+- **Wheel-drag interrupted** (pointer leaves the component, or focus lost mid-drag):
+  the pan ends cleanly without leaving the component stuck in a dragging state.
+- **Trackpad two-finger scroll**: behaves as a wheel scroll (pan), and pinch/Ctrl
+  as zoom, per browser convention, without special-casing device type.
+- **Interaction with existing drag-pan and +/− buttons**: the new wheel
+  interactions coexist with the existing click-drag pan and the Pan-mode zoom
+  buttons; none of them are removed or broken.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The component MUST respond to mouse-wheel input over the
+  spectrogram in every interaction mode (analysis, harmonics, doppler, pan).
+- **FR-002**: When the analyst scrolls the wheel while holding Ctrl, the system
+  MUST zoom the view in (scroll up/away) or out (scroll down/toward).
+- **FR-003**: Ctrl+scroll zoom MUST apply to both the frequency and time
+  directions together and MUST respect the existing zoom minimum and maximum.
+- **FR-004**: Ctrl+scroll zoom MUST be centred on the pointer position so the
+  point under the cursor stays approximately under the cursor after zooming.
+- **FR-005**: When the analyst scrolls the wheel without Ctrl and the view is
+  zoomed in, the system MUST pan the view horizontally along the frequency axis.
+- **FR-006**: When the analyst presses the wheel (middle) button and drags, and
+  the view is zoomed in, the system MUST pan the view following the drag.
+- **FR-007**: Scroll-pan and wheel-drag-pan MUST have no effect when the view is
+  not zoomed in (zoom level 1), because nothing is off-screen to reveal.
+- **FR-008**: Panning (by scroll or wheel-drag) MUST clamp at the edges of the
+  available data and MUST NOT reveal empty space beyond the data.
+- **FR-009**: Wheel-drag-pan MUST NOT trigger the active mode's left-button action
+  (placing a cursor, marker, harmonic set, or doppler point).
+- **FR-010**: Wheel actions over the spectrogram MUST prevent the host page from
+  scrolling.
+- **FR-011**: A wheel-drag pan MUST end cleanly when the wheel button is released
+  or the interaction is interrupted (pointer leaves the component), leaving no
+  residual dragging state.
+- **FR-012**: The on-screen guidance MUST describe the wheel interactions
+  (scroll-to-pan, Ctrl+scroll-to-zoom, wheel-drag-to-pan), noting that the pan
+  interactions require the view to be zoomed in.
+- **FR-013**: The new wheel interactions MUST coexist with the existing click-drag
+  pan and the Pan-mode +/− zoom buttons without removing or breaking them.
+
+### Key Entities *(include if data involved)*
+
+- **Zoom state**: The current zoom level and centre of the view (already stored
+  by the component). Wheel zoom and wheel pan update this state; they add no new
+  persisted data.
+- **Wheel interaction**: A transient user input (scroll, Ctrl+scroll, or
+  wheel-button drag) that maps to a pan or zoom of the view. No entity is
+  persisted; the effect is entirely a change to the existing zoom/pan state.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In every mode, Ctrl+scroll changes the zoom level, bounded by the
+  existing min and max, with no page scroll.
+- **SC-002**: In every mode, plain scroll pans horizontally along frequency when
+  zoomed in, and has no effect when not zoomed in.
+- **SC-003**: In every mode, wheel-button drag pans the view when zoomed in and
+  never places a cursor/marker/harmonic/doppler point.
+- **SC-004**: Wheel zoom is centred on the pointer, keeping the feature under the
+  cursor approximately in place.
+- **SC-005**: Panning by any means stops at the data edges without exposing blank
+  space.
+- **SC-006**: The guidance panel names all three wheel interactions and their
+  zoom-in precondition, so a first-time analyst can discover them.
+- **SC-007**: Existing zoom buttons and click-drag pan continue to work unchanged.
+
+## Assumptions
+
+- Mouse-wheel and middle-button input are currently unused everywhere in the
+  component, so adopting them globally (in all modes) introduces no conflict with
+  existing interactions.
+- "Zoom in both directions" means zoom is uniform across frequency and time,
+  matching the current button-driven zoom, which scales the whole image rather
+  than one axis.
+- "Scroll to pan horizontally (fwd/back in frequency)" maps vertical wheel-scroll
+  delta to horizontal frequency panning, following the common convention for
+  horizontally-oriented data views; the exact direction mapping is a design detail
+  that does not change scope.
+- Scroll-pan and wheel-drag-pan reuse the existing pan mechanism and its
+  zoom-level-1 gating, so they are naturally inert when not zoomed in.
+- Guidance for the wheel interactions is added to the on-screen mode guidance;
+  because the interactions are global, the guidance may appear in the Pan mode
+  guidance and/or be surfaced across modes — the exact placement is a design
+  detail.
+- Zoom centring on the pointer is a refinement of the existing centre-based zoom;
+  if pointer-centred zoom proves impractical, zooming about the current centre is
+  an acceptable fallback that does not change the feature's scope.
+- Standard browser wheel semantics apply to trackpads (two-finger scroll = wheel
+  scroll; pinch or Ctrl = zoom) without device-specific handling.

--- a/specs/161-reformat-markers-harmonics/spec.md
+++ b/specs/161-reformat-markers-harmonics/spec.md
@@ -1,0 +1,236 @@
+# Feature Specification: Reformat Existing Markers & Harmonics, with a "Cross" (Symbol-less) Style
+
+**Feature Branch**: `161-reformat-markers-harmonics`  
+**Created**: 2026-07-24  
+**Status**: Draft  
+**Input**: GH issue #198 (Review feedback) — bullets 4 & 5: "Introduce `cross` symbol style" and "Allow existing markers and harmonics to be reformatted".
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  Today the colour selector and symbol selector only affect the NEXT feature the
+  analyst creates; there is no way to restyle an already-placed harmonic set or
+  marker (you must delete and re-create it). Selecting a table row highlights it
+  but changes nothing else. Harmonic sets carry a symbol (circle/square/diamond/
+  triangle/triangle-down/star, default circle); markers do NOT carry a symbol —
+  they render as a fixed crosshair and show a plain colour swatch in the table.
+  This feature (a) adds a "cross" style meaning "no drawn symbol", and (b) lets
+  the analyst select an existing marker or harmonic set and instantly restyle its
+  colour and symbol. The "cross" style is the stepping stone that lets markers
+  and harmonics carry a symbol OR remain symbol-less.
+-->
+
+### User Story 1 - Reformat an existing harmonic set (Priority: P1)
+
+An analyst has already placed several harmonic sets and now wants to recolour one
+or give it a different symbol — without deleting and re-drawing it. They select
+the harmonic set (on the overlay or in the harmonics table). It is shown as
+selected, and the colour selector and symbol selector update to reflect that
+set's current colour and symbol. The analyst changes the colour or picks a
+different symbol, and the selected harmonic set updates instantly on the
+spectrogram and in the table to match.
+
+**Why this priority**: This is the core new capability requested — editing the
+appearance of existing features in place. It removes the delete-and-recreate
+workaround and is independently valuable and testable on harmonic sets alone.
+
+**Independent Test**: Create two harmonic sets with different colours/symbols,
+select one, confirm the selectors show that set's values, change the colour and
+symbol, and confirm only the selected set changes — immediately, on both the
+overlay and the table.
+
+**Acceptance Scenarios**:
+
+1. **Given** one or more placed harmonic sets, **When** the analyst selects one,
+   **Then** it is visibly marked as selected and the colour and symbol selectors
+   update to show that set's current colour and symbol.
+2. **Given** a selected harmonic set, **When** the analyst changes the colour,
+   **Then** that set's colour changes instantly on the overlay and in the table,
+   and no other set changes.
+3. **Given** a selected harmonic set, **When** the analyst chooses a different
+   symbol, **Then** that set's symbol changes instantly on the overlay and in the
+   table, and no other set changes.
+4. **Given** a selected harmonic set, **When** the analyst changes its symbol to
+   "cross", **Then** the set's pins show no drawn symbol shape while keeping their
+   lines and labels.
+5. **Given** no feature is selected, **When** the analyst changes the colour or
+   symbol selector, **Then** the change applies to the NEXT feature created (the
+   existing behaviour is preserved) and no placed feature changes.
+
+---
+
+### User Story 2 - The "cross" (symbol-less) style as the default (Priority: P1)
+
+An analyst adding features does not always want a symbol drawn. A "cross" style is
+available in the symbol selector; choosing it means "no symbol shape is drawn".
+"Cross" is the default style, so a newly created harmonic set or marker has no
+drawn symbol unless the analyst deliberately picks one. Existing shaped symbols
+(circle, square, diamond, triangle, triangle-down, star) remain available.
+
+**Why this priority**: The cross style is the foundation the reformatting relies
+on — it is the value the selectors show for symbol-less features and the state a
+feature returns to when the analyst removes its symbol. It ships alongside Story 1
+as a P1.
+
+**Independent Test**: Open the symbol selector, confirm "cross" is present and is
+the default, create a feature without changing the symbol, and confirm no symbol
+shape is drawn.
+
+**Acceptance Scenarios**:
+
+1. **Given** the symbol selector, **When** the analyst opens it, **Then** "cross"
+   is offered as an option and is the default selection.
+2. **Given** the default symbol (cross), **When** the analyst creates a harmonic
+   set or marker, **Then** no symbol shape is drawn for it.
+3. **Given** a feature with the "cross" style, **When** it is shown or reloaded,
+   **Then** it renders with no symbol shape and without error.
+4. **Given** a shaped symbol was previously selected, **When** the analyst chooses
+   "cross", **Then** subsequent new features (and any selected feature being
+   reformatted) show no symbol shape.
+
+---
+
+### User Story 3 - Reformat a marker, including giving it a symbol (Priority: P2)
+
+An analyst has placed analysis markers, which today are plain colour-coded
+crosses. They select a marker and change its colour, or give it a symbol. When a
+marker has a symbol, it is shown as that colour-coded symbol; when a marker has no
+symbol (cross), it continues to show a filled rectangle of its colour as the
+colour indicator. Reformatting a marker takes effect instantly.
+
+**Why this priority**: Extending reformatting to markers — and letting markers
+carry symbols for the first time — is a natural companion to Story 1 but touches a
+second feature type and introduces a new marker capability, so it is P2.
+
+**Independent Test**: Place a marker, select it, confirm the selectors show its
+colour and "cross" symbol, change its colour and give it a symbol, and confirm the
+marker instantly shows the colour-coded symbol; set it back to cross and confirm
+it shows the filled colour rectangle.
+
+**Acceptance Scenarios**:
+
+1. **Given** one or more placed markers, **When** the analyst selects one, **Then**
+   it is marked as selected and the colour and symbol selectors show that marker's
+   colour and symbol (cross for markers that have none).
+2. **Given** a selected marker, **When** the analyst changes its colour, **Then**
+   the marker's colour changes instantly on the overlay and in the markers table.
+3. **Given** a selected marker with the cross style, **When** the analyst assigns a
+   shaped symbol, **Then** the marker is drawn as that colour-coded symbol.
+4. **Given** a marker with a shaped symbol, **When** the analyst changes it back to
+   cross, **Then** the marker's colour indicator reverts to the filled colour
+   rectangle.
+5. **Given** a marker's colour indicator, **When** the marker has a symbol, **Then**
+   the indicator shows the colour-coded symbol; **when** it has no symbol (cross),
+   **then** the indicator shows the filled colour rectangle.
+
+---
+
+### Edge Cases
+
+- **Selecting then deselecting**: when selection is cleared, the selectors revert
+  to controlling the next-created feature; no placed feature is affected by later
+  selector changes until something is selected again.
+- **Reformatting the currently-dragged feature**: changing colour/symbol while a
+  feature is selected mid-interaction applies to that feature and does not disturb
+  its position.
+- **Cross style on harmonic pins**: the pin still draws its line and (for labelled
+  pins) its number label; only the symbol shape is omitted.
+- **Legacy harmonic sets** (persisted before symbols, or before cross existed):
+  they load without error; a set with no recorded symbol is treated consistently
+  with the defined default.
+- **Legacy markers** (persisted before markers could carry symbols): they load as
+  cross (no symbol) and show the filled colour rectangle.
+- **Switching symbol while multiple features exist**: only the selected feature is
+  reformatted; unselected features are untouched.
+- **Reformat persistence**: a reformatted colour/symbol survives save and reload
+  the same way an originally-chosen colour/symbol does.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The symbol selector MUST offer a "cross" style meaning "no symbol
+  shape is drawn", in addition to the existing shaped symbols.
+- **FR-002**: "Cross" MUST be the default symbol style for newly created harmonic
+  sets and markers (replacing the previous default).
+- **FR-003**: A feature (harmonic set or marker) whose style is "cross" MUST render
+  with no symbol shape, without error.
+- **FR-004**: Selecting an existing harmonic set or marker MUST mark it as selected
+  and MUST update the colour and symbol selectors to reflect that feature's current
+  colour and symbol.
+- **FR-005**: While a feature is selected, changing the colour selector MUST
+  immediately change that feature's colour on the overlay and in its table.
+- **FR-006**: While a feature is selected, changing the symbol selector MUST
+  immediately change that feature's symbol on the overlay and in its table.
+- **FR-007**: Reformatting a selected feature MUST affect only that feature; no
+  other placed feature may change.
+- **FR-008**: When no feature is selected, changing the colour or symbol selector
+  MUST continue to set the style for the next feature created (existing behaviour
+  preserved), and MUST NOT change any placed feature.
+- **FR-009**: Markers MUST be able to carry a symbol; a marker with a shaped symbol
+  MUST be drawn as that colour-coded symbol.
+- **FR-010**: A marker's colour indicator MUST depend on its style: a marker with a
+  shaped symbol shows the colour-coded symbol; a marker with the cross style shows
+  a filled rectangle of its colour.
+- **FR-011**: A reformatted colour and symbol MUST persist so that saving and
+  reloading restores the reformatted appearance.
+- **FR-012**: Loading legacy persisted data MUST NOT error: features with no
+  recorded symbol MUST be shown consistently with the defined default handling, and
+  legacy markers MUST render as cross with a filled colour rectangle.
+- **FR-013**: Clearing the selection MUST return the selectors to controlling the
+  next-created feature.
+
+### Key Entities *(include if data involved)*
+
+- **Symbol style**: The visual coding of a feature. Extended to include "cross"
+  (no drawn shape) alongside the existing filled shapes. "Cross" is the default.
+- **Harmonic Set**: Already carries colour and symbol. This feature makes its
+  colour and symbol editable in place and lets its symbol be "cross" (symbol-less).
+- **Marker**: Analysis-mode annotation that today carries only colour. This feature
+  adds a symbol attribute to markers (default cross) and makes colour and symbol
+  editable in place. Its colour indicator becomes symbol-dependent.
+- **Selection**: The currently selected feature (marker or harmonic set). This
+  feature makes selection drive the colour/symbol selectors and route restyle edits
+  to the selected feature.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An analyst can change an existing harmonic set's colour or symbol in
+  place, seeing the change immediately, without deleting and re-creating it.
+- **SC-002**: An analyst can change an existing marker's colour or symbol in place,
+  seeing the change immediately.
+- **SC-003**: Selecting any feature updates the colour and symbol selectors to that
+  feature's current values 100% of the time.
+- **SC-004**: Reformatting a selected feature never alters any other placed
+  feature.
+- **SC-005**: "Cross" is available and is the default; a feature created without
+  choosing a symbol shows no symbol shape.
+- **SC-006**: A marker with a symbol shows the colour-coded symbol; a marker with
+  cross shows the filled colour rectangle — matching its current style in every
+  case.
+- **SC-007**: Reformatted colours/symbols survive save and reload for 100% of
+  features; legacy data loads without error.
+
+## Assumptions
+
+- The colour selector and symbol selector are the existing controls; this feature
+  changes them from "always target the next feature" to "target the selected
+  feature when one is selected, otherwise the next feature".
+- "Cross" denotes the symbol-less style. The name reflects that markers currently
+  render as a cross/crosshair; a "cross" harmonic or marker simply has no filled
+  symbol shape. Whether a literal small cross glyph is drawn or nothing at all is a
+  design detail; the intent is "no shaped symbol".
+- Selection already exists as a concept (highlighting a table row / overlay
+  element); this feature extends what selection does rather than inventing
+  selection.
+- Making the default "cross" changes the default appearance of new features from
+  the previous default shape (circle) to no symbol; this is intended.
+- Persistence reuses the existing annotation storage; the stored record for a
+  harmonic set already includes a symbol, and this feature adds a symbol to the
+  stored marker record, remaining backward compatible with records that lack it.
+- This feature is the follow-on to the harmonic symbol work (spec 157); it does not
+  change the shaped-symbol catalogue, only adds "cross" and makes styles editable.
+- Instant restyle applies within the current session view; no additional
+  confirmation step is required.

--- a/specs/162-legacy-browser-check/spec.md
+++ b/specs/162-legacy-browser-check/spec.md
@@ -1,0 +1,174 @@
+# Feature Specification: Legacy-Browser Compatibility Warning
+
+**Feature Branch**: `162-legacy-browser-check`  
+**Created**: 2026-07-24  
+**Status**: Draft  
+**Input**: GH issue #198 (Review feedback) — bullet 6: a legacy Chrome (v84) lacked `replaceChildren` (needs v86), so GramFrame silently failed. Add an early check for the required JS/DOM APIs and show a clear "please update your browser" warning instead of failing silently.
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  Background: GramFrame uses modern DOM APIs — notably Element.replaceChildren()
+  (Chrome/Edge 86+) — with no feature-detection guard. On an older browser these
+  calls throw during rendering and the component silently fails: the analyst sees
+  a blank or broken area with no explanation. GramFrames are about to be
+  distributed more widely, where old Chrome/Edge installs are likely. This
+  feature adds a check, very early in the render process, that the required APIs
+  exist, and shows an actionable warning message when they do not.
+-->
+
+### User Story 1 - Legacy-browser user gets a clear, actionable warning (Priority: P1)
+
+An analyst opens training material containing a GramFrame on an out-of-date
+browser (for example Chrome/Edge 84) that lacks the JavaScript/DOM features the
+component needs. Instead of a blank or half-rendered area with no explanation, the
+analyst sees a plain, readable message in place of the component telling them the
+component needs a newer browser and to update. The message names the minimum
+supported version so the analyst (or their IT support) knows what to do.
+
+**Why this priority**: This is the whole point of the feature — replacing a silent
+failure with a clear instruction. It is independently valuable and testable by
+simulating a missing API.
+
+**Independent Test**: In an environment where a required API is absent (or
+simulated absent), load a page with a GramFrame and confirm a readable warning
+message is shown in place of the component, naming the minimum browser version and
+telling the user to update.
+
+**Acceptance Scenarios**:
+
+1. **Given** a browser missing one or more required JS/DOM APIs, **When** a
+   GramFrame would initialise, **Then** a human-readable warning is shown in place
+   of the component instead of a blank/broken area or a thrown error.
+2. **Given** the warning is shown, **When** the analyst reads it, **Then** it
+   states that a newer version of Chrome/Edge is required, names the minimum
+   supported version, and asks the user to update their browser.
+3. **Given** a page containing multiple GramFrames on an unsupported browser,
+   **When** the page loads, **Then** each GramFrame area shows the warning (no
+   area is left silently blank).
+4. **Given** an unsupported browser, **When** the check fails, **Then** the failure
+   is detected before the component attempts the rendering that would otherwise
+   throw, so the analyst never sees a partially-rendered, broken component.
+
+---
+
+### User Story 2 - Modern-browser user is unaffected (Priority: P1)
+
+An analyst on a current, supported browser opens the same material. The
+compatibility check passes silently and the GramFrame renders and behaves exactly
+as it does today, with no warning, no delay noticeable to the user, and no change
+in behaviour.
+
+**Why this priority**: The check must be invisible on supported browsers — the
+overwhelming majority of users. A guard that degraded the normal experience would
+be unacceptable, so this is P1 alongside Story 1.
+
+**Independent Test**: On a current supported browser, load a page with a GramFrame
+and confirm no warning appears and the component renders and works exactly as
+before.
+
+**Acceptance Scenarios**:
+
+1. **Given** a supported browser with all required APIs present, **When** a
+   GramFrame initialises, **Then** no warning is shown and the component renders
+   normally.
+2. **Given** a supported browser, **When** the check runs, **Then** it adds no
+   perceptible delay and does not change any existing behaviour.
+
+---
+
+### Edge Cases
+
+- **Partial support** (some required APIs present, others missing): the check
+  treats the browser as unsupported and shows the warning, rather than proceeding
+  and failing later.
+- **Non-Chromium browser lacking a required API**: the warning still appears; the
+  wording refers to Chrome/Edge as the supported browsers but the guard is based on
+  feature presence, not on sniffing a specific browser brand.
+- **Check itself must not depend on an unsupported API**: the detection code must
+  run on the old browser without throwing, or it would reproduce the silent
+  failure it is meant to prevent.
+- **Component embedded where its container is small**: the warning message must
+  still be legible (it should not be clipped to nothing).
+- **API present but the config table is malformed**: this feature covers only
+  browser capability; existing config-parsing behaviour is unchanged.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Before performing rendering that relies on modern JS/DOM APIs, the
+  system MUST check that the APIs GramFrame requires are present in the current
+  browser.
+- **FR-002**: The check MUST run early enough that, on an unsupported browser, the
+  component never reaches the code that would throw — the analyst MUST NOT see a
+  partially-rendered or broken component.
+- **FR-003**: When the check fails, the system MUST display a human-readable
+  warning in place of the GramFrame instead of failing silently or throwing an
+  uncaught error.
+- **FR-004**: The warning message MUST state that a newer version of Chrome/Edge is
+  required, MUST name the minimum supported version, and MUST ask the user to
+  update their browser.
+- **FR-005**: When the check passes, the component MUST render and behave exactly
+  as it does today, with no warning and no perceptible delay.
+- **FR-006**: On a page with multiple GramFrames, an unsupported browser MUST show
+  the warning for each one (no GramFrame area may be left silently blank).
+- **FR-007**: The detection logic itself MUST NOT rely on any API that is absent on
+  the browsers it is meant to catch, so the check runs without throwing on those
+  browsers.
+- **FR-008**: The set of required APIs checked MUST include, at minimum, the
+  APIs that caused the original silent failure (e.g. `Element.replaceChildren`)
+  and any other post-baseline APIs the component depends on.
+- **FR-009**: The minimum supported version named in the warning MUST correspond to
+  the actual APIs the component requires (i.e. the highest browser version needed
+  by any required API).
+
+### Key Entities *(include if data involved)*
+
+- **Required-API set**: The list of JS/DOM capabilities the component depends on
+  that are newer than the legacy baseline (Chrome/Edge 84). Presence of all of
+  them is the pass condition; absence of any is the fail condition.
+- **Compatibility warning**: The user-facing message shown in place of the
+  component when the check fails — stating the minimum browser version and asking
+  the user to update.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: On a browser missing a required API, 100% of GramFrame areas show the
+  warning message instead of failing silently.
+- **SC-002**: The warning names the minimum supported Chrome/Edge version and tells
+  the user to update.
+- **SC-003**: On an unsupported browser, the component never throws an uncaught
+  error and never shows a partially-rendered component.
+- **SC-004**: On a supported browser, no warning appears and the component behaves
+  identically to today, with no measurable regression.
+- **SC-005**: The detection runs without error on the legacy browsers it targets
+  (it does not itself require an unsupported API).
+- **SC-006**: The minimum version stated in the warning matches the highest browser
+  version any required API needs.
+
+## Assumptions
+
+- The original failure was caused by `Element.replaceChildren` (added in
+  Chrome/Edge 86) being absent on Chrome 84. The minimum supported version stated
+  in the warning should be derived from the actual required-API set; based on
+  current usage this is expected to be around version 86, but the exact number is
+  whatever the highest-versioned required API demands.
+- The required-API set is determined by auditing the modern DOM/JS APIs the
+  component uses without a fallback (e.g. `replaceChildren`, and any others found).
+  The exact list is an implementation detail; the requirement is that the set
+  covers the APIs whose absence would otherwise cause a silent failure.
+- The check is feature-detection based (testing for the presence of the APIs), not
+  user-agent-string sniffing, so it is robust across browser brands and future
+  versions; the warning text still refers to Chrome/Edge because those are the
+  supported/target browsers for the training material.
+- The warning replaces the component's own area (where the config table / rendered
+  component would appear); it does not need to block or alter the rest of the host
+  page.
+- Wording is along the lines of: "To view this interactive analysis component, at
+  least version XX of Chrome/Edge is required. Please update your browser." Exact
+  copy is a design detail.
+- This feature does not add polyfills or attempt to make the component work on
+  unsupported browsers; it only detects and warns.

--- a/specs/163-pan-tooltip-version/spec.md
+++ b/specs/163-pan-tooltip-version/spec.md
@@ -1,0 +1,89 @@
+# Feature Specification: Remove the Version Number from the Pan-Mode Button Tooltip
+
+**Feature Branch**: `163-pan-tooltip-version`  
+**Created**: 2026-07-24  
+**Status**: Draft  
+**Input**: GH issue #198 (Review feedback) — bullet 7: "Drop version number from PanMode tooltip. We recently added a tooltip to the Pan Mode button, to show the version number. I'd forgotten that we already show the version in the pan mode guidance. We should drop showing the version in the pan mode tooltip."
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  Background: The version number is currently surfaced in TWO places — (a) as the
+  hover tooltip (title) on the Pan Mode button, and (b) as the last line of the Pan
+  Mode guidance panel. The guidance panel is the intended place; the button
+  tooltip was added before that was remembered and is now redundant. This change
+  removes the redundant tooltip while keeping the guidance display.
+-->
+
+### User Story 1 - Version shown in one place, not duplicated (Priority: P1)
+
+A trainer or analyst hovers over the Pan Mode button. Today a tooltip appears
+showing the GramFrame version, duplicating the version that already appears in the
+Pan Mode guidance panel. After this change, hovering the Pan Mode button no longer
+shows the version tooltip, while the version remains visible in the Pan Mode
+guidance. The version is therefore surfaced in exactly one place.
+
+**Why this priority**: It is the entire requested change — remove the redundant
+tooltip. Small but self-contained and independently verifiable.
+
+**Independent Test**: Hover the Pan Mode button and confirm no version tooltip
+appears; open the Pan Mode guidance and confirm the version is still shown there.
+
+**Acceptance Scenarios**:
+
+1. **Given** the mode buttons, **When** the analyst hovers over the Pan Mode
+   button, **Then** no version-number tooltip is shown.
+2. **Given** the Pan Mode guidance panel, **When** the analyst views it, **Then**
+   the GramFrame version is still displayed there (unchanged by this change).
+3. **Given** the version was the only content of the Pan Mode button's tooltip,
+   **When** the tooltip is removed, **Then** the Pan Mode button behaves like the
+   other mode buttons with respect to hover (no leftover empty tooltip).
+
+---
+
+### Edge Cases
+
+- **Version still needed for support/debugging**: it remains available via the Pan
+  Mode guidance, so removing the tooltip does not hide the version entirely.
+- **Other mode buttons**: only the Pan Mode button carries the version tooltip
+  today; this change must not add or alter tooltips on the other mode buttons.
+- **Disabled Pan button**: the version tooltip previously appeared even while the
+  button was disabled; after the change there is no version tooltip in either
+  state.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Pan Mode button MUST NOT display the GramFrame version number as
+  a hover tooltip.
+- **FR-002**: The GramFrame version MUST continue to be displayed in the Pan Mode
+  guidance panel, unchanged.
+- **FR-003**: Removing the tooltip MUST NOT leave the Pan Mode button with an empty
+  or placeholder tooltip; it should behave like the other mode buttons regarding
+  hover.
+- **FR-004**: This change MUST NOT alter the version display or tooltips of any
+  other mode button or component.
+
+### Key Entities *(include if data involved)*
+
+- **Version indicator**: The GramFrame version string. This change reduces where it
+  is surfaced from two locations (Pan button tooltip + Pan guidance) to one (Pan
+  guidance only). The version value and its source are unchanged.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Hovering the Pan Mode button shows no version tooltip.
+- **SC-002**: The Pan Mode guidance still shows the version, so the version remains
+  discoverable in exactly one place.
+- **SC-003**: No other mode button's tooltip behaviour changes.
+
+## Assumptions
+
+- The version is currently shown in both the Pan Mode button tooltip and the Pan
+  Mode guidance; this change removes only the tooltip occurrence.
+- The version value and how it is generated/sourced are out of scope and unchanged.
+- No other button currently shows the version as a tooltip, so no other button is
+  affected.


### PR DESCRIPTION
## Summary

Issue #198 ("Review feedback") captured seven potential improvements from a review session. This PR turns them into a series of SpecKit feature specifications (spec.md files only — no code changes), grouped into **five independently-deliverable features**. Two ticket items were combined with their tightly-coupled siblings, following the ticket's own framing.

Closes #198 once all five specs are implemented (tracking, not code).

## Specs added

| # | Spec | Issue #198 item(s) |
|---|------|--------------------|
| 159 | `specs/159-harmonic-pin-labels` — Show all harmonic pins, label only the major subset, and centre the label above the symbol | items 1 & 2 |
| 160 | `specs/160-mouse-wheel-navigation` — Scroll to pan, Ctrl+scroll to zoom, wheel-drag to pan, plus guidance | item 3 |
| 161 | `specs/161-reformat-markers-harmonics` — "Cross" (symbol-less) default style + in-place restyling of existing markers and harmonic sets | items 4 & 5 |
| 162 | `specs/162-legacy-browser-check` — Early feature-detection guard with an "update your browser" warning instead of silent failure | item 6 |
| 163 | `specs/163-pan-tooltip-version` — Drop the redundant version tooltip from the Pan Mode button | item 7 |

## Grouping rationale

- **159 (items 1+2)**: Item 2 ("move label above symbol") is explicitly motivated by item 1 ("once we're showing all pins, labels will be obscured"). Both touch the same pin/label/symbol rendering surface, so they are one feature with two user stories.
- **161 (items 4+5)**: Item 4 ("cross symbol") is called out in the ticket as "a stepping stone to supporting reformatting" (item 5). They are one feature: the cross style is the symbol-less value the reformat selectors read and write.
- Items 3, 6, and 7 are self-contained and each get their own spec.

## Notes for reviewers

- Spec **159 revises** the pin-sampling behaviour introduced in spec **158**: instead of dropping whole pins beyond the limit, all pin *lines* are drawn and only *labels/symbols* are thinned. This is called out in that spec's Assumptions.
- Spec **161** extends markers to carry a symbol for the first time and makes marker colour display symbol-dependent (colour-coded symbol when a symbol is set, filled colour rectangle for the cross style).
- Specs are grounded in current behaviour (verified against `src/utils/harmonicSampling.js`, `src/modes/harmonics/HarmonicsMode.js`, `src/rendering/symbols.js`, `src/modes/analysis/AnalysisMode.js`, `src/modes/pan/PanMode.js`, `src/components/ModeButtons.js`, `src/utils/secureHTML.js`, and the entry/init flow) but describe requirements, not implementation.
- Each spec follows the repo's SpecKit `spec-template.md` (prioritised user stories, functional requirements, success criteria, assumptions). Plan/tasks artifacts are intentionally not generated here — this PR delivers the specifications only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAHwRiwzmUBCKBiUeHHwrW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAHwRiwzmUBCKBiUeHHwrW)_