### PR TITLE
feat(159): show all harmonic pins, label only the major subset

### DIFF
--- a/specs/159-harmonic-pin-labels/plan.md
+++ b/specs/159-harmonic-pin-labels/plan.md
@@ -1,0 +1,95 @@
+# Implementation Plan: Show All Harmonic Pins, Label Only the Major Subset
+
+**Feature Branch**: `159-harmonic-pin-labels`
+**Spec**: [spec.md](./spec.md)
+**Status**: Ready for implementation
+
+## Summary
+
+Spec 158 kept dense harmonic sets legible by *sampling the pins* — drawing only
+every Nth pin (default max 25) and dropping the rest entirely (line + label +
+symbol). Review feedback (GH #198) is that dropping the lines loses the harmonic
+structure analysts read. This feature keeps the sampling maths but re-targets it:
+
+1. **Every pin line** in the visible frequency span is drawn (US1 / FR-001).
+2. Only a **thinned "major" subset** (the same `sampledHarmonics()` result,
+   ≤ 25) gets a **number label + symbol** (US1 / FR-002–FR-008).
+3. Each drawn label is **centred horizontally on its pin** and stacked **above
+   its symbol** — vertical order label → symbol → pin line — clamped to stay
+   on-screen at the top edge (US2 / FR-009–FR-011).
+
+The pure sampling utility (`src/utils/harmonicSampling.js`) is unchanged; only
+its consumer (`HarmonicsMode`) changes what it applies the sample to.
+
+## Technical Context
+
+- **Language**: JavaScript (ES2020+, JSDoc-typed, no compilation), Vite build.
+- **Rendering**: SVG overlay in `HarmonicsMode.renderHarmonicSet()`.
+- **Viewport awareness**: visible span comes from `calculateVisibleDataRange()`,
+  so the drawn range and the labelled subset both recompute on every zoom/pan
+  (FR-006, FR-007) — no extra wiring needed.
+
+## Design
+
+### Pin lines (all) vs labels/symbols (thinned)
+
+`renderHarmonicSet()` derives the visible harmonic range
+`[minHarmonic, maxHarmonic]` and:
+
+- draws a `.gram-frame-harmonic-line` for **every** harmonic in the range;
+- computes the labelled subset once via
+  `sampledHarmonics(minHarmonic, maxHarmonic).harmonics` (a `Set`), and draws a
+  `.gram-frame-harmonic-symbol` + `.gram-frame-harmonic-number` only for those.
+
+Because the sampled subset is always a set of harmonics inside the drawn range,
+every label maps to a drawn pin (FR-008). When the range already fits under the
+cap, the sample is the whole range so every pin is labelled (FR-005).
+
+Lines are appended first, then symbols + labels, so labels/symbols paint on top
+of the (possibly dense) block of lines.
+
+### Label stack geometry (US2)
+
+A single per-set vertical layout is computed from the pin-line top and the image
+top edge (`calculateLabelStackPositions`):
+
+```
+label  (text-anchor=middle, x = pin lineX, baseline = labelY)   ← top
+symbol (centred at lineX, cy = symbolCy)
+pin line top (lineTop)                                          ← bottom
+```
+
+- symbol caps the line: `symbolCy = lineTop - r`
+- label baseline sits just above the symbol: `labelY = symbolCy - r - gap`
+- if the label's top would clip above the image top, the whole stack (label +
+  symbol) is nudged down by the overflow so it stays visible (FR-011).
+
+Labels gain `data-harmonic-set-id` + `data-harmonic-number` so tests can verify
+one-label-per-drawn-pin correspondence (FR-008).
+
+## Files Changed
+
+- `src/modes/harmonics/HarmonicsMode.js` — draw-all-lines / thin-labels logic,
+  centred-above-symbol label placement, shared stack geometry.
+- `tests/helpers/gram-frame-page.js` — scope `getHarmonicLabelNumbers()` to a set
+  and read the label's `data-harmonic-number`.
+- `tests/harmonic-pin-sampling.spec.js` — re-target 158's sampling assertions
+  from *drawn lines* to *drawn labels* (158's pin-dropping is superseded).
+- `tests/harmonic-labels.spec.js` — new E2E coverage for US1 (all lines drawn,
+  labels thinned) and US2 (label centred above symbol, clamped at top).
+- `tests/harmonic-symbols.spec.js` — flip the label-vs-symbol vertical-order
+  assertion to label-above-symbol.
+
+## Testing Strategy
+
+- Unit (`harmonic-sampling-unit.spec.js`): unchanged — util is untouched.
+- E2E US1: dense 0.5 Hz set → every line in span drawn (> cap), labels ≤ cap on a
+  regular step; sparse set → every pin drawn and labelled; zoom in refines the
+  label step down to 1; every label matches a drawn line.
+- E2E US2: label horizontally centred on its pin line and above its symbol;
+  near-top-edge stack stays within the image.
+
+## Out of Scope
+
+- Symbol catalogue / default symbol (specs 157/158).
+- Harmonic-set data model, colour, persistence, selection (unchanged; FR-012/13).

--- a/src/modes/harmonics/HarmonicsMode.js
+++ b/src/modes/harmonics/HarmonicsMode.js
@@ -127,6 +127,32 @@ export class HarmonicsMode extends BaseMode {
   static harmonicColors = ['#ff6b6b', '#2ecc71', '#f39c12', '#9b59b6', '#ffc93c', '#ff9ff3', '#45b7d1', '#e67e22']
 
   /**
+   * Pixel size (width/height) of a pin's symbol mark.
+   * @type {number}
+   */
+  static SYMBOL_SIZE = 10
+
+  /**
+   * Font size (px) of a pin's number label; also used as its approximate ascent
+   * when clamping the label/symbol stack to the image's top edge.
+   * @type {number}
+   */
+  static LABEL_FONT_SIZE = 12
+
+  /**
+   * Vertical gap (px) between the pin's number label and its symbol.
+   * @type {number}
+   */
+  static LABEL_GAP = 3
+
+  /**
+   * Minimum padding (px) kept between the top of a pin's label and the top edge
+   * of the spectrogram image.
+   * @type {number}
+   */
+  static STACK_TOP_PAD = 1
+
+  /**
    * Get guidance content for harmonics mode
    * @returns {Object} Structured guidance content
    */
@@ -635,22 +661,42 @@ export class HarmonicsMode extends BaseMode {
   }
 
   /**
-   * Get the harmonic numbers to draw for a set within the currently visible
-   * frequency span, capped and regularly sampled so a dense set stays legible.
+   * Get the inclusive harmonic-number range of a set that falls within the
+   * currently visible frequency span.
    *
    * The visible range comes from `calculateVisibleDataRange(instance)` (the same
-   * source the frequency axis uses), so pin density is viewport-aware: zooming
-   * in narrows the span and reveals more pins, zooming out / panning thins them.
-   * At zoom 1.0 the visible range equals the full data range.
+   * source the frequency axis uses), so it is viewport-aware: zooming in narrows
+   * the span (fewer harmonics), zooming out / panning widens it. At zoom 1.0 the
+   * visible range equals the full data range.
+   *
+   * Every harmonic in this range is drawn as a pin line (spec 159, FR-001); the
+   * label/symbol subset is a regularly-sampled slice of it (see
+   * {@link getLabelledHarmonics}).
    *
    * @param {HarmonicSet} harmonicSet - Harmonic set configuration
-   * @returns {number[]} Array of harmonic numbers to render (length <= cap)
+   * @returns {{minHarmonic: number, maxHarmonic: number}} Inclusive harmonic range
    */
-  getVisibleHarmonics(harmonicSet) {
+  getVisibleHarmonicRange(harmonicSet) {
     const { freqMin, freqMax } = calculateVisibleDataRange(this.instance)
     const minHarmonic = Math.max(1, Math.ceil(freqMin / harmonicSet.spacing))
     const maxHarmonic = Math.floor(freqMax / harmonicSet.spacing)
+    return { minHarmonic, maxHarmonic }
+  }
 
+  /**
+   * Get the "major" subset of harmonic numbers that receive a number label and
+   * symbol, thinned to at most the label limit (default 25) by regular sampling.
+   *
+   * Reuses the spec-158 sampling maths, but that limit now governs
+   * labels/symbols only — every pin line is still drawn (spec 159). When the
+   * visible range already fits under the limit the subset is the whole range, so
+   * every drawn pin is labelled (FR-005).
+   *
+   * @param {number} minHarmonic - Lowest visible harmonic number (>= 1)
+   * @param {number} maxHarmonic - Highest visible harmonic number
+   * @returns {number[]} Ascending harmonic numbers to label/symbol (length <= cap)
+   */
+  getLabelledHarmonics(minHarmonic, maxHarmonic) {
     return sampledHarmonics(minHarmonic, maxHarmonic).harmonics
   }
 
@@ -698,18 +744,26 @@ export class HarmonicsMode extends BaseMode {
   }
 
   /**
-   * Create SVG text label for a harmonic number
+   * Create SVG text label for a harmonic number.
+   *
+   * Centred horizontally on the pin's line (`text-anchor: middle` at `lineX`) and
+   * positioned above the pin's symbol (baseline at `labelY`), so the vertical
+   * stack over a pin reads label -> symbol -> line (spec 159, FR-009/FR-010).
+   *
    * @param {number} harmonicNumber - Harmonic number
    * @param {HarmonicSet} harmonicSet - Harmonic set configuration
-   * @param {number} lineX - X position for the label
-   * @param {number} lineTop - Top Y position for the label
+   * @param {number} lineX - X position of the pin line (label is centred on it)
+   * @param {number} labelY - Baseline Y position for the label text
    * @returns {SVGTextElement} SVG text element
    */
-  createHarmonicLabel(harmonicNumber, harmonicSet, lineX, lineTop) {
+  createHarmonicLabel(harmonicNumber, harmonicSet, lineX, labelY) {
     const label = document.createElementNS('http://www.w3.org/2000/svg', 'text')
     label.setAttribute('class', 'gram-frame-harmonic-number')
-    label.setAttribute('x', String(lineX + 3)) // 3 pixels to the right of line
-    label.setAttribute('y', String(lineTop + 12)) // 12 pixels down from top
+    label.setAttribute('data-harmonic-set-id', harmonicSet.id)
+    label.setAttribute('data-harmonic-number', String(harmonicNumber))
+    label.setAttribute('x', String(lineX)) // centred on the pin line
+    label.setAttribute('y', String(labelY)) // above the symbol
+    label.setAttribute('text-anchor', 'middle')
     label.setAttribute('fill', harmonicSet.color)
     label.setAttribute('font-size', '12')
     label.setAttribute('font-weight', 'bold')
@@ -719,35 +773,79 @@ export class HarmonicsMode extends BaseMode {
   }
 
   /**
-   * Create the filled symbol mark drawn at the top of a pin.
+   * Create the filled symbol mark drawn between a pin's number label and the top
+   * of its line.
    *
-   * Centred horizontally on the pin line and placed just above the line's top
-   * endpoint so it caps the pin without obscuring the number label (which is
-   * drawn to the right of, and below, the line top). Nudged downward if it would
-   * otherwise clip the top edge of the spectrogram image.
+   * The vertical position (`symbolCy`) is computed once per set by
+   * {@link calculateLabelStackPositions} so the whole label/symbol stack shares a
+   * consistent, on-screen layout.
    *
    * @param {HarmonicSet} harmonicSet - Harmonic set configuration
-   * @param {number} lineX - X position of the pin line
-   * @param {number} lineTop - Top Y position of the pin line
-   * @param {number} imageTop - Top edge of the spectrogram image in SVG coords
+   * @param {number} lineX - X position of the pin line (symbol is centred on it)
+   * @param {number} symbolCy - Centre Y position for the symbol
    * @returns {SVGElement} SVG symbol element
    */
-  createHarmonicSymbol(harmonicSet, lineX, lineTop, imageTop) {
-    const size = 10
-    const r = size / 2
-    // Cap the pin: sit the symbol just above the line's top endpoint.
-    let cy = lineTop - r
-    // Nudge downward if the symbol would clip the top edge of the image.
-    if (cy - r < imageTop) {
-      cy = imageTop + r
-    }
-    const symbol = createSymbolMark(harmonicSet.symbol, lineX, cy, size, harmonicSet.color)
+  createHarmonicSymbol(harmonicSet, lineX, symbolCy) {
+    const symbol = createSymbolMark(
+      harmonicSet.symbol, lineX, symbolCy, HarmonicsMode.SYMBOL_SIZE, harmonicSet.color
+    )
     symbol.setAttribute('data-harmonic-set-id', harmonicSet.id)
     return symbol
   }
 
   /**
-   * Render a single harmonic set as vertical lines
+   * Compute the shared vertical layout of a pin's label/symbol stack.
+   *
+   * Ideal (top-to-bottom): label baseline, then symbol, then the pin line top,
+   * so the symbol caps the line and the label sits above the symbol. When the
+   * stack's top would clip above the spectrogram's top edge, the whole stack
+   * (label + symbol) is nudged down by the overflow so it stays legible
+   * (spec 159, FR-011).
+   *
+   * @param {number} lineTop - Top Y position of the pin lines (SVG coords)
+   * @param {number} imageTop - Top edge of the spectrogram image in SVG coords
+   * @returns {{symbolCy: number, labelY: number}} Symbol centre and label baseline Y
+   */
+  calculateLabelStackPositions(lineTop, imageTop) {
+    const r = HarmonicsMode.SYMBOL_SIZE / 2
+    const gap = HarmonicsMode.LABEL_GAP
+    const fontSize = HarmonicsMode.LABEL_FONT_SIZE
+
+    // Symbol caps the line; label baseline sits just above the symbol.
+    let symbolCy = lineTop - r
+    let labelY = symbolCy - r - gap
+
+    // Keep the top of the label (approx one ascent above its baseline) on-screen.
+    const labelTop = labelY - fontSize
+    const minTop = imageTop + HarmonicsMode.STACK_TOP_PAD
+    if (labelTop < minTop) {
+      const shift = minTop - labelTop
+      symbolCy += shift
+      labelY += shift
+    }
+
+    return { symbolCy, labelY }
+  }
+
+  /**
+   * Compute the SVG x-coordinate of a harmonic's vertical pin line.
+   * @param {HarmonicSet} harmonicSet - Harmonic set configuration
+   * @param {number} harmonicNumber - Harmonic number
+   * @returns {number} SVG x-coordinate of the pin line
+   */
+  harmonicLineX(harmonicSet, harmonicNumber) {
+    const harmonicPoint = { freq: harmonicNumber * harmonicSet.spacing, time: harmonicSet.anchorTime }
+    return calculateZoomAwarePosition(harmonicPoint, this.getViewport(), this.instance.spectrogramImage).x
+  }
+
+  /**
+   * Render a single harmonic set as vertical pin lines.
+   *
+   * Spec 159: draw a pin line for EVERY harmonic in the visible span (no pins are
+   * dropped, even if they merge into a solid block), then draw a number label and
+   * symbol only for the thinned "major" subset so the overlay stays readable.
+   * Lines are appended first so the labels/symbols paint on top of them.
+   *
    * @param {HarmonicSet} harmonicSet - Harmonic set to render
    */
   renderHarmonicSet(harmonicSet) {
@@ -755,28 +853,32 @@ export class HarmonicsMode extends BaseMode {
       return
     }
 
-    // Get visible harmonics and line dimensions
-    const visibleHarmonics = this.getVisibleHarmonics(harmonicSet)
+    const { minHarmonic, maxHarmonic } = this.getVisibleHarmonicRange(harmonicSet)
+    if (maxHarmonic < minHarmonic) {
+      return
+    }
+
     const { lineHeight, lineTop } = this.calculateHarmonicLineDimensions(harmonicSet)
     const imageTop = getImageBounds(this.getViewport(), this.instance.spectrogramImage).top
 
-    // Render each harmonic line in this set
-    visibleHarmonics.forEach(harmonicNumber => {
-      const harmonicFreq = harmonicNumber * harmonicSet.spacing
-
-      // Calculate X position using coordinate transformation utility
-      const harmonicPoint = { freq: harmonicFreq, time: harmonicSet.anchorTime }
-      const harmonicSVG = calculateZoomAwarePosition(harmonicPoint, this.getViewport(), this.instance.spectrogramImage)
-      const lineX = harmonicSVG.x
-
-      // Create and append line, label, and symbol elements
+    // Draw every pin line in the visible span (FR-001).
+    for (let harmonicNumber = minHarmonic; harmonicNumber <= maxHarmonic; harmonicNumber++) {
+      const lineX = this.harmonicLineX(harmonicSet, harmonicNumber)
       const line = this.createHarmonicLine(harmonicNumber, harmonicSet, lineX, lineTop, lineHeight)
-      const label = this.createHarmonicLabel(harmonicNumber, harmonicSet, lineX, lineTop)
-      const symbol = this.createHarmonicSymbol(harmonicSet, lineX, lineTop, imageTop)
-
       this.instance.cursorGroup.appendChild(line)
-      this.instance.cursorGroup.appendChild(label)
+    }
+
+    // Draw labels + symbols only on the thinned major subset (FR-002), stacked
+    // above each pin line with a shared, on-screen vertical layout.
+    const labelledHarmonics = this.getLabelledHarmonics(minHarmonic, maxHarmonic)
+    const { symbolCy, labelY } = this.calculateLabelStackPositions(lineTop, imageTop)
+
+    labelledHarmonics.forEach(harmonicNumber => {
+      const lineX = this.harmonicLineX(harmonicSet, harmonicNumber)
+      const symbol = this.createHarmonicSymbol(harmonicSet, lineX, symbolCy)
+      const label = this.createHarmonicLabel(harmonicNumber, harmonicSet, lineX, labelY)
       this.instance.cursorGroup.appendChild(symbol)
+      this.instance.cursorGroup.appendChild(label)
     })
   }
 

--- a/tests/harmonic-labels.spec.js
+++ b/tests/harmonic-labels.spec.js
@@ -1,0 +1,225 @@
+import { test, expect } from './helpers/fixtures.js'
+import { MAX_VISIBLE_PINS } from '../src/utils/harmonicSampling.js'
+
+/**
+ * @fileoverview E2E tests for feature 159 — show every harmonic pin line, label
+ * only the thinned "major" subset, and stack each label centred above its symbol.
+ *
+ * Debug config spans freq 0-100 Hz over time 0-60 s, so a 0.5 Hz set places 200
+ * pins (harmonics 1..200) across the visible span.
+ *
+ * @see specs/159-harmonic-pin-labels/spec.md
+ */
+
+/**
+ * Read per-harmonic client-rect geometry for one set's lines, labels and symbols.
+ * Symbols carry no harmonic number, so each is matched to a line by nearest
+ * centre-x. Returns null entries where a labelled harmonic has no matched symbol.
+ * @param {import('./helpers/gram-frame-page.js').GramFramePage} gfp - Page helper
+ * @param {string} setId - Harmonic set id
+ * @returns {Promise<{image: {top:number}, byNum: Record<string, any>}>}
+ */
+async function readStackGeometry(gfp, setId) {
+  return gfp.page.evaluate((id) => {
+    const centreX = (r) => (r.left + r.right) / 2
+    const image = document.querySelector('.gram-frame-spectrogram-image')
+    const imageRect = image.getBoundingClientRect()
+
+    const lines = Array.from(document.querySelectorAll(
+      `.gram-frame-harmonic-line[data-harmonic-set-id="${id}"]`
+    ))
+    const labels = Array.from(document.querySelectorAll(
+      `.gram-frame-harmonic-number[data-harmonic-set-id="${id}"]`
+    ))
+    const symbols = Array.from(document.querySelectorAll(
+      `.gram-frame-harmonic-symbol[data-harmonic-set-id="${id}"]`
+    ))
+
+    /** @type {Record<string, any>} */
+    const byNum = {}
+    for (const label of labels) {
+      const num = label.getAttribute('data-harmonic-number')
+      const line = lines.find((l) => l.getAttribute('data-harmonic-number') === num)
+      if (!line) continue
+      const lineRect = line.getBoundingClientRect()
+      const lineCx = centreX(lineRect)
+      const labelRect = label.getBoundingClientRect()
+
+      // Match the symbol whose centre-x is closest to this pin's line.
+      let symbolRect = null
+      let best = Infinity
+      for (const s of symbols) {
+        const sr = s.getBoundingClientRect()
+        const d = Math.abs(centreX(sr) - lineCx)
+        if (d < best) { best = d; symbolRect = sr }
+      }
+
+      byNum[num] = {
+        lineTop: lineRect.top,
+        lineCx,
+        labelBottom: labelRect.bottom,
+        labelTop: labelRect.top,
+        labelCx: centreX(labelRect),
+        symbolTop: symbolRect ? symbolRect.top : null,
+        symbolBottom: symbolRect ? symbolRect.bottom : null,
+        symbolCx: symbolRect ? centreX(symbolRect) : null
+      }
+    }
+    return { image: { top: imageRect.top }, byNum }
+  }, setId)
+}
+
+test.describe('Harmonic Pin Labels (feature 159)', () => {
+  test.beforeEach(async ({ gramFramePage }) => {
+    await gramFramePage.page.waitForTimeout(100)
+    await gramFramePage.clickMode('Harmonics')
+    await gramFramePage.waitForImageDimensions()
+  })
+
+  // ────────────────────────────────────────────────────────────────
+  // User Story 1 — See every harmonic pin, even at high density
+  // ────────────────────────────────────────────────────────────────
+  test.describe('US1: every pin line drawn, only labels thinned', () => {
+    test('a dense set draws a line for every harmonic in the span (no gaps)', async ({ gramFramePage }) => {
+      const setId = await gramFramePage.addHarmonicSet(30, 0.5)
+      await gramFramePage.page.waitForTimeout(100)
+
+      const lineNums = await gramFramePage.getHarmonicNumbers(setId)
+      // Far more than the label cap are drawn
+      expect(lineNums.length).toBeGreaterThan(MAX_VISIBLE_PINS)
+      // Contiguous run of every harmonic in the span (no dropped lines)
+      for (let i = 1; i < lineNums.length; i++) {
+        expect(lineNums[i]).toBe(lineNums[i - 1] + 1)
+      }
+      // freq 0-100 at 0.5 Hz -> harmonics 1..200
+      expect(lineNums[0]).toBe(1)
+      expect(lineNums[lineNums.length - 1]).toBe(200)
+    })
+
+    test('labels are a bounded, evenly-spaced subset of the drawn lines', async ({ gramFramePage }) => {
+      const setId = await gramFramePage.addHarmonicSet(30, 0.5)
+      await gramFramePage.page.waitForTimeout(100)
+
+      const lineNums = new Set(await gramFramePage.getHarmonicNumbers(setId))
+      const labelNums = await gramFramePage.getHarmonicLabelNumbers(setId)
+
+      expect(labelNums.length).toBeGreaterThan(0)
+      expect(labelNums.length).toBeLessThanOrEqual(MAX_VISIBLE_PINS)
+      // Every label maps to an actual drawn pin (no orphan labels, FR-008)
+      for (const n of labelNums) {
+        expect(lineNums.has(n)).toBe(true)
+      }
+      // Evenly spaced (regular step > 1 for a dense set, FR-004)
+      const step = labelNums[1] - labelNums[0]
+      expect(step).toBeGreaterThan(1)
+      for (let i = 1; i < labelNums.length; i++) {
+        expect(labelNums[i] - labelNums[i - 1]).toBe(step)
+      }
+    })
+
+    test('one symbol per labelled pin, capped with the labels', async ({ gramFramePage }) => {
+      const setId = await gramFramePage.addHarmonicSet(30, 0.5)
+      await gramFramePage.page.waitForTimeout(100)
+
+      const labelCount = (await gramFramePage.getHarmonicLabelNumbers(setId)).length
+      const symbols = await gramFramePage.getPinSymbols(setId)
+      expect(symbols.length).toBe(labelCount)
+      expect(symbols.length).toBeLessThanOrEqual(MAX_VISIBLE_PINS)
+    })
+
+    test('a set within the limit labels every drawn pin', async ({ gramFramePage }) => {
+      // spacing 20 Hz over 0-100 Hz -> harmonics 1..5, under the cap
+      const setId = await gramFramePage.addHarmonicSet(30, 20)
+      await gramFramePage.page.waitForTimeout(100)
+
+      const lineNums = await gramFramePage.getHarmonicNumbers(setId)
+      const labelNums = await gramFramePage.getHarmonicLabelNumbers(setId)
+      expect(lineNums).toEqual([1, 2, 3, 4, 5])
+      expect(labelNums).toEqual([1, 2, 3, 4, 5])
+    })
+
+    test('zooming in on a dense set never coarsens the label step', async ({ gramFramePage }) => {
+      const setId = await gramFramePage.addHarmonicSet(30, 0.5)
+      await gramFramePage.page.waitForTimeout(100)
+
+      /** @type {number|null} */
+      let prevStep = null
+      for (const level of [1.0, 2.0, 4.0, 8.0]) {
+        await gramFramePage.setZoom(level, 0.5, 0.5)
+        await gramFramePage.page.waitForTimeout(100)
+
+        // Every visible pin still has a line (contiguous) at each zoom level
+        const lineNums = await gramFramePage.getHarmonicNumbers(setId)
+        for (let i = 1; i < lineNums.length; i++) {
+          expect(lineNums[i]).toBe(lineNums[i - 1] + 1)
+        }
+
+        const labelNums = await gramFramePage.getHarmonicLabelNumbers(setId)
+        expect(labelNums.length).toBeLessThanOrEqual(MAX_VISIBLE_PINS)
+        const step = labelNums.length >= 2 ? labelNums[1] - labelNums[0] : 1
+        if (prevStep !== null) {
+          expect(step).toBeLessThanOrEqual(prevStep)
+        }
+        prevStep = step
+      }
+    })
+  })
+
+  // ────────────────────────────────────────────────────────────────
+  // User Story 2 — Read labels clearly above the pins
+  // ────────────────────────────────────────────────────────────────
+  test.describe('US2: label centred above the symbol', () => {
+    test('each label is centred on its pin and stacked above symbol above line', async ({ gramFramePage }) => {
+      // Sparse set -> every pin labelled, clear 1:1 label/symbol/line matching
+      const setId = await gramFramePage.addHarmonicSet(30, 20)
+      await gramFramePage.page.waitForTimeout(100)
+
+      // Label element attributes: centred on the pin line, anchored middle
+      const attrs = await gramFramePage.page.evaluate((id) => {
+        const line = document.querySelector(
+          `.gram-frame-harmonic-line[data-harmonic-set-id="${id}"][data-harmonic-number="2"]`
+        )
+        const label = document.querySelector(
+          `.gram-frame-harmonic-number[data-harmonic-set-id="${id}"][data-harmonic-number="2"]`
+        )
+        return {
+          lineX: parseFloat(line.getAttribute('x1')),
+          labelX: parseFloat(label.getAttribute('x')),
+          anchor: label.getAttribute('text-anchor')
+        }
+      }, setId)
+      expect(attrs.anchor).toBe('middle')
+      expect(Math.abs(attrs.labelX - attrs.lineX)).toBeLessThanOrEqual(0.5)
+
+      // Client-rect geometry: label above symbol above line top, centred
+      const { byNum } = await readStackGeometry(gramFramePage, setId)
+      const entries = Object.values(byNum)
+      expect(entries.length).toBeGreaterThan(0)
+      for (const g of entries) {
+        // Horizontally centred on the pin (within a few px)
+        expect(Math.abs(g.labelCx - g.lineCx)).toBeLessThanOrEqual(3)
+        expect(Math.abs(g.symbolCx - g.lineCx)).toBeLessThanOrEqual(3)
+        // Vertical order: label -> symbol -> line top (small tolerance)
+        expect(g.labelBottom).toBeLessThanOrEqual(g.symbolTop + 2)
+        expect(g.symbolBottom).toBeLessThanOrEqual(g.lineTop + 2)
+      }
+    })
+
+    test('a label/symbol stack near the top edge stays within the image', async ({ gramFramePage }) => {
+      // Place the pin at each time extreme; whichever puts the pin near the top
+      // must still keep the label within the image's top edge (FR-011).
+      for (const anchorTime of [0, 60]) {
+        const setId = await gramFramePage.addHarmonicSet(anchorTime, 20)
+        await gramFramePage.page.waitForTimeout(100)
+
+        const { image, byNum } = await readStackGeometry(gramFramePage, setId)
+        const entries = Object.values(byNum)
+        expect(entries.length).toBeGreaterThan(0)
+        for (const g of entries) {
+          // The label never renders above the top edge of the spectrogram
+          expect(g.labelTop).toBeGreaterThanOrEqual(image.top - 1)
+        }
+      }
+    })
+  })
+})

--- a/tests/harmonic-pin-sampling.spec.js
+++ b/tests/harmonic-pin-sampling.spec.js
@@ -2,14 +2,19 @@ import { test, expect } from './helpers/fixtures.js'
 import { MAX_VISIBLE_PINS, NICE_STEPS } from '../src/utils/harmonicSampling.js'
 
 /**
- * @fileoverview E2E tests for harmonic pin sampling (feature 158).
+ * @fileoverview E2E tests for harmonic pin sampling (feature 158), updated for
+ * feature 159 which supersedes 158's pin-dropping.
  *
  * The debug page config spans freq 0-100 Hz over time 0-60 s. A harmonic set
- * with 0.5 Hz spacing would place 200 pins across that span; sampling caps the
- * drawn pins at MAX_VISIBLE_PINS (25) and thins to a regular "nice" step. A
- * sparse set (large spacing) is drawn in full.
+ * with 0.5 Hz spacing would place 200 pins across that span. Feature 159 draws a
+ * pin LINE for every one of them; the spec-158 sampling maths (cap
+ * MAX_VISIBLE_PINS = 25, regular "nice" step) now governs which pins carry a
+ * number LABEL/symbol. So these tests assert the sampling invariants on the
+ * drawn labels, not on the drawn lines. A sparse set (large spacing) is drawn
+ * and labelled in full.
  *
  * @see specs/158-harmonic-pin-sampling/spec.md
+ * @see specs/159-harmonic-pin-labels/spec.md
  */
 
 /**
@@ -39,21 +44,26 @@ test.describe('Harmonic Pin Sampling (feature 158)', () => {
   // ────────────────────────────────────────────────────────────────
   test.describe('US1: dense sets stay legible', () => {
     // T012
-    test('a dense 0.5 Hz set over a wide span draws no more than the cap', async ({ gramFramePage }) => {
+    test('a dense 0.5 Hz set labels no more than the cap while drawing all pins', async ({ gramFramePage }) => {
       const setId = await gramFramePage.addHarmonicSet(30, 0.5)
       await gramFramePage.page.waitForTimeout(100)
 
-      const count = await gramFramePage.getHarmonicLineCount(setId)
-      expect(count).toBeGreaterThan(0)
-      expect(count).toBeLessThanOrEqual(MAX_VISIBLE_PINS)
+      // Every pin line is drawn (200 across 0-100 Hz) -> well over the label cap
+      const lineCount = await gramFramePage.getHarmonicLineCount(setId)
+      expect(lineCount).toBeGreaterThan(MAX_VISIBLE_PINS)
+
+      // Only the thinned major subset carries a label
+      const labelCount = (await gramFramePage.getHarmonicLabelNumbers(setId)).length
+      expect(labelCount).toBeGreaterThan(0)
+      expect(labelCount).toBeLessThanOrEqual(MAX_VISIBLE_PINS)
     })
 
     // T013
-    test('drawn harmonic numbers form a constant-step series from NICE_STEPS', async ({ gramFramePage }) => {
+    test('labelled harmonic numbers form a constant-step series from NICE_STEPS', async ({ gramFramePage }) => {
       const setId = await gramFramePage.addHarmonicSet(30, 0.5)
       await gramFramePage.page.waitForTimeout(100)
 
-      const nums = await gramFramePage.getHarmonicNumbers(setId)
+      const nums = await gramFramePage.getHarmonicLabelNumbers(setId)
       // Ascending order
       for (let i = 1; i < nums.length; i++) {
         expect(nums[i]).toBeGreaterThan(nums[i - 1])
@@ -63,21 +73,23 @@ test.describe('Harmonic Pin Sampling (feature 158)', () => {
       // Dense set is thinned, so the step is a NICE_STEPS member greater than 1
       expect(NICE_STEPS).toContain(step)
       expect(step).toBeGreaterThan(1)
-      // Every drawn number is a multiple of the step (anchored on multiples)
+      // Every labelled number is a multiple of the step (anchored on multiples)
       for (const n of nums) {
         expect(n % (/** @type {number} */ (step))).toBe(0)
       }
     })
 
     // T014
-    test('a sparse set draws every pin (no thinning, step 1)', async ({ gramFramePage }) => {
+    test('a sparse set draws and labels every pin (no thinning, step 1)', async ({ gramFramePage }) => {
       // spacing 20 Hz over 0-100 Hz -> harmonics 1..5, well under the cap
       const setId = await gramFramePage.addHarmonicSet(30, 20)
       await gramFramePage.page.waitForTimeout(100)
 
-      const nums = await gramFramePage.getHarmonicNumbers(setId)
-      expect(nums).toEqual([1, 2, 3, 4, 5])
-      expect(nums.length).toBeLessThanOrEqual(MAX_VISIBLE_PINS)
+      const lineNums = await gramFramePage.getHarmonicNumbers(setId)
+      expect(lineNums).toEqual([1, 2, 3, 4, 5])
+      // Under the cap -> every drawn pin is labelled
+      const labelNums = await gramFramePage.getHarmonicLabelNumbers(setId)
+      expect(labelNums).toEqual([1, 2, 3, 4, 5])
     })
   })
 
@@ -93,7 +105,7 @@ test.describe('Harmonic Pin Sampling (feature 158)', () => {
   // the invariant the spec guarantees, so that is what we assert.
   test.describe('US2: progressive disclosure on zoom/pan', () => {
     // T016
-    test('zooming in yields the same or a finer step and stays within the cap', async ({ gramFramePage }) => {
+    test('zooming in yields the same or a finer label step and stays within the cap', async ({ gramFramePage }) => {
       const setId = await gramFramePage.addHarmonicSet(30, 0.5)
       await gramFramePage.page.waitForTimeout(100)
 
@@ -103,11 +115,11 @@ test.describe('Harmonic Pin Sampling (feature 158)', () => {
         await gramFramePage.setZoom(level, 0.5, 0.5)
         await gramFramePage.page.waitForTimeout(100)
 
-        const nums = await gramFramePage.getHarmonicNumbers(setId)
+        const nums = await gramFramePage.getHarmonicLabelNumbers(setId)
         expect(nums.length).toBeLessThanOrEqual(MAX_VISIBLE_PINS)
         const step = arithmeticStep(nums) ?? 1
         if (prevStep !== null) {
-          // density never decreases when zooming in -> step never coarsens
+          // density never decreases when zooming in -> label step never coarsens
           expect(step).toBeLessThanOrEqual(prevStep)
         }
         prevStep = step
@@ -115,12 +127,12 @@ test.describe('Harmonic Pin Sampling (feature 158)', () => {
     })
 
     // T017
-    test('zooming in far enough shows every pin in view (step 1)', async ({ gramFramePage }) => {
+    test('zooming in far enough labels every pin in view (step 1)', async ({ gramFramePage }) => {
       const setId = await gramFramePage.addHarmonicSet(30, 0.5)
       await gramFramePage.page.waitForTimeout(100)
 
       // Zoom in progressively until the visible span is small enough that every
-      // pin is shown (step 1). Robust to the configured cap value.
+      // pin is labelled (step 1). Robust to the configured cap value.
       /** @type {number|null} */
       let step = null
       /** @type {number[]} */
@@ -128,27 +140,27 @@ test.describe('Harmonic Pin Sampling (feature 158)', () => {
       for (const level of [4.0, 8.0, 16.0, 32.0]) {
         await gramFramePage.setZoom(level, 0.5, 0.5)
         await gramFramePage.page.waitForTimeout(100)
-        nums = await gramFramePage.getHarmonicNumbers(setId)
+        nums = await gramFramePage.getHarmonicLabelNumbers(setId)
         expect(nums.length).toBeLessThanOrEqual(MAX_VISIBLE_PINS)
         step = arithmeticStep(nums)
         if (step === 1) break
       }
       expect(nums.length).toBeGreaterThan(0)
-      // Every consecutive harmonic present -> nothing thinned out
+      // Every consecutive harmonic labelled -> nothing thinned out
       expect(step).toBe(1)
     })
 
     // T018
-    test('zoom out/reset returns to a thinned state; a pan keeps the same step', async ({ gramFramePage }) => {
+    test('zoom out/reset returns to a thinned state; a pan keeps the same label step', async ({ gramFramePage }) => {
       const setId = await gramFramePage.addHarmonicSet(30, 0.5)
       await gramFramePage.page.waitForTimeout(100)
 
-      // Zoom in far enough to reveal every pin (step 1)
+      // Zoom in far enough to label every pin (step 1)
       let zoomedStep = null
       for (const level of [4.0, 8.0, 16.0, 32.0]) {
         await gramFramePage.setZoom(level, 0.5, 0.5)
         await gramFramePage.page.waitForTimeout(100)
-        zoomedStep = arithmeticStep(await gramFramePage.getHarmonicNumbers(setId))
+        zoomedStep = arithmeticStep(await gramFramePage.getHarmonicLabelNumbers(setId))
         if (zoomedStep === 1) break
       }
       expect(zoomedStep).toBe(1)
@@ -156,25 +168,25 @@ test.describe('Harmonic Pin Sampling (feature 158)', () => {
       // Reset -> thinned again, within cap, coarser step
       await gramFramePage.setZoom(1.0, 0.5, 0.5)
       await gramFramePage.page.waitForTimeout(100)
-      const resetNums = await gramFramePage.getHarmonicNumbers(setId)
+      const resetNums = await gramFramePage.getHarmonicLabelNumbers(setId)
       expect(resetNums.length).toBeLessThanOrEqual(MAX_VISIBLE_PINS)
       const resetStep = arithmeticStep(resetNums)
       expect(resetStep).toBeGreaterThan(1)
 
       // Pan at a fixed zoom (with comfortable margin from the cap threshold):
-      // the step is unchanged, only which multiples are in view shifts.
+      // the label step is unchanged, only which multiples are labelled shifts.
       await gramFramePage.setZoom(3.0, 0.5, 0.5)
       await gramFramePage.page.waitForTimeout(100)
-      const before = await gramFramePage.getHarmonicNumbers(setId)
+      const before = await gramFramePage.getHarmonicLabelNumbers(setId)
       const stepBefore = arithmeticStep(before)
 
       await gramFramePage.setZoom(3.0, 0.6, 0.5)
       await gramFramePage.page.waitForTimeout(100)
-      const after = await gramFramePage.getHarmonicNumbers(setId)
+      const after = await gramFramePage.getHarmonicLabelNumbers(setId)
       const stepAfter = arithmeticStep(after)
 
       expect(stepAfter).toBe(stepBefore)
-      // Panning shifted the window -> the specific pins in view changed
+      // Panning shifted the window -> the specific pins labelled changed
       expect(after[0]).not.toBe(before[0])
     })
   })
@@ -185,34 +197,37 @@ test.describe('Harmonic Pin Sampling (feature 158)', () => {
   test.describe('US3: label and interaction consistency', () => {
     // T020
     test('every label corresponds to a drawn line (no orphan labels)', async ({ gramFramePage }) => {
-      await gramFramePage.addHarmonicSet(30, 0.5)
+      const setId = await gramFramePage.addHarmonicSet(30, 0.5)
       await gramFramePage.page.waitForTimeout(100)
 
-      const lineNums = await gramFramePage.getHarmonicNumbers()
-      const labelNums = await gramFramePage.getHarmonicLabelNumbers()
+      const lineNums = await gramFramePage.getHarmonicNumbers(setId)
+      const labelNums = await gramFramePage.getHarmonicLabelNumbers(setId)
 
-      // One label per drawn line, and each label's number is a drawn line number
-      expect(labelNums.length).toBe(lineNums.length)
+      // Labels are a thinned subset of the (all-drawn) lines: fewer labels than
+      // lines, and every label's number is a drawn line number.
+      expect(labelNums.length).toBeGreaterThan(0)
+      expect(labelNums.length).toBeLessThanOrEqual(lineNums.length)
       const lineSet = new Set(lineNums)
       for (const label of labelNums) {
         expect(lineSet.has(label)).toBe(true)
       }
-      expect([...labelNums].sort((a, b) => a - b)).toEqual([...lineNums].sort((a, b) => a - b))
     })
 
     // T021
-    test('a thinned set stays selectable in a sampling gap and adjustable', async ({ gramFramePage }) => {
+    test('a thinned set stays selectable in a label gap and adjustable', async ({ gramFramePage }) => {
       const setId = await gramFramePage.addHarmonicSet(30, 0.5)
       await gramFramePage.page.waitForTimeout(100)
 
-      // Confirm the overlay is genuinely thinned (a real sampling gap exists)
-      const nums = await gramFramePage.getHarmonicNumbers(setId)
-      const step = arithmeticStep(nums)
+      // Confirm the labels are genuinely thinned (a real label gap exists)
+      const labelNums = await gramFramePage.getHarmonicLabelNumbers(setId)
+      const step = arithmeticStep(labelNums)
       expect(step).toBeGreaterThan(1)
+      // Harmonic 7 is drawn as a line but is NOT labelled (labels anchored on
+      // multiples of the step > 1)
+      expect(labelNums).not.toContain(7)
 
-      // Harmonic 7 (freq 3.5 Hz) is a real harmonic that is NOT drawn (step is a
-      // multiple > 1 anchored on multiples of the step). Hit-testing runs over
-      // the FULL series, so the set is still selectable in that gap.
+      // Harmonic 7 (freq 3.5 Hz). Hit-testing runs over the FULL series of drawn
+      // pins, so the set is still selectable at an unlabelled pin.
       const gapFreq = 7 * 0.5
       const result = await gramFramePage.page.evaluate(([id, freq]) => {
         // @ts-ignore - test-only global
@@ -250,12 +265,13 @@ test.describe('Harmonic Pin Sampling (feature 158)', () => {
       // Adjustment took effect
       expect(result.spacingChanged).toBe(true)
 
-      // After adjustment the overlay is still bounded and consistent
+      // After adjustment the labels are still bounded and a subset of the lines
       await gramFramePage.page.waitForTimeout(100)
       const afterNums = await gramFramePage.getHarmonicNumbers(setId)
-      expect(afterNums.length).toBeLessThanOrEqual(MAX_VISIBLE_PINS)
-      const afterLabels = await gramFramePage.getHarmonicLabelNumbers()
-      expect(afterLabels.length).toBe(afterNums.length)
+      const afterLabels = await gramFramePage.getHarmonicLabelNumbers(setId)
+      expect(afterLabels.length).toBeGreaterThan(0)
+      expect(afterLabels.length).toBeLessThanOrEqual(MAX_VISIBLE_PINS)
+      expect(afterLabels.length).toBeLessThanOrEqual(afterNums.length)
     })
   })
 })

--- a/tests/harmonic-symbols.spec.js
+++ b/tests/harmonic-symbols.spec.js
@@ -79,19 +79,42 @@ test.describe('US1: Symbols on harmonic pins', () => {
       expect(s.fill.toLowerCase()).toBe(String(set.color).toLowerCase())
     }
 
-    // The pin-number label is present and not obscured — the symbol sits above
-    // the label rather than overlapping it (FR-006).
-    const overlap = await gramFramePage.page.evaluate(() => {
-      const symbol = document.querySelector('.gram-frame-harmonic-symbol')
-      const label = document.querySelector('.gram-frame-harmonic-number')
-      if (!symbol || !label) return null
-      const s = symbol.getBoundingClientRect()
+    // The pin-number label is present and not obscured — spec 159 stacks the
+    // label ABOVE the symbol (order: label, symbol, line), and centres the label
+    // horizontally on the pin. Scope to the pin overlay (symbols with a set id;
+    // the harmonics-table swatches share the class but carry no set id) and pair
+    // a label with the symbol on the same pin (nearest centre-x).
+    const overlap = await gramFramePage.page.evaluate((setId) => {
+      const centreX = (r) => (r.left + r.right) / 2
+      const label = document.querySelector(
+        `.gram-frame-harmonic-number[data-harmonic-set-id="${setId}"]`
+      )
+      const symbols = Array.from(document.querySelectorAll(
+        `.gram-frame-harmonic-symbol[data-harmonic-set-id="${setId}"]`
+      ))
+      if (!label || symbols.length === 0) return null
       const l = label.getBoundingClientRect()
-      return { symbolBottom: s.bottom, labelTop: l.top }
-    })
+      const lCx = centreX(l)
+      // Pick the symbol on the same pin as this label
+      let symbol = symbols[0]
+      let best = Infinity
+      for (const s of symbols) {
+        const d = Math.abs(centreX(s.getBoundingClientRect()) - lCx)
+        if (d < best) { best = d; symbol = s }
+      }
+      const s = symbol.getBoundingClientRect()
+      return {
+        symbolTop: s.top,
+        labelBottom: l.bottom,
+        symbolCenterX: centreX(s),
+        labelCenterX: lCx
+      }
+    }, set.id)
     expect(overlap).not.toBeNull()
-    // Symbol's bottom is at or above the label's top (with a couple px tolerance)
-    expect(overlap.symbolBottom).toBeLessThanOrEqual(overlap.labelTop + 3)
+    // Label's bottom is at or above the symbol's top (with a couple px tolerance)
+    expect(overlap.labelBottom).toBeLessThanOrEqual(overlap.symbolTop + 3)
+    // Label is horizontally centred on the symbol/pin (within a few px)
+    expect(Math.abs(overlap.labelCenterX - overlap.symbolCenterX)).toBeLessThanOrEqual(3)
   })
 
   // T006

--- a/tests/helpers/gram-frame-page.js
+++ b/tests/helpers/gram-frame-page.js
@@ -485,14 +485,19 @@ class GramFramePage {
   }
 
   /**
-   * Read the numeric text of every harmonic number label currently rendered.
+   * Read the harmonic number of every rendered number label, optionally scoped to
+   * a single set. Reads the label's `data-harmonic-number` attribute.
+   * @param {string} [setId] - Restrict to one harmonic set
    * @returns {Promise<number[]>} Label numbers in document order
    */
-  async getHarmonicLabelNumbers() {
-    return this.page.evaluate(() => {
-      const labels = Array.from(document.querySelectorAll('.gram-frame-harmonic-number'))
-      return labels.map((label) => Number(label.textContent))
-    })
+  async getHarmonicLabelNumbers(setId) {
+    const selector = setId
+      ? `.gram-frame-harmonic-number[data-harmonic-set-id="${setId}"]`
+      : '.gram-frame-harmonic-number'
+    return this.page.evaluate((sel) => {
+      const labels = Array.from(document.querySelectorAll(sel))
+      return labels.map((label) => Number(label.getAttribute('data-harmonic-number')))
+    }, selector)
   }
 
   /**


### PR DESCRIPTION
## Summary

Implements **spec 159 — Show All Harmonic Pins, Label Only the Major Subset** ([spec.md](https://github.com/DeepBlueCLtd/GramFrame/blob/claude/spec-159-planning-implementation-ar0eh3/specs/159-harmonic-pin-labels/spec.md)), addressing review feedback from GH #198 (bullets 1 & 2).

Spec 158 kept dense harmonic sets legible by *sampling the pins* — drawing only every Nth pin and dropping the rest entirely (line + label + symbol). Review feedback is that dropping the lines loses the harmonic structure analysts read. This feature keeps the sampling maths but re-targets it so it governs **labels/symbols** instead of **which pins are drawn**.

## What changed

**User Story 1 — see every pin, thin only the labels**
- A pin **line** is now drawn for **every** harmonic in the visible frequency span (FR-001). A "solid block" at extreme density is acceptable and intended.
- **Number labels + symbols** are drawn only on the thinned "major" subset (the existing `sampledHarmonics()` result, cap 25) so the overlay stays readable (FR-002–FR-008).
- When the visible pins already fit under the cap, every pin is labelled (FR-005). Zoom/pan recompute both the drawn lines and the labelled subset (FR-006/FR-007).

**User Story 2 — labels above the pins**
- Each label is **centred horizontally** on its pin line (`text-anchor: middle`) and stacked **above its symbol**, above the pin line — top-to-bottom order: label → symbol → line (FR-009/FR-010).
- The label/symbol stack is clamped to stay within the image's top edge (FR-011).

## Implementation

- `src/modes/harmonics/HarmonicsMode.js`
  - `getVisibleHarmonics` → `getVisibleHarmonicRange` (drives all lines) + `getLabelledHarmonics` (thinned subset).
  - `renderHarmonicSet` draws all lines first, then labels/symbols on the subset (so labels/symbols paint on top).
  - New `calculateLabelStackPositions` computes the shared, on-screen label/symbol layout; `createHarmonicLabel` now centres the label above the symbol and tags it with `data-harmonic-set-id` / `data-harmonic-number`.
- The pure sampling utility (`src/utils/harmonicSampling.js`) is unchanged.

## Testing

- **New** `tests/harmonic-labels.spec.js` — US1 (every line drawn as a contiguous run, labels bounded/evenly-spaced subset, one symbol per labelled pin, zoom never coarsens the label step) and US2 (label centred above symbol above line; near-top-edge stack stays within the image).
- `tests/harmonic-pin-sampling.spec.js` — re-targeted 158's sampling assertions from *drawn lines* to *drawn labels* (158's pin-dropping is superseded).
- `tests/harmonic-symbols.spec.js` — flipped the vertical-order assertion to label-above-symbol; scoped it to pin symbols.
- `tests/helpers/gram-frame-page.js` — `getHarmonicLabelNumbers()` now scopes to a set and reads `data-harmonic-number`.

All harmonic label/sampling/symbol tests pass (30/30). Full suite: 148 passed. The 6 remaining failures are a pre-existing `state.version === "DEV"` metadata check in the dev build (present on `main`, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fJJpKcwbD9H2tLZg5SYAF

---
_Generated by [Claude Code](https://claude.ai/code/session_012fJJpKcwbD9H2tLZg5SYAF)_