### PR TITLE
Remove version number from Pan Mode button tooltip

### DIFF
--- a/src/components/ModeButtons.js
+++ b/src/components/ModeButtons.js
@@ -7,7 +7,6 @@
 /// <reference path="../types.js" />
 
 import { getModeDisplayName } from '../utils/calculations.js'
-import { getVersion } from '../utils/version.js'
 
 /**
  * Create mode switching UI with buttons and guidance panel
@@ -57,13 +56,6 @@ export function createModeSwitchingUI(modeCell, state, modeSwitchCallback, modes
     button.textContent = getModeDisplayName(modeType)
     button.dataset.mode = modeType
 
-    // Subtle version surface for debugging: hovering the Pan button reveals the
-    // GramFrame version. The tooltip shows even while the button is disabled
-    // (before the user has zoomed in), so it is always available on request.
-    if (modeType === 'pan') {
-      button.title = `GramFrame v${getVersion()}`
-    }
-    
     // Set active state for current mode
     if (modeType === state.mode) {
       button.classList.add('active')


### PR DESCRIPTION
## Summary

Implements spec 163 (GH issue #198, review feedback bullet 7).

The GramFrame version was surfaced in two places:
- the hover tooltip (`title`) on the Pan Mode button, and
- the last line of the Pan Mode guidance panel.

The button tooltip was added before the guidance display was remembered, making it redundant. This PR removes the redundant tooltip while keeping the version in the guidance panel, so the version is surfaced in exactly one place.

## Changes

- `src/components/ModeButtons.js`: removed the `if (modeType === 'pan') { button.title = ... }` block that set the version tooltip, and removed the now-unused `getVersion` import.

## Verification against requirements

- **FR-001 / SC-001**: Hovering the Pan Mode button no longer shows a version tooltip.
- **FR-002 / SC-002**: The version is still displayed in the Pan Mode guidance (`src/modes/pan/PanMode.js`, unchanged).
- **FR-003**: The Pan Mode button no longer sets any `title`, so it behaves like the other mode buttons on hover (no leftover/empty tooltip).
- **FR-004 / SC-003**: No other mode button's tooltip behaviour is touched.

## Notes

- The pre-existing `tsc` error about the `./gramframe.css` side-effect import is present on the base branch and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNEupQwdro2h6wx4h3Pf9q)_