### PR TITLE
feat(161): reformat markers/harmonics in place; add cross (symbol-less) style

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,9 @@ Example configuration:
 - Browser Web Storage (localStorage for trainers / sessionStorage for students) (157-harmonic-pin-symbols)
 - JavaScript ES2020+, JSDoc-typed (no TS compilation) + None at runtime (zero runtime deps); Vite for build (158-harmonic-pin-sampling)
 - N/A — purely presentational; no persisted data or new state (158-harmonic-pin-sampling)
+- JavaScript ES2020+, JSDoc-typed (no TS compilation) + None at runtime (zero runtime deps); Vite for build (161-reformat-markers-harmonics)
+- Browser Web Storage — additive `symbol` field on markers; `cross` (symbol-less) default; no schema bump (161-reformat-markers-harmonics)
 
 ## Recent Changes
+- 161-reformat-markers-harmonics: Added a `cross` (symbol-less) default style and in-place restyling of selected markers/harmonic sets (colour + symbol)
 - 154-enrich-docs: Added Markdown documentation (no code changes) + N/A (documentation-only feature)

--- a/specs/161-reformat-markers-harmonics/plan.md
+++ b/specs/161-reformat-markers-harmonics/plan.md
@@ -1,0 +1,124 @@
+# Implementation Plan: Reformat Existing Markers & Harmonics, with a "Cross" (Symbol-less) Style
+
+**Branch**: `161-reformat-markers-harmonics` | **Date**: 2026-07-24 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/161-reformat-markers-harmonics/spec.md` (GH issue #198, bullets 4 & 5)
+
+## Summary
+
+Two capabilities ship together:
+
+1. **A "cross" (symbol-less) style**, added to the shared symbol catalogue and
+   made the **default**. `cross` means "no drawn symbol shape". A feature with
+   this style renders without a filled mark — a harmonic set keeps its pin lines
+   and number labels but draws no symbol; a marker keeps its crosshair. `cross`
+   becomes the value the style controls show for symbol-less features and the
+   state a feature returns to when its symbol is removed.
+
+2. **In-place reformatting** of an already-placed marker or harmonic set.
+   Selecting a feature (via its table row or the overlay) now drives the colour
+   and symbol controls to that feature's current values, and changing a control
+   restyles the selected feature instantly — on the overlay and in its table —
+   affecting only that feature. When nothing is selected, the controls keep the
+   existing behaviour: they set the style for the **next** created feature.
+
+Markers gain a `symbol` attribute for the first time (default `cross`). A marker
+with a shaped symbol is drawn as that colour-coded symbol; a marker with `cross`
+draws the crosshair. A marker's table colour indicator is symbol-dependent: a
+shaped symbol shows the colour-coded symbol, `cross` shows a filled colour
+rectangle.
+
+### Technical approach
+
+This is a small, contained set of edits building on infrastructure that already
+exists: the shared symbol factory (`src/rendering/symbols.js`, feature 157) and
+the shared selection system (`src/core/keyboardControl.js`: `setSelection` /
+`clearSelection` / `updateSelectionVisuals`, used today for keyboard nudging).
+
+- **`cross` as a symbol id**: add `'cross'` to `SYMBOL_CATALOG` (first, so it is
+  the default option), add its display name and drop-down glyph, and export a
+  `DEFAULT_SYMBOL = 'cross'`. `createSymbolMark()` resolves unknown/absent
+  symbols to the default and returns **`null`** for `cross` (draws nothing).
+  Callers that append a mark handle the `null`.
+- **Shared colour indicator**: a new `createColorIndicator(symbol, color, size)`
+  helper returns the symbol swatch for a shape, or a filled colour rectangle for
+  `cross`. Both the markers table and the harmonics table use it, so the colour
+  stays visible even when no symbol is drawn.
+- **Selection drives the controls**: the colour/symbol picker takes the
+  `instance` (not just `state`), routes a change to the selected feature when one
+  is selected (`applyColorToSelectedFeature` / `applySymbolToSelectedFeature`)
+  and otherwise to `state.selectedColor` / `state.selectedSymbol`. It registers
+  `instance.syncStyleControls()`, which `setSelection` / `clearSelection` call so
+  the controls always reflect the active style (selected feature, or next-feature
+  defaults).
+- **Markers carry a symbol**: marker creation reads `state.selectedSymbol`;
+  `renderMarker` draws the symbol mark when shaped, else the crosshair; the
+  markers table uses the shared colour indicator and refreshes it on update so an
+  in-place restyle shows immediately.
+- **Persistence**: `symbol` is added to the stored marker record and defaults to
+  `cross` on restore; the harmonic-set restore default changes from `circle` to
+  `cross`. Both are **additive** — no `SCHEMA_VERSION` bump — so legacy records
+  load without error (absent symbol → `cross`).
+
+## Technical Context
+
+**Language/Version**: JavaScript ES2020+, JSDoc-typed (no TS compilation)
+**Primary Dependencies**: None at runtime (zero runtime deps); Vite for build
+**Storage**: Browser Web Storage (existing adapter). `symbol` is an additive
+field on the stored marker record; the harmonic restore default changes to
+`cross`. No `SCHEMA_VERSION` change; legacy records remain loadable.
+**Testing**: Playwright end-to-end (`yarn test`) with the `GramFramePage` helper
+**Target Platform**: Modern evergreen browsers (SVG-based overlay component)
+**Project Type**: Single-project front-end library/component
+**Constraints**: `yarn typecheck` + `yarn test` + `yarn build` must all pass;
+state deep-copied before listener notification; HMR preserves listeners; no
+change to the `gram-config` HTML contract
+**Scale/Scope**: ~10 existing files touched + 2 test files updated + 1 new test
+file; no new modules
+
+## Constitution Check
+
+- **Zero runtime dependencies**: preserved — only DOM/SVG and existing helpers.
+- **JSDoc-typed, no compilation**: preserved — types updated in `types.js`.
+- **Backward-compatible persistence**: preserved — additive field, no version
+  bump, legacy records default to `cross`.
+- **Separation of concerns**: rendering stays in `symbols.js` / mode renderers;
+  selection/restyle logic lives with the selection system in
+  `keyboardControl.js`; the picker only wires UI to those.
+- **All gates green**: `yarn typecheck`, `yarn test`, `yarn build` must pass.
+
+## Project Structure (files touched)
+
+```
+src/
+  rendering/symbols.js          # +cross, DEFAULT_SYMBOL, null for cross, createColorIndicator()
+  core/state.js                 # selectedSymbol default 'circle' -> 'cross'
+  core/storage.js               # persist marker.symbol; harmonic/marker default -> 'cross'
+  core/keyboardControl.js       # getSelectedFeature/getActiveStyle/apply*ToSelectedFeature; sync on (set|clear)Selection
+  core/initialization/EventBindings.js  # bind apply*ToSelectedFeature onto instance
+  components/SymbolPicker.js     # take instance; route to selection or next; register _symbolControl
+  components/ColorPicker.js      # take instance; route colour; define syncStyleControls
+  components/MainUI.js           # pass instance to createColorPicker
+  components/HarmonicPanel.js    # table indicator via createColorIndicator (rectangle for cross)
+  modes/analysis/AnalysisMode.js # marker.symbol; render symbol-or-crosshair; table indicator + refresh
+  modes/harmonics/HarmonicsMode.js # default 'cross'; skip null symbol mark (keep line + label)
+  main.js                        # restore marker/harmonic symbol default 'cross'; new instance fields
+  types.js                       # SymbolType +cross; AnalysisMarker/StoredMarker.symbol; instance methods
+tests/
+  reformat-markers-harmonics.spec.js  # NEW — US1/US2/US3 coverage
+  harmonic-symbols.spec.js       # US3 legacy default updated circle -> cross
+  harmonic-labels.spec.js        # beforeEach selects a shaped symbol (default is now cross)
+```
+
+## Phasing
+
+- **Phase 0 — cross style**: symbol catalogue, default, `null` render, shared
+  colour indicator. (FR-001, FR-002, FR-003)
+- **Phase 1 — selection drives controls**: picker takes the instance;
+  `syncStyleControls`; route changes to selection or next-feature. (FR-004,
+  FR-005, FR-006, FR-007, FR-008, FR-013)
+- **Phase 2 — markers carry symbols**: marker `symbol`, render, table indicator.
+  (FR-009, FR-010)
+- **Phase 3 — persistence**: additive marker `symbol`; restore defaults to
+  `cross`; legacy loads clean. (FR-011, FR-012)
+- **Phase 4 — tests & gates**: new spec; adapt the two default-dependent specs;
+  typecheck / test / build green.

--- a/specs/161-reformat-markers-harmonics/tasks.md
+++ b/specs/161-reformat-markers-harmonics/tasks.md
@@ -1,0 +1,92 @@
+# Tasks: Reformat Existing Markers & Harmonics, with a "Cross" (Symbol-less) Style
+
+**Branch**: `161-reformat-markers-harmonics` | **Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+Tasks are grouped by phase. `[P]` marks tasks that touch independent files and
+could be done in parallel. Each task lists the functional requirements it
+satisfies.
+
+## Phase 0 — The "cross" (symbol-less) style
+
+- [x] **T001** In `src/rendering/symbols.js`, export `DEFAULT_SYMBOL = 'cross'`,
+  add `'cross'` as the first entry of `SYMBOL_CATALOG`, and add its
+  `SYMBOL_DISPLAY_NAMES` entry. (FR-001, FR-002)
+- [x] **T002** In `createSymbolMark()`, resolve unknown/absent symbols to
+  `DEFAULT_SYMBOL` and return `null` for `cross` (draw no shape). Update the
+  return type and doc. (FR-003)
+- [x] **T003** Add `createColorIndicator(symbol, color, size)` to
+  `src/rendering/symbols.js`: symbol swatch for a shape, filled colour rectangle
+  for `cross`. (FR-010)
+- [x] **T004** In `src/core/state.js`, change `selectedSymbol` default from
+  `'circle'` to `'cross'`. (FR-002)
+- [x] **T005 [P]** In `src/types.js`, add `'cross'` to `SymbolType`; document the
+  default. (FR-001)
+
+## Phase 1 — Selection drives the style controls; restyle in place
+
+- [x] **T006** In `src/core/keyboardControl.js`, add `getSelectedFeature()`,
+  `getActiveStyle()`, `applyColorToSelectedFeature()`,
+  `applySymbolToSelectedFeature()` (mutate the selected feature, re-render
+  overlay + affected table, notify listeners). (FR-005, FR-006, FR-007)
+- [x] **T007** In `setSelection()` and `clearSelection()`, call
+  `instance.syncStyleControls?.()` so the controls reflect the selection (or
+  next-feature defaults when cleared). (FR-004, FR-013)
+- [x] **T008** In `src/core/initialization/EventBindings.js`, bind
+  `applyColorToSelectedFeature` / `applySymbolToSelectedFeature` onto the
+  instance. (FR-005, FR-006)
+- [x] **T009** In `src/components/SymbolPicker.js`, take the `instance`; on
+  change route to `applySymbolToSelectedFeature`, else set
+  `state.selectedSymbol`; add the `cross` glyph; register `instance._symbolControl`
+  (`setValue` / `setTint`). (FR-006, FR-008)
+- [x] **T010** In `src/components/ColorPicker.js`, take the `instance`; on canvas
+  click route to `applyColorToSelectedFeature`, else set `state.selectedColor`;
+  define `instance.syncStyleControls()` from `getActiveStyle()`. (FR-004, FR-005,
+  FR-008)
+- [x] **T011 [P]** In `src/components/MainUI.js`, pass `instance` to
+  `createColorPicker`. (FR-004)
+
+## Phase 2 — Markers carry a symbol
+
+- [x] **T012** In `src/modes/analysis/AnalysisMode.js`, set `marker.symbol` from
+  `state.selectedSymbol` on creation; add `MARKER_SYMBOL_SIZE`. (FR-009)
+- [x] **T013** In `renderMarker()`, draw the colour-coded symbol when the marker
+  has a shaped symbol, else the crosshair (cross). (FR-009)
+- [x] **T014** In the markers table, build the colour cell via
+  `createColorIndicator()` and refresh it in `updateMarkerRow()` so an in-place
+  restyle shows immediately. (FR-010)
+- [x] **T015 [P]** In `src/components/HarmonicPanel.js`, build the harmonics-table
+  colour cell via `createColorIndicator()` (rectangle for `cross`). (FR-010)
+- [x] **T016 [P]** In `src/modes/harmonics/HarmonicsMode.js`, default new sets to
+  `cross`; skip the `null` symbol mark while still drawing the line and label.
+  (FR-002, FR-003)
+
+## Phase 3 — Persistence & legacy
+
+- [x] **T017** In `src/core/storage.js`, persist `marker.symbol` (default
+  `cross`) and change the harmonic-set save/restore default to `cross`; keep it
+  additive (no `SCHEMA_VERSION` bump). (FR-011, FR-012)
+- [x] **T018** In `src/main.js` `_restoreAnnotations()`, default restored marker
+  and harmonic symbols to `cross`; add the new instance fields. (FR-011, FR-012)
+- [x] **T019 [P]** In `src/types.js`, add `symbol` to `AnalysisMarker` and
+  `StoredMarker`, and the new instance method properties. (FR-009, FR-011)
+
+## Phase 4 — Tests & gates
+
+- [x] **T020** New `tests/reformat-markers-harmonics.spec.js` — US2 (cross is the
+  default, symbol-less), US1 (select → controls reflect; restyle colour/symbol in
+  place; only selected changes; cross keeps lines/labels; nothing-selected sets
+  next feature), US3 (assign a marker a symbol; revert to cross; colour restyle
+  affects only the selected marker). (SC-001…SC-006)
+- [x] **T021** Update `tests/harmonic-symbols.spec.js` US3 — legacy no-symbol set
+  now loads as `cross` (no pin symbol, rectangle table indicator). (FR-012)
+- [x] **T022** Update `tests/harmonic-labels.spec.js` `beforeEach` to select a
+  shaped symbol (the default is now `cross`).
+- [x] **T023** `yarn typecheck`, `yarn test`, `yarn build` all pass. (SC-007)
+
+## Coverage
+
+Every functional requirement FR-001…FR-013 is covered: FR-001/002/003 (T001–T005,
+T016); FR-004 (T007, T010, T011); FR-005/006/007 (T006, T008, T009, T010);
+FR-008 (T009, T010); FR-009 (T012, T013); FR-010 (T003, T014, T015); FR-011
+(T017, T018, T019); FR-012 (T017, T018, T021); FR-013 (T007). Success criteria
+SC-001…SC-007 are exercised by T020–T023.

--- a/src/components/ColorPicker.js
+++ b/src/components/ColorPicker.js
@@ -8,6 +8,7 @@
 /// <reference path="../types.js" />
 
 import { createSymbolSelect } from './SymbolPicker.js'
+import { getActiveStyle } from '../core/keyboardControl.js'
 
 /**
  * Standard color palette used for color picker gradient and calculations
@@ -30,12 +31,17 @@ const COLOR_PALETTE = [
 
 /**
  * Create the combined "Symbol" control: a colour slider on the left and a
- * symbol drop-down (tinted with the selected colour) on the right. Both the
- * colour and symbol for the next harmonic set are chosen from this one panel.
- * @param {GramFrameState} state - Current state object
+ * symbol drop-down (tinted with the selected colour) on the right.
+ *
+ * When a marker or harmonic set is selected, this panel restyles that feature
+ * in place; otherwise it sets the colour/symbol for the next created feature
+ * (feature 161). The panel also syncs its displayed colour/symbol to whichever
+ * feature is selected via `instance.syncStyleControls`.
+ * @param {GramFrame} instance - GramFrame instance
  * @returns {HTMLDivElement} The combined colour/symbol picker element
  */
-export function createColorPicker(state) {
+export function createColorPicker(instance) {
+  const state = instance.state
   const container = document.createElement('div')
   container.className = 'gram-frame-color-picker'
   container.style.display = 'block'
@@ -84,7 +90,7 @@ export function createColorPicker(state) {
   // Symbol drop-down on the right (where the colour swatch used to be); its
   // glyphs are tinted with the currently selected colour, so it doubles as the
   // colour readout.
-  const symbolSelect = createSymbolSelect(state)
+  const symbolSelect = createSymbolSelect(instance)
   paletteContainer.appendChild(symbolSelect)
 
   // Add click handler for color selection
@@ -98,8 +104,11 @@ export function createColorPicker(state) {
 
     const color = getColorFromPosition(canvasX, canvas.width)
 
-    // Update state
-    state.selectedColor = color
+    // Route to the selected feature when one is selected (restyle in place),
+    // otherwise set the colour for the next created feature (feature 161).
+    if (!instance.applyColorToSelectedFeature || !instance.applyColorToSelectedFeature(color)) {
+      state.selectedColor = color
+    }
 
     // Tint the symbol drop-down with the newly selected colour
     symbolSelect.style.color = color
@@ -107,6 +116,29 @@ export function createColorPicker(state) {
     // Update indicator position using the same canvasX coordinate for consistency
     updateIndicatorPosition(indicator, canvasX, canvas.width)
   })
+
+  /**
+   * Move the colour indicator/tint to reflect a given colour (without mutating
+   * state) — used when selection changes to show the selected feature's colour.
+   * @param {string} color - Hex colour to display
+   */
+  const showColor = (color) => {
+    const position = getPositionFromColor(color, canvas.width)
+    updateIndicatorPosition(indicator, position, canvas.width)
+    symbolSelect.style.color = color
+  }
+
+  // Sync both controls (colour indicator + symbol drop-down) to whatever is
+  // currently selected, or to the next-feature defaults when nothing is
+  // selected (feature 161, FR-004/FR-013).
+  instance.syncStyleControls = () => {
+    const { color, symbol } = getActiveStyle(instance)
+    showColor(color)
+    if (instance._symbolControl) {
+      instance._symbolControl.setValue(symbol)
+      instance._symbolControl.setTint(color)
+    }
+  }
 
   // Initialize indicator position (use canvas coordinates directly)
   const initialPosition = getPositionFromColor(state.selectedColor, canvas.width)

--- a/src/components/HarmonicPanel.js
+++ b/src/components/HarmonicPanel.js
@@ -4,24 +4,17 @@
 
 /// <reference path="../types.js" />
 
-import { createSymbolMark } from '../rendering/symbols.js'
+import { createColorIndicator } from '../rendering/symbols.js'
 
 /**
- * Build a small inline SVG swatch showing a harmonic set's symbol in its colour.
- * Used in the harmonics-table colour cell as a colour-blind-friendly affordance.
+ * Build the colour/symbol indicator for a harmonic set's table row: the set's
+ * symbol drawn in its colour, or — for the symbol-less `cross` style — a plain
+ * filled colour rectangle (feature 161). Colour-blind-friendly affordance.
  * @param {HarmonicSet} harmonicSet - The harmonic set data
- * @returns {SVGSVGElement} The swatch SVG element
+ * @returns {SVGSVGElement|HTMLDivElement} The indicator element
  */
 function createSymbolSwatch(harmonicSet) {
-  const swSize = 16
-  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
-  svg.setAttribute('class', 'gram-frame-harmonic-symbol-swatch')
-  svg.setAttribute('width', String(swSize))
-  svg.setAttribute('height', String(swSize))
-  svg.setAttribute('viewBox', `0 0 ${swSize} ${swSize}`)
-  const mark = createSymbolMark(harmonicSet.symbol, swSize / 2, swSize / 2, 12, harmonicSet.color)
-  svg.appendChild(mark)
-  return svg
+  return createColorIndicator(harmonicSet.symbol, harmonicSet.color)
 }
 
 /**

--- a/src/components/MainUI.js
+++ b/src/components/MainUI.js
@@ -64,7 +64,7 @@ export function createUnifiedLayout(instance) {
   controlsColumn.appendChild(cursorContainer)
   
   // Combined colour + symbol control (labelled "Symbol") in controls column
-  const colorPicker = createColorPicker(instance.state)
+  const colorPicker = createColorPicker(instance)
   controlsColumn.appendChild(colorPicker)
 
   // Add columns to left panel

--- a/src/components/SymbolPicker.js
+++ b/src/components/SymbolPicker.js
@@ -1,24 +1,29 @@
 /**
- * Symbol selector for GramFrame harmonic overlays.
+ * Symbol selector for GramFrame overlays.
  *
  * Renders a compact native drop-down of symbol glyphs. It is embedded in the
  * combined "Symbol" panel (see ColorPicker.js) to the right of the colour
- * slider, where the selected-colour swatch used to sit, and its glyphs are
- * tinted with the currently selected colour. The chosen symbol is written to
- * `state.selectedSymbol` and applied to the next created harmonic set.
+ * slider, and its glyphs are tinted with the currently selected colour.
+ *
+ * When a marker or harmonic set is selected, changing the symbol restyles that
+ * feature in place (feature 161); otherwise the chosen symbol is written to
+ * `state.selectedSymbol` and applied to the next created feature. The default
+ * option is `cross` — the symbol-less style.
  */
 
 /// <reference path="../types.js" />
 
-import { SYMBOL_CATALOG, SYMBOL_DISPLAY_NAMES } from '../rendering/symbols.js'
+import { SYMBOL_CATALOG, SYMBOL_DISPLAY_NAMES, DEFAULT_SYMBOL } from '../rendering/symbols.js'
 
 /**
  * Unicode glyph shown for each symbol id in the drop-down. The list is a
  * compact "drop-down of symbols" (glyph only) so it fits beside the colour
  * slider; the full name is kept on each option's tooltip for accessibility.
+ * `cross` uses a small cross glyph to signal the symbol-less style.
  * @type {Record<SymbolType, string>}
  */
 const SYMBOL_GLYPHS = {
+  'cross': '✕',
   'circle': '●',
   'square': '■',
   'diamond': '◆',
@@ -29,13 +34,15 @@ const SYMBOL_GLYPHS = {
 
 /**
  * Create the symbol selector drop-down.
- * @param {GramFrameState} state - Current state object
+ * @param {GramFrame} instance - GramFrame instance
  * @returns {HTMLSelectElement} The symbol `<select>` element
  */
-export function createSymbolSelect(state) {
+export function createSymbolSelect(instance) {
+  const state = instance.state
+
   // Initialise default symbol if unset
   if (!state.selectedSymbol) {
-    state.selectedSymbol = 'circle'
+    state.selectedSymbol = DEFAULT_SYMBOL
   }
 
   const select = document.createElement('select')
@@ -57,8 +64,26 @@ export function createSymbolSelect(state) {
   })
 
   select.addEventListener('change', () => {
-    state.selectedSymbol = /** @type {SymbolType} */ (select.value)
+    const symbol = /** @type {SymbolType} */ (select.value)
+    // Route to the selected feature when one is selected (restyle in place),
+    // otherwise set the style for the next created feature.
+    if (!instance.applySymbolToSelectedFeature || !instance.applySymbolToSelectedFeature(symbol)) {
+      state.selectedSymbol = symbol
+    }
   })
+
+  // Expose a control handle so selection changes can reflect the selected
+  // feature's symbol back into this drop-down (feature 161, FR-004).
+  instance._symbolControl = {
+    /** @param {SymbolType} symbol */
+    setValue(symbol) {
+      select.value = symbol
+    },
+    /** @param {string} color */
+    setTint(color) {
+      select.style.color = color
+    }
+  }
 
   return select
 }

--- a/src/core/initialization/EventBindings.js
+++ b/src/core/initialization/EventBindings.js
@@ -9,7 +9,7 @@
 /// <reference path="../../types.js" />
 
 import { setupEventListeners, setupResizeObserver } from '../events.js'
-import { initializeKeyboardControl, setSelection, clearSelection, updateSelectionVisuals, removeHarmonicSet } from '../keyboardControl.js'
+import { initializeKeyboardControl, setSelection, clearSelection, updateSelectionVisuals, removeHarmonicSet, applyColorToSelectedFeature, applySymbolToSelectedFeature } from '../keyboardControl.js'
 import { getGlobalStateListeners } from '../state.js'
 
 /**
@@ -31,6 +31,8 @@ export function setupAllEventListeners(instance) {
   instance.clearSelection = () => clearSelection(instance)
   instance.updateSelectionVisuals = () => updateSelectionVisuals(instance)
   instance.removeHarmonicSet = (id) => removeHarmonicSet(instance, id)
+  instance.applyColorToSelectedFeature = (color) => applyColorToSelectedFeature(instance, color)
+  instance.applySymbolToSelectedFeature = (symbol) => applySymbolToSelectedFeature(instance, symbol)
 }
 
 /**

--- a/src/core/keyboardControl.js
+++ b/src/core/keyboardControl.js
@@ -9,6 +9,7 @@
 
 import { notifyStateListeners } from './state.js'
 import { updateHarmonicPanelContent } from '../components/HarmonicPanel.js'
+import { DEFAULT_SYMBOL } from '../rendering/symbols.js'
 import { registerInstance, unregisterInstance, getFocusedInstance, focusNextInstance, focusPreviousInstance, setFocusedInstance } from './FocusManager.js'
 
 /**
@@ -363,14 +364,20 @@ function svgToDataCoordinates(svgX, svgY, config, imageDetails, rate, margins) {
 export function setSelection(instance, type, id, index) {
   // When selecting an item, also focus the instance
   setFocusedInstance(instance)
-  
+
   instance.state.selection.selectedType = type
   instance.state.selection.selectedId = id
   instance.state.selection.selectedIndex = index
-  
+
   // Update visual feedback
   updateSelectionVisuals(instance)
-  
+
+  // Reflect the selected feature's colour/symbol in the style controls so the
+  // analyst can restyle it in place (feature 161, FR-004).
+  if (instance.syncStyleControls) {
+    instance.syncStyleControls()
+  }
+
   notifyStateListeners(instance.state, instance.stateListeners)
 }
 
@@ -382,11 +389,119 @@ export function clearSelection(instance) {
   instance.state.selection.selectedType = null
   instance.state.selection.selectedId = null
   instance.state.selection.selectedIndex = null
-  
+
   // Update visual feedback
   updateSelectionVisuals(instance)
-  
+
+  // With nothing selected, the style controls revert to targeting the NEXT
+  // created feature (feature 161, FR-013).
+  if (instance.syncStyleControls) {
+    instance.syncStyleControls()
+  }
+
   notifyStateListeners(instance.state, instance.stateListeners)
+}
+
+/**
+ * Resolve the currently selected feature (marker or harmonic set).
+ * @param {GramFrame} instance - GramFrame instance
+ * @returns {{type: 'marker'|'harmonicSet', feature: AnalysisMarker|HarmonicSet}|null} Selected feature or null
+ */
+export function getSelectedFeature(instance) {
+  const sel = instance.state.selection
+  if (!sel || !sel.selectedType || !sel.selectedId) {
+    return null
+  }
+  if (sel.selectedType === 'marker') {
+    const feature = instance.state.analysis && instance.state.analysis.markers
+      ? instance.state.analysis.markers.find(m => m.id === sel.selectedId)
+      : null
+    return feature ? { type: 'marker', feature } : null
+  }
+  if (sel.selectedType === 'harmonicSet') {
+    const feature = instance.state.harmonics && instance.state.harmonics.harmonicSets
+      ? instance.state.harmonics.harmonicSets.find(h => h.id === sel.selectedId)
+      : null
+    return feature ? { type: 'harmonicSet', feature } : null
+  }
+  return null
+}
+
+/**
+ * Get the colour/symbol the style controls should currently show: the selected
+ * feature's when one is selected, otherwise the next-feature defaults.
+ * @param {GramFrame} instance - GramFrame instance
+ * @returns {{color: string, symbol: SymbolType}} Active style
+ */
+export function getActiveStyle(instance) {
+  const selected = getSelectedFeature(instance)
+  if (selected) {
+    return {
+      color: selected.feature.color,
+      symbol: /** @type {SymbolType} */ (selected.feature.symbol || DEFAULT_SYMBOL)
+    }
+  }
+  return {
+    color: instance.state.selectedColor,
+    symbol: instance.state.selectedSymbol
+  }
+}
+
+/**
+ * Re-render the overlay and the affected feature's table after a restyle, then
+ * notify listeners (which also triggers persistence).
+ * @param {GramFrame} instance - GramFrame instance
+ * @param {'marker'|'harmonicSet'} type - Which feature type changed
+ */
+function refreshFeatureVisuals(instance, type) {
+  if (instance.featureRenderer) {
+    instance.featureRenderer.renderAllPersistentFeatures()
+  }
+  if (type === 'marker') {
+    const analysisMode = instance.modes && instance.modes['analysis']
+    if (analysisMode && typeof analysisMode.updateMarkersTable === 'function') {
+      analysisMode.updateMarkersTable()
+    }
+  } else if (type === 'harmonicSet') {
+    if (instance.harmonicPanel) {
+      updateHarmonicPanelContent(instance.harmonicPanel, instance)
+    }
+  }
+  notifyStateListeners(instance.state, instance.stateListeners)
+}
+
+/**
+ * Apply a colour to the currently selected feature, updating the overlay and
+ * table instantly (feature 161, FR-005/FR-007). No-op when nothing is selected.
+ * @param {GramFrame} instance - GramFrame instance
+ * @param {string} color - Hex colour to apply
+ * @returns {boolean} True if a feature was restyled
+ */
+export function applyColorToSelectedFeature(instance, color) {
+  const selected = getSelectedFeature(instance)
+  if (!selected) {
+    return false
+  }
+  selected.feature.color = color
+  refreshFeatureVisuals(instance, selected.type)
+  return true
+}
+
+/**
+ * Apply a symbol to the currently selected feature, updating the overlay and
+ * table instantly (feature 161, FR-006/FR-007). No-op when nothing is selected.
+ * @param {GramFrame} instance - GramFrame instance
+ * @param {SymbolType} symbol - Symbol style to apply
+ * @returns {boolean} True if a feature was restyled
+ */
+export function applySymbolToSelectedFeature(instance, symbol) {
+  const selected = getSelectedFeature(instance)
+  if (!selected) {
+    return false
+  }
+  selected.feature.symbol = symbol
+  refreshFeatureVisuals(instance, selected.type)
+  return true
 }
 
 /**

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -42,7 +42,7 @@ export const initialState = {
   previousMode: null, // Previous mode for switching back
   rate: 1,
   selectedColor: '#ff6b6b', // Currently selected color for new features across all modes
-  selectedSymbol: 'circle', // Currently selected symbol applied to the next created harmonic set (mirrors selectedColor)
+  selectedSymbol: 'cross', // Currently selected symbol; 'cross' (default) means no drawn symbol shape (feature 161)
   cursorPosition: null,
   cursors: [],
   imageDetails: {

--- a/src/core/storage.js
+++ b/src/core/storage.js
@@ -173,7 +173,11 @@ export function saveAnnotations(state, instanceIndex) {
           id: m.id,
           color: m.color,
           time: m.time,
-          freq: m.freq
+          freq: m.freq,
+          // `symbol` is an ADDITIVE field (feature 161). It MUST NOT trigger a
+          // SCHEMA_VERSION bump: legacy records simply lack it and default to
+          // 'cross' (no drawn symbol) on restore.
+          symbol: m.symbol || 'cross'
         }))
       },
       harmonics: {
@@ -185,8 +189,9 @@ export function saveAnnotations(state, instanceIndex) {
           // `symbol` is an ADDITIVE field (feature 157-harmonic-pin-symbols). It
           // MUST NOT trigger a SCHEMA_VERSION bump: the strict version guard in
           // loadAnnotations would otherwise discard all pre-existing v1 records.
-          // Legacy records simply lack this key and default to 'circle' on restore.
-          symbol: hs.symbol || 'circle'
+          // Legacy records simply lack this key and default to 'cross' (the
+          // symbol-less default, feature 161) on restore.
+          symbol: hs.symbol || 'cross'
         }))
       },
       doppler: {

--- a/src/main.js
+++ b/src/main.js
@@ -118,6 +118,14 @@ export class GramFrame {
   setSelection;
   clearSelection;
   updateSelectionVisuals;
+
+  // Reformatting (feature 161): restyle the selected feature in place
+  applyColorToSelectedFeature;
+  applySymbolToSelectedFeature;
+  // Sync the colour/symbol controls to the current selection
+  syncStyleControls;
+  // Symbol drop-down control handle (registered by the symbol picker)
+  _symbolControl;
   
   // ResizeObserver
   resizeObserver;
@@ -324,17 +332,22 @@ export class GramFrame {
     const saved = loadAnnotations(this._storageInstanceIndex)
     if (!saved) return
 
-    // Merge analysis markers
+    // Merge analysis markers. Legacy records (persisted before feature 161)
+    // have no `symbol`; default those to 'cross' (the symbol-less crosshair).
     if (saved.analysis && Array.isArray(saved.analysis.markers)) {
-      this.state.analysis.markers = saved.analysis.markers
+      this.state.analysis.markers = saved.analysis.markers.map(m => ({
+        ...m,
+        symbol: m.symbol || 'cross'
+      }))
     }
 
     // Merge harmonic sets. Legacy records (persisted before feature
-    // 157-harmonic-pin-symbols) have no `symbol`; default those to 'circle'.
+    // 157-harmonic-pin-symbols) have no `symbol`; default those to 'cross'
+    // (the symbol-less default, feature 161).
     if (saved.harmonics && Array.isArray(saved.harmonics.harmonicSets)) {
       this.state.harmonics.harmonicSets = saved.harmonics.harmonicSets.map(hs => ({
         ...hs,
-        symbol: hs.symbol || 'circle'
+        symbol: hs.symbol || 'cross'
       }))
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -433,7 +433,16 @@ export class GramFrame {
     this.state.dragState.originalSpacing = null
     this.state.dragState.originalAnchorTime = null
     this.state.dragState.clickedHarmonicNumber = null
-    
+
+    // Changing mode signals the analyst is about to add something new, so drop
+    // any selected marker/harmonic. This returns the colour/symbol controls to
+    // targeting the NEXT created feature instead of restyling the previously
+    // selected one (feature 161).
+    const modeChanged = this.state.previousMode !== mode
+    if (modeChanged && this.state.selection && this.state.selection.selectedType && this.clearSelection) {
+      this.clearSelection()
+    }
+
     // Cursor styling removed - no display element
     
     // Update UI

--- a/src/modes/analysis/AnalysisMode.js
+++ b/src/modes/analysis/AnalysisMode.js
@@ -4,12 +4,20 @@ import { formatTime } from '../../utils/timeFormatter.js'
 import { calculateZoomAwarePosition } from '../../utils/coordinateTransformations.js'
 import { BaseDragHandler } from '../shared/BaseDragHandler.js'
 import { getUniformTolerance, isWithinToleranceRadius } from '../../utils/tolerance.js'
+import { createSymbolMark, createColorIndicator } from '../../rendering/symbols.js'
 
 /**
  * Analysis mode implementation
  * Provides crosshair rendering, basic time/frequency display, and persistent markers
  */
 export class AnalysisMode extends BaseMode {
+  /**
+   * Pixel size (width/height) of a marker's symbol mark when it carries a
+   * shaped symbol (feature 161). Roughly matches the crosshair's visual weight.
+   * @type {number}
+   */
+  static MARKER_SYMBOL_SIZE = 14
+
   /**
    * Initialize AnalysisMode with drag handler
    * @param {Object} instance - GramFrame instance
@@ -196,16 +204,18 @@ export class AnalysisMode extends BaseMode {
    * @param {DataCoordinates} dataCoords - Data coordinates {freq, time}
    */
   createMarkerAtPosition(dataCoords) {
-    // Get the current marker color from global state
+    // Get the current marker color and symbol from global state
     const color = this.instance.state.selectedColor || '#ff6b6b'
-    
+    const symbol = this.instance.state.selectedSymbol || 'cross'
+
     // Create marker object (we only need time/freq for positioning)
     /** @type {AnalysisMarker} */
     const marker = {
       id: `marker-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
       color,
       time: dataCoords.time,
-      freq: dataCoords.freq
+      freq: dataCoords.freq,
+      symbol
     }
     
     // Add marker to state
@@ -249,43 +259,53 @@ export class AnalysisMode extends BaseMode {
     const markerGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g')
     markerGroup.setAttribute('class', 'gram-frame-analysis-marker')
     markerGroup.setAttribute('data-marker-id', marker.id)
-    
-    // Create crosshair lines
-    const crosshairSize = 15
-    
-    // Horizontal line
-    const hLine = document.createElementNS('http://www.w3.org/2000/svg', 'line')
-    hLine.setAttribute('x1', String(currentX - crosshairSize))
-    hLine.setAttribute('y1', String(currentY))
-    hLine.setAttribute('x2', String(currentX + crosshairSize))
-    hLine.setAttribute('y2', String(currentY))
-    hLine.setAttribute('stroke', marker.color)
-    hLine.setAttribute('stroke-width', '2')
-    hLine.setAttribute('stroke-linecap', 'round')
-    
-    // Vertical line
-    const vLine = document.createElementNS('http://www.w3.org/2000/svg', 'line')
-    vLine.setAttribute('x1', String(currentX))
-    vLine.setAttribute('y1', String(currentY - crosshairSize))
-    vLine.setAttribute('x2', String(currentX))
-    vLine.setAttribute('y2', String(currentY + crosshairSize))
-    vLine.setAttribute('stroke', marker.color)
-    vLine.setAttribute('stroke-width', '2')
-    vLine.setAttribute('stroke-linecap', 'round')
-    
-    // Center circle
-    const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle')
-    circle.setAttribute('cx', String(currentX))
-    circle.setAttribute('cy', String(currentY))
-    circle.setAttribute('r', '3')
-    circle.setAttribute('fill', marker.color)
-    circle.setAttribute('stroke', '#fff')
-    circle.setAttribute('stroke-width', '1')
-    
-    markerGroup.appendChild(hLine)
-    markerGroup.appendChild(vLine)
-    markerGroup.appendChild(circle)
-    
+
+    // A marker carrying a shaped symbol is drawn as that colour-coded symbol
+    // (feature 161, FR-009); a marker with the `cross` (symbol-less) style
+    // continues to render as the crosshair.
+    const symbolMark = createSymbolMark(marker.symbol, currentX, currentY, AnalysisMode.MARKER_SYMBOL_SIZE, marker.color)
+
+    if (symbolMark) {
+      symbolMark.setAttribute('data-marker-id', marker.id)
+      markerGroup.appendChild(symbolMark)
+    } else {
+      // Crosshair rendering (cross style / default)
+      const crosshairSize = 15
+
+      // Horizontal line
+      const hLine = document.createElementNS('http://www.w3.org/2000/svg', 'line')
+      hLine.setAttribute('x1', String(currentX - crosshairSize))
+      hLine.setAttribute('y1', String(currentY))
+      hLine.setAttribute('x2', String(currentX + crosshairSize))
+      hLine.setAttribute('y2', String(currentY))
+      hLine.setAttribute('stroke', marker.color)
+      hLine.setAttribute('stroke-width', '2')
+      hLine.setAttribute('stroke-linecap', 'round')
+
+      // Vertical line
+      const vLine = document.createElementNS('http://www.w3.org/2000/svg', 'line')
+      vLine.setAttribute('x1', String(currentX))
+      vLine.setAttribute('y1', String(currentY - crosshairSize))
+      vLine.setAttribute('x2', String(currentX))
+      vLine.setAttribute('y2', String(currentY + crosshairSize))
+      vLine.setAttribute('stroke', marker.color)
+      vLine.setAttribute('stroke-width', '2')
+      vLine.setAttribute('stroke-linecap', 'round')
+
+      // Center circle
+      const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle')
+      circle.setAttribute('cx', String(currentX))
+      circle.setAttribute('cy', String(currentY))
+      circle.setAttribute('r', '3')
+      circle.setAttribute('fill', marker.color)
+      circle.setAttribute('stroke', '#fff')
+      circle.setAttribute('stroke-width', '1')
+
+      markerGroup.appendChild(hLine)
+      markerGroup.appendChild(vLine)
+      markerGroup.appendChild(circle)
+    }
+
     this.instance.cursorGroup.appendChild(markerGroup)
   }
 
@@ -567,6 +587,13 @@ export class AnalysisMode extends BaseMode {
    * @param {AnalysisMarker} marker - The marker data
    */
   updateMarkerRow(row, marker) {
+    // Refresh the colour/symbol indicator in case the marker was reformatted
+    // in place (feature 161). Rebuild the cell's indicator to match its style.
+    const colorCell = row.cells[0]
+    if (colorCell) {
+      colorCell.replaceChildren(createColorIndicator(marker.symbol, marker.color, 20))
+    }
+
     // Update time cell (second cell)
     const timeCell = row.cells[1]
     if (timeCell) {
@@ -623,16 +650,11 @@ export class AnalysisMode extends BaseMode {
         }
       })
       
-      // Color swatch cell
+      // Colour/symbol cell — a shaped symbol shows the colour-coded symbol; the
+      // cross (symbol-less) style shows a filled colour rectangle (FR-010).
       const colorCell = document.createElement('td')
-      const colorSwatch = document.createElement('div')
-      colorSwatch.className = 'gram-frame-color-swatch'
-      colorSwatch.style.backgroundColor = marker.color
-      colorSwatch.style.width = '20px'
-      colorSwatch.style.height = '20px'
-      colorSwatch.style.borderRadius = '3px'
-      colorSwatch.style.border = '1px solid #ccc'
-      colorCell.appendChild(colorSwatch)
+      colorCell.className = 'gram-frame-marker-color'
+      colorCell.appendChild(createColorIndicator(marker.symbol, marker.color, 20))
       row.appendChild(colorCell)
       
       // Time cell

--- a/src/modes/analysis/AnalysisMode.js
+++ b/src/modes/analysis/AnalysisMode.js
@@ -266,6 +266,11 @@ export class AnalysisMode extends BaseMode {
     const symbolMark = createSymbolMark(marker.symbol, currentX, currentY, AnalysisMode.MARKER_SYMBOL_SIZE, marker.color)
 
     if (symbolMark) {
+      // Use a marker-specific class so the harmonics renderer's symbol cleanup
+      // (which clears `.gram-frame-harmonic-symbol` from the overlay) never
+      // removes a marker's symbol. `data-symbol`/fill from createSymbolMark are
+      // preserved. (Fixes symbols vanishing when a harmonic set is present.)
+      symbolMark.setAttribute('class', 'gram-frame-marker-symbol')
       symbolMark.setAttribute('data-marker-id', marker.id)
       markerGroup.appendChild(symbolMark)
     } else {

--- a/src/modes/harmonics/HarmonicsMode.js
+++ b/src/modes/harmonics/HarmonicsMode.js
@@ -363,8 +363,8 @@ export class HarmonicsMode extends BaseMode {
       color = HarmonicsMode.harmonicColors[colorIndex]
     }
     
-    // Use selected symbol from global state, defaulting to circle
-    const symbol = this.instance.state.selectedSymbol || 'circle'
+    // Use selected symbol from global state, defaulting to the symbol-less cross
+    const symbol = this.instance.state.selectedSymbol || 'cross'
 
     /** @type {HarmonicSet} */
     const harmonicSet = {
@@ -783,12 +783,16 @@ export class HarmonicsMode extends BaseMode {
    * @param {HarmonicSet} harmonicSet - Harmonic set configuration
    * @param {number} lineX - X position of the pin line (symbol is centred on it)
    * @param {number} symbolCy - Centre Y position for the symbol
-   * @returns {SVGElement} SVG symbol element
+   * @returns {SVGElement|null} SVG symbol element, or null for the `cross` (symbol-less) style
    */
   createHarmonicSymbol(harmonicSet, lineX, symbolCy) {
     const symbol = createSymbolMark(
       harmonicSet.symbol, lineX, symbolCy, HarmonicsMode.SYMBOL_SIZE, harmonicSet.color
     )
+    // `cross` sets draw no symbol shape (the pin keeps its line and label).
+    if (!symbol) {
+      return null
+    }
     symbol.setAttribute('data-harmonic-set-id', harmonicSet.id)
     return symbol
   }
@@ -877,7 +881,10 @@ export class HarmonicsMode extends BaseMode {
       const lineX = this.harmonicLineX(harmonicSet, harmonicNumber)
       const symbol = this.createHarmonicSymbol(harmonicSet, lineX, symbolCy)
       const label = this.createHarmonicLabel(harmonicNumber, harmonicSet, lineX, labelY)
-      this.instance.cursorGroup.appendChild(symbol)
+      // `cross` sets have no symbol mark; the number label is still drawn.
+      if (symbol) {
+        this.instance.cursorGroup.appendChild(symbol)
+      }
       this.instance.cursorGroup.appendChild(label)
     })
   }

--- a/src/modes/harmonics/HarmonicsMode.js
+++ b/src/modes/harmonics/HarmonicsMode.js
@@ -648,10 +648,12 @@ export class HarmonicsMode extends BaseMode {
       return
     }
     
-    // Clear existing harmonic lines and their symbol marks
+    // Clear existing harmonic lines and their symbol marks. Scope the symbol
+    // cleanup to harmonic pin symbols (which carry data-harmonic-set-id) so it
+    // never removes analysis-marker symbols that share the base symbol class.
     const existingHarmonics = this.instance.cursorGroup.querySelectorAll('.gram-frame-harmonic-line')
     existingHarmonics.forEach(line => line.remove())
-    const existingSymbols = this.instance.cursorGroup.querySelectorAll('.gram-frame-harmonic-symbol')
+    const existingSymbols = this.instance.cursorGroup.querySelectorAll('.gram-frame-harmonic-symbol[data-harmonic-set-id]')
     existingSymbols.forEach(symbol => symbol.remove())
     
     // Render all harmonic sets

--- a/src/rendering/symbols.js
+++ b/src/rendering/symbols.js
@@ -17,16 +17,27 @@
 const SVG_NS = 'http://www.w3.org/2000/svg'
 
 /**
- * Canonical list of available symbol ids, in selector display order.
+ * Default symbol style. `cross` means "no drawn symbol shape" (feature 161):
+ * a feature with this style renders without a filled mark. It is the default so
+ * a newly created harmonic set or marker carries no symbol unless the analyst
+ * deliberately picks one.
+ * @type {SymbolType}
+ */
+export const DEFAULT_SYMBOL = 'cross'
+
+/**
+ * Canonical list of available symbol ids, in selector display order. `cross`
+ * (the symbol-less default) leads the list so it is the first/default option.
  * @type {SymbolType[]}
  */
-export const SYMBOL_CATALOG = ['circle', 'square', 'diamond', 'triangle', 'triangle-down', 'star']
+export const SYMBOL_CATALOG = ['cross', 'circle', 'square', 'diamond', 'triangle', 'triangle-down', 'star']
 
 /**
  * Human-readable display names for each symbol id (used by the selector).
  * @type {Record<SymbolType, string>}
  */
 export const SYMBOL_DISPLAY_NAMES = {
+  'cross': 'Cross (no symbol)',
   'circle': 'Circle',
   'square': 'Square',
   'diamond': 'Diamond',
@@ -69,14 +80,18 @@ function starPoints(cx, cy, outerR, innerR) {
  *
  * Pure: performs no DOM insertion and reads no state. Returns a detached SVG
  * element the caller appends. Any unknown/null/undefined `symbolType` falls
- * back to `circle`.
+ * back to the default (`cross`).
  *
- * @param {SymbolType|string|null|undefined} symbolType - Symbol id (falls back to `circle`)
+ * The `cross` style is symbol-less: it returns `null` so the caller draws no
+ * shape (the pin still keeps its line and label; a table cell falls back to a
+ * plain colour swatch). Callers MUST handle a `null` return.
+ *
+ * @param {SymbolType|string|null|undefined} symbolType - Symbol id (falls back to `cross`)
  * @param {number} cx - Centre X coordinate in the SVG overlay space
  * @param {number} cy - Centre Y coordinate in the SVG overlay space
  * @param {number} size - Nominal diameter in px (radius = size / 2)
- * @param {string} color - Fill colour (the harmonic set's hex colour)
- * @returns {SVGElement} A detached, filled SVG element
+ * @param {string} color - Fill colour (the feature's hex colour)
+ * @returns {SVGElement|null} A detached, filled SVG element, or `null` for `cross`
  */
 export function createSymbolMark(symbolType, cx, cy, size, color) {
   const r = size / 2
@@ -85,7 +100,12 @@ export function createSymbolMark(symbolType, cx, cy, size, color) {
   // recorded `data-symbol` reflect the actual fallback.
   const resolved = SYMBOL_CATALOG.includes(/** @type {SymbolType} */ (symbolType))
     ? /** @type {SymbolType} */ (symbolType)
-    : 'circle'
+    : DEFAULT_SYMBOL
+
+  // The symbol-less `cross` style draws nothing.
+  if (resolved === 'cross') {
+    return null
+  }
 
   /** @type {SVGElement} */
   let el
@@ -140,4 +160,44 @@ export function createSymbolMark(symbolType, cx, cy, size, color) {
   el.setAttribute('data-symbol', resolved)
   el.setAttribute('fill', color)
   return el
+}
+
+/**
+ * Build a colour indicator for a feature's table row (markers or harmonic sets).
+ *
+ * The indicator is symbol-dependent (feature 161, FR-010):
+ *   - a feature with a shaped symbol → the symbol drawn in the feature's colour,
+ *     inside a small inline SVG swatch;
+ *   - a feature with the `cross` (symbol-less) style → a plain filled rectangle
+ *     of the feature's colour, so the colour stays visible when no shape is drawn.
+ *
+ * Pure: builds and returns a detached element; performs no DOM insertion.
+ *
+ * @param {SymbolType|string|null|undefined} symbol - The feature's symbol style
+ * @param {string} color - The feature's hex colour
+ * @param {number} [size=16] - Indicator box size in px
+ * @returns {SVGSVGElement|HTMLDivElement} The detached indicator element
+ */
+export function createColorIndicator(symbol, color, size = 16) {
+  const mark = createSymbolMark(symbol, size / 2, size / 2, size * 0.75, color)
+
+  if (mark) {
+    const svg = document.createElementNS(SVG_NS, 'svg')
+    svg.setAttribute('class', 'gram-frame-symbol-swatch')
+    svg.setAttribute('width', String(size))
+    svg.setAttribute('height', String(size))
+    svg.setAttribute('viewBox', `0 0 ${size} ${size}`)
+    svg.appendChild(mark)
+    return svg
+  }
+
+  // Cross (symbol-less): a plain filled colour rectangle.
+  const div = document.createElement('div')
+  div.className = 'gram-frame-color-swatch'
+  div.style.backgroundColor = color
+  div.style.width = `${size}px`
+  div.style.height = `${size}px`
+  div.style.borderRadius = '3px'
+  div.style.border = '1px solid #ccc'
+  return div
 }

--- a/src/types.js
+++ b/src/types.js
@@ -71,6 +71,7 @@
  * @property {string} color - Marker color
  * @property {number} time - Time coordinate
  * @property {number} freq - Frequency coordinate
+ * @property {SymbolType} [symbol] - Marker symbol; `cross` (default) draws a crosshair, a shaped symbol draws that mark
  */
 
 /**
@@ -91,9 +92,10 @@
  */
 
 /**
- * Named filled shape used as a colour-blind-friendly visual code for a
- * harmonic set. Any unknown/absent value resolves to `circle`.
- * @typedef {'circle'|'square'|'diamond'|'triangle'|'triangle-down'|'star'} SymbolType
+ * Symbol style used as a colour-blind-friendly visual code for a feature.
+ * `cross` is the symbol-less default (no drawn shape); the remaining values are
+ * filled shapes. Any unknown/absent value resolves to `cross`.
+ * @typedef {'cross'|'circle'|'square'|'diamond'|'triangle'|'triangle-down'|'star'} SymbolType
  */
 
 /**
@@ -179,8 +181,8 @@
  * @property {ModeType} mode - Current analysis mode
  * @property {ModeType|null} previousMode - Previous analysis mode
  * @property {number} rate - Rate value affecting frequency calculations (Hz/s)
- * @property {string} selectedColor - Currently selected color for new features across all modes
- * @property {SymbolType} selectedSymbol - Currently selected symbol applied to the next created harmonic set
+ * @property {string} selectedColor - Colour for the NEXT created feature (when nothing is selected); when a feature is selected the picker restyles it instead
+ * @property {SymbolType} selectedSymbol - Symbol for the NEXT created harmonic set or marker (when nothing is selected); when a feature is selected the picker restyles it instead
  * @property {CursorPosition|null} cursorPosition - Current cursor position data
  * @property {Array<CursorPosition>} cursors - Array of cursor positions (future use)
  * @property {HarmonicsState} harmonics - Harmonics mode state
@@ -240,6 +242,7 @@
  * @property {string} color - Marker colour (hex)
  * @property {number} time - Time position in seconds
  * @property {number} freq - Frequency position in Hz
+ * @property {SymbolType} [symbol] - Persisted symbol; ABSENT in legacy records (default `cross` on restore)
  */
 
 /**
@@ -349,6 +352,10 @@
  * @property {function(): void} [clearSelection] - Clear selection  
  * @property {function(): void} [updateSelectionVisuals] - Update selection visuals
  * @property {function(string): void} [removeHarmonicSet] - Remove harmonic set by ID
+ * @property {function(string): boolean} [applyColorToSelectedFeature] - Restyle the selected feature's colour in place (feature 161)
+ * @property {function(SymbolType): boolean} [applySymbolToSelectedFeature] - Restyle the selected feature's symbol in place (feature 161)
+ * @property {function(): void} [syncStyleControls] - Sync the colour/symbol controls to the current selection (feature 161)
+ * @property {{setValue: function(SymbolType): void, setTint: function(string): void}|null} [_symbolControl] - Symbol drop-down control handle
  * @property {function(): void} [createUnifiedLayout] - Create unified layout
  */
 

--- a/tests/harmonic-labels.spec.js
+++ b/tests/harmonic-labels.spec.js
@@ -74,6 +74,9 @@ test.describe('Harmonic Pin Labels (feature 159)', () => {
     await gramFramePage.page.waitForTimeout(100)
     await gramFramePage.clickMode('Harmonics')
     await gramFramePage.waitForImageDimensions()
+    // The default symbol is now 'cross' (no drawn shape, feature 161); these
+    // tests assert symbol geometry, so pick a shaped symbol first.
+    await gramFramePage.selectSymbol('circle')
   })
 
   // ────────────────────────────────────────────────────────────────

--- a/tests/harmonic-symbols.spec.js
+++ b/tests/harmonic-symbols.spec.js
@@ -207,8 +207,8 @@ test.describe('US2: Symbols persist across reload', () => {
 // User Story 3 — Gracefully display legacy harmonics that predate symbols
 // ──────────────────────────────────────────────────────────────
 
-test.describe('US3: Legacy harmonic sets default to circle', () => {
-  test('a legacy v1 blob without symbol reloads with circles and no console error', async ({ page }) => {
+test.describe('US3: Legacy harmonic sets default to cross (symbol-less)', () => {
+  test('a legacy v1 blob without symbol reloads as cross with no symbol shape and no console error', async ({ page }) => {
     /** @type {string[]} */
     const consoleErrors = []
     page.on('console', (msg) => {
@@ -234,7 +234,8 @@ test.describe('US3: Legacy harmonic sets default to circle', () => {
       }))
     })
 
-    // Reload — legacy data must load (SCHEMA_VERSION unchanged) and default to circle
+    // Reload — legacy data must load (SCHEMA_VERSION unchanged) and default to
+    // the symbol-less 'cross' style (feature 161 changed the default from circle)
     await page.reload()
     await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
     await page.waitForTimeout(500)
@@ -243,19 +244,15 @@ test.describe('US3: Legacy harmonic sets default to circle', () => {
     const state = await getStateFromPage(page)
     const legacySet = state.harmonics.harmonicSets.find((s) => s.id === 'legacy-1')
     expect(legacySet).toBeTruthy()
-    expect(legacySet.symbol).toBe('circle')
+    expect(legacySet.symbol).toBe('cross')
 
-    // Every rendered pin symbol is a circle
+    // Pin lines are still drawn, but no symbol shape is rendered for a cross set
     const pins = await gfp.getPinSymbols('legacy-1')
-    expect(pins.length).toBeGreaterThan(0)
-    for (const p of pins) {
-      expect(p.symbol).toBe('circle')
-    }
+    expect(pins.length).toBe(0)
 
-    // Table swatch is a circle
+    // The harmonics-table row shows a filled colour rectangle (no symbol mark)
     const swatches = await gfp.getTableSymbolSwatches()
-    expect(swatches.length).toBeGreaterThan(0)
-    expect(swatches.every((s) => s.symbol === 'circle')).toBe(true)
+    expect(swatches.length).toBe(0)
 
     // No console errors during the legacy load
     expect(consoleErrors).toEqual([])

--- a/tests/reformat-markers-harmonics.spec.js
+++ b/tests/reformat-markers-harmonics.spec.js
@@ -28,7 +28,7 @@ async function markerOverlay(page, markerId) {
   return page.evaluate((id) => {
     const g = document.querySelector(`.gram-frame-analysis-marker[data-marker-id="${id}"]`)
     if (!g) return { lines: 0, symbols: 0, symbol: null }
-    const symbol = g.querySelector('.gram-frame-harmonic-symbol')
+    const symbol = g.querySelector('.gram-frame-marker-symbol')
     return {
       lines: g.querySelectorAll('line').length,
       symbols: symbol ? 1 : 0,
@@ -236,6 +236,90 @@ test.describe('US1: reformat an existing harmonic set', () => {
     await page.waitForTimeout(100)
     state = await gramFramePage.getState()
     expect(state.harmonics.harmonicSets.find((s) => s.id === set2).symbol).toBe('triangle')
+  })
+})
+
+// ──────────────────────────────────────────────────────────────
+// Switching mode clears the selection (about to add something new)
+// ──────────────────────────────────────────────────────────────
+
+test.describe('Switching mode clears the current selection', () => {
+  test('a selected harmonic is deselected on mode switch, so the controls target the next feature', async ({ gramFramePage }) => {
+    const page = gramFramePage.page
+
+    await gramFramePage.clickMode('Harmonics')
+    await page.waitForTimeout(100)
+    await gramFramePage.selectSymbol('star')
+    const setId = await gramFramePage.addHarmonicSet(30, 20)
+    await page.waitForTimeout(100)
+
+    // The new set is selected
+    let state = await gramFramePage.getState()
+    expect(state.selection.selectedType).toBe('harmonicSet')
+    expect(state.selection.selectedId).toBe(setId)
+    const colorBefore = state.harmonics.harmonicSets.find((s) => s.id === setId).color
+
+    // Switching to Cross Cursor clears the selection
+    await gramFramePage.clickMode('Cross Cursor')
+    await page.waitForTimeout(150)
+    state = await gramFramePage.getState()
+    expect(state.selection.selectedType).toBeNull()
+
+    // Picking a colour now arms the next feature and must NOT restyle the set
+    await page.locator(COLOR_CANVAS).click({ position: { x: 4, y: 10 } })
+    await page.waitForTimeout(100)
+    state = await gramFramePage.getState()
+    expect(state.harmonics.harmonicSets.find((s) => s.id === setId).color).toBe(colorBefore)
+  })
+})
+
+// ──────────────────────────────────────────────────────────────
+// Marker symbols coexist with harmonic sets (regression)
+// ──────────────────────────────────────────────────────────────
+
+test.describe('Marker symbols coexist with harmonic sets', () => {
+  test('a marker symbol survives adding a harmonic set and switching modes', async ({ gramFramePage }) => {
+    const page = gramFramePage.page
+
+    // Cross Cursor: create a marker and give it a square symbol
+    await gramFramePage.clickMode('Cross Cursor')
+    await page.waitForTimeout(150)
+    await gramFramePage.clickSpectrogram(200, 150)
+    await page.waitForTimeout(120)
+    let state = await gramFramePage.getState()
+    const markerId = state.analysis.markers[0].id
+    await gramFramePage.selectSymbol('square') // marker is auto-selected -> restyle it
+    await page.waitForTimeout(120)
+
+    let ov = await markerOverlay(page, markerId)
+    expect(ov.symbol).toBe('square')
+
+    // Add a harmonic set — its renderer must not wipe the marker's symbol
+    await gramFramePage.clickMode('Harmonics')
+    await page.waitForTimeout(120)
+    await gramFramePage.addHarmonicSet(30, 20)
+    await page.waitForTimeout(150)
+
+    ov = await markerOverlay(page, markerId)
+    expect(ov.symbols).toBe(1)
+    expect(ov.symbol).toBe('square')
+
+    // Back to Cross Cursor: the symbol is still on the overlay
+    await gramFramePage.clickMode('Cross Cursor')
+    await page.waitForTimeout(150)
+    ov = await markerOverlay(page, markerId)
+    expect(ov.symbol).toBe('square')
+
+    // Adding a new marker re-renders everything; both markers keep their symbol
+    await gramFramePage.selectSymbol('square')
+    await gramFramePage.clickSpectrogram(320, 220)
+    await page.waitForTimeout(150)
+    state = await gramFramePage.getState()
+    const secondId = state.analysis.markers.find((m) => m.id !== markerId).id
+    const ov1 = await markerOverlay(page, markerId)
+    const ov2 = await markerOverlay(page, secondId)
+    expect(ov1.symbol).toBe('square')
+    expect(ov2.symbol).toBe('square')
   })
 })
 

--- a/tests/reformat-markers-harmonics.spec.js
+++ b/tests/reformat-markers-harmonics.spec.js
@@ -1,0 +1,319 @@
+import { test, expect } from './helpers/fixtures.js'
+
+/**
+ * @fileoverview E2E tests for feature 161 — "Reformat existing markers &
+ * harmonics, with a cross (symbol-less) style".
+ *
+ * Covers:
+ *  - US2: the `cross` symbol-less style is available and is the default.
+ *  - US1: selecting a harmonic set drives the style controls and restyling the
+ *    selected set (colour/symbol) takes effect in place, affecting only it.
+ *  - US3: markers can carry a symbol; a shaped marker draws that symbol, a
+ *    cross marker draws the crosshair and shows a filled colour rectangle.
+ */
+
+/** Locator for the shared symbol drop-down */
+const SYMBOL_SELECT = '.gram-frame-symbol-select'
+/** Locator for the colour slider canvas */
+const COLOR_CANVAS = '.gram-frame-color-canvas'
+
+/**
+ * Read the DOM shape of a marker overlay group: how many crosshair lines and
+ * how many symbol marks it contains, and the symbol id if present.
+ * @param {import('@playwright/test').Page} page
+ * @param {string} markerId
+ * @returns {Promise<{lines: number, symbols: number, symbol: string|null}>}
+ */
+async function markerOverlay(page, markerId) {
+  return page.evaluate((id) => {
+    const g = document.querySelector(`.gram-frame-analysis-marker[data-marker-id="${id}"]`)
+    if (!g) return { lines: 0, symbols: 0, symbol: null }
+    const symbol = g.querySelector('.gram-frame-harmonic-symbol')
+    return {
+      lines: g.querySelectorAll('line').length,
+      symbols: symbol ? 1 : 0,
+      symbol: symbol ? symbol.getAttribute('data-symbol') : null
+    }
+  }, markerId)
+}
+
+/**
+ * Read the marker table row's colour-indicator shape.
+ * @param {import('@playwright/test').Page} page
+ * @param {string} markerId
+ * @returns {Promise<{swatchSymbol: string|null, hasRect: boolean}>}
+ */
+async function markerRowIndicator(page, markerId) {
+  return page.evaluate((id) => {
+    const row = document.querySelector(`tr[data-marker-id="${id}"]`)
+    if (!row) return { swatchSymbol: null, hasRect: false }
+    const mark = row.querySelector('.gram-frame-harmonic-symbol')
+    const rect = row.querySelector('.gram-frame-color-swatch')
+    return {
+      swatchSymbol: mark ? mark.getAttribute('data-symbol') : null,
+      hasRect: !!rect
+    }
+  }, markerId)
+}
+
+// ──────────────────────────────────────────────────────────────
+// US2 — the cross (symbol-less) style as the default
+// ──────────────────────────────────────────────────────────────
+
+test.describe('US2: cross is the default, symbol-less style', () => {
+  test('the symbol selector offers "cross" and it is the default selection', async ({ gramFramePage }) => {
+    const select = gramFramePage.page.locator(SYMBOL_SELECT)
+    await expect(select).toBeVisible()
+
+    const values = await select.locator('option').evaluateAll(
+      (opts) => opts.map((o) => /** @type {HTMLOptionElement} */ (o).value)
+    )
+    expect(values).toContain('cross')
+
+    // Default selection is cross
+    await expect(select).toHaveValue('cross')
+    const state = await gramFramePage.getState()
+    expect(state.selectedSymbol).toBe('cross')
+  })
+
+  test('a harmonic set created without picking a symbol draws no symbol shape', async ({ gramFramePage }) => {
+    await gramFramePage.clickMode('Harmonics')
+    await gramFramePage.page.waitForTimeout(100)
+
+    const setId = await gramFramePage.addHarmonicSet(30, 20)
+    await gramFramePage.page.waitForTimeout(150)
+
+    const state = await gramFramePage.getState()
+    const set = state.harmonics.harmonicSets.find((s) => s.id === setId)
+    expect(set.symbol).toBe('cross')
+
+    // No symbol marks, but the pin lines are still drawn
+    const symbols = await gramFramePage.getPinSymbols(setId)
+    expect(symbols.length).toBe(0)
+    const lines = await gramFramePage.getHarmonicNumbers(setId)
+    expect(lines.length).toBeGreaterThan(0)
+  })
+
+  test('a marker created without picking a symbol renders as a crosshair', async ({ gramFramePage }) => {
+    await gramFramePage.clickMode('Cross Cursor')
+    await gramFramePage.page.waitForTimeout(150)
+
+    await gramFramePage.clickSpectrogram(220, 160)
+    await gramFramePage.page.waitForTimeout(150)
+
+    const state = await gramFramePage.getState()
+    expect(state.analysis.markers.length).toBe(1)
+    const marker = state.analysis.markers[0]
+    expect(marker.symbol).toBe('cross')
+
+    const overlay = await markerOverlay(gramFramePage.page, marker.id)
+    expect(overlay.lines).toBe(2) // crosshair h + v line
+    expect(overlay.symbols).toBe(0)
+
+    // Table indicator is a filled colour rectangle (no symbol swatch)
+    const indicator = await markerRowIndicator(gramFramePage.page, marker.id)
+    expect(indicator.hasRect).toBe(true)
+    expect(indicator.swatchSymbol).toBeNull()
+  })
+})
+
+// ──────────────────────────────────────────────────────────────
+// US1 — reformat an existing harmonic set
+// ──────────────────────────────────────────────────────────────
+
+test.describe('US1: reformat an existing harmonic set', () => {
+  test.beforeEach(async ({ gramFramePage }) => {
+    await gramFramePage.clickMode('Harmonics')
+    await gramFramePage.page.waitForTimeout(100)
+  })
+
+  test('selecting a set updates the symbol selector; restyling affects only that set', async ({ gramFramePage }) => {
+    const page = gramFramePage.page
+
+    // Set 1 — square
+    await gramFramePage.selectSymbol('square')
+    const set1 = await gramFramePage.addHarmonicSet(30, 20)
+    await page.waitForTimeout(100)
+    // Deselect (toggle the row) so the next symbol choice targets the NEXT set
+    await page.locator(`tr[data-harmonic-id="${set1}"]`).click()
+    await page.waitForTimeout(50)
+
+    // Set 2 — star
+    await gramFramePage.selectSymbol('star')
+    const set2 = await gramFramePage.addHarmonicSet(30, 25)
+    await page.waitForTimeout(100)
+
+    // Selecting set 1 makes the symbol selector show its symbol (square)
+    await page.locator(`tr[data-harmonic-id="${set1}"]`).click()
+    await page.waitForTimeout(50)
+    await expect(page.locator(SYMBOL_SELECT)).toHaveValue('square')
+
+    // Reformat set 1 to diamond — only set 1 changes
+    await gramFramePage.selectSymbol('diamond')
+    await page.waitForTimeout(100)
+
+    const state = await gramFramePage.getState()
+    const s1 = state.harmonics.harmonicSets.find((s) => s.id === set1)
+    const s2 = state.harmonics.harmonicSets.find((s) => s.id === set2)
+    expect(s1.symbol).toBe('diamond')
+    expect(s2.symbol).toBe('star')
+
+    const pins1 = await gramFramePage.getPinSymbols(set1)
+    expect(pins1.length).toBeGreaterThan(0)
+    for (const p of pins1) expect(p.symbol).toBe('diamond')
+  })
+
+  test('reformatting a set to cross removes its symbol shape but keeps its lines', async ({ gramFramePage }) => {
+    const page = gramFramePage.page
+
+    await gramFramePage.selectSymbol('circle')
+    const setId = await gramFramePage.addHarmonicSet(30, 20)
+    await page.waitForTimeout(100)
+    // The set is auto-selected after creation; reformat it to cross
+    await gramFramePage.selectSymbol('cross')
+    await page.waitForTimeout(100)
+
+    const state = await gramFramePage.getState()
+    const set = state.harmonics.harmonicSets.find((s) => s.id === setId)
+    expect(set.symbol).toBe('cross')
+
+    const symbols = await gramFramePage.getPinSymbols(setId)
+    expect(symbols.length).toBe(0)
+    const lines = await gramFramePage.getHarmonicNumbers(setId)
+    expect(lines.length).toBeGreaterThan(0)
+  })
+
+  test('changing the colour of a selected set restyles only that set', async ({ gramFramePage }) => {
+    const page = gramFramePage.page
+
+    const set1 = await gramFramePage.addHarmonicSet(30, 20)
+    await page.waitForTimeout(80)
+    await page.locator(`tr[data-harmonic-id="${set1}"]`).click() // deselect
+    const set2 = await gramFramePage.addHarmonicSet(30, 25)
+    await page.waitForTimeout(80)
+
+    const before = await gramFramePage.getState()
+    const set2ColorBefore = before.harmonics.harmonicSets.find((s) => s.id === set2).color
+
+    // Select set 1 and pick a colour from the far-left of the slider
+    await page.locator(`tr[data-harmonic-id="${set1}"]`).click()
+    await page.waitForTimeout(50)
+    await page.locator(COLOR_CANVAS).click({ position: { x: 4, y: 10 } })
+    await page.waitForTimeout(100)
+
+    const after = await gramFramePage.getState()
+    const set1ColorBefore = before.harmonics.harmonicSets.find((s) => s.id === set1).color
+    const set1ColorAfter = after.harmonics.harmonicSets.find((s) => s.id === set1).color
+    const set2ColorAfter = after.harmonics.harmonicSets.find((s) => s.id === set2).color
+
+    expect(set1ColorAfter).not.toBe(set1ColorBefore)
+    // The unselected set is untouched
+    expect(set2ColorAfter).toBe(set2ColorBefore)
+  })
+
+  test('with nothing selected, changing the symbol sets the next feature only', async ({ gramFramePage }) => {
+    const page = gramFramePage.page
+
+    await gramFramePage.selectSymbol('square')
+    const set1 = await gramFramePage.addHarmonicSet(30, 20)
+    await page.waitForTimeout(100)
+    // Deselect
+    await page.locator(`tr[data-harmonic-id="${set1}"]`).click()
+    await page.waitForTimeout(50)
+
+    // No selection: changing the symbol must not touch the placed set
+    await gramFramePage.selectSymbol('triangle')
+    await page.waitForTimeout(100)
+
+    let state = await gramFramePage.getState()
+    expect(state.harmonics.harmonicSets.find((s) => s.id === set1).symbol).toBe('square')
+    // The control now targets the next feature (its DOM value is the source of
+    // truth; state.selectedSymbol is not broadcast when nothing is selected).
+    await expect(page.locator(SYMBOL_SELECT)).toHaveValue('triangle')
+
+    // The next created set uses the newly selected symbol
+    const set2 = await gramFramePage.addHarmonicSet(30, 25)
+    await page.waitForTimeout(100)
+    state = await gramFramePage.getState()
+    expect(state.harmonics.harmonicSets.find((s) => s.id === set2).symbol).toBe('triangle')
+  })
+})
+
+// ──────────────────────────────────────────────────────────────
+// US3 — reformat a marker, including giving it a symbol
+// ──────────────────────────────────────────────────────────────
+
+test.describe('US3: reformat a marker and give it a symbol', () => {
+  test.beforeEach(async ({ gramFramePage }) => {
+    await gramFramePage.clickMode('Cross Cursor')
+    await gramFramePage.page.waitForTimeout(150)
+  })
+
+  test('assigning a shaped symbol draws that symbol; reverting to cross restores the crosshair', async ({ gramFramePage }) => {
+    const page = gramFramePage.page
+
+    await gramFramePage.clickSpectrogram(220, 160)
+    await page.waitForTimeout(150)
+    let state = await gramFramePage.getState()
+    const markerId = state.analysis.markers[0].id
+
+    // The new marker is auto-selected; the selector shows cross
+    await expect(page.locator(SYMBOL_SELECT)).toHaveValue('cross')
+
+    // Assign a square — the marker is drawn as a colour-coded square
+    await gramFramePage.selectSymbol('square')
+    await page.waitForTimeout(120)
+    state = await gramFramePage.getState()
+    expect(state.analysis.markers[0].symbol).toBe('square')
+
+    let overlay = await markerOverlay(page, markerId)
+    expect(overlay.symbols).toBe(1)
+    expect(overlay.symbol).toBe('square')
+    expect(overlay.lines).toBe(0) // symbol replaces the crosshair
+
+    // The table indicator now shows the colour-coded symbol
+    let indicator = await markerRowIndicator(page, markerId)
+    expect(indicator.swatchSymbol).toBe('square')
+    expect(indicator.hasRect).toBe(false)
+
+    // Revert to cross — crosshair and filled rectangle indicator come back
+    await gramFramePage.selectSymbol('cross')
+    await page.waitForTimeout(120)
+    state = await gramFramePage.getState()
+    expect(state.analysis.markers[0].symbol).toBe('cross')
+
+    overlay = await markerOverlay(page, markerId)
+    expect(overlay.symbols).toBe(0)
+    expect(overlay.lines).toBe(2)
+
+    indicator = await markerRowIndicator(page, markerId)
+    expect(indicator.hasRect).toBe(true)
+    expect(indicator.swatchSymbol).toBeNull()
+  })
+
+  test('changing the colour of a selected marker restyles only that marker', async ({ gramFramePage }) => {
+    const page = gramFramePage.page
+
+    await gramFramePage.clickSpectrogram(180, 140)
+    await page.waitForTimeout(120)
+    await gramFramePage.clickSpectrogram(300, 220)
+    await page.waitForTimeout(120)
+
+    const before = await gramFramePage.getState()
+    expect(before.analysis.markers.length).toBe(2)
+    const m1 = before.analysis.markers[0]
+    const m2 = before.analysis.markers[1]
+
+    // Select marker 1 via its table row, then pick a far-left colour
+    await page.locator(`tr[data-marker-id="${m1.id}"]`).click()
+    await page.waitForTimeout(50)
+    await page.locator(COLOR_CANVAS).click({ position: { x: 4, y: 10 } })
+    await page.waitForTimeout(100)
+
+    const after = await gramFramePage.getState()
+    const m1After = after.analysis.markers.find((m) => m.id === m1.id)
+    const m2After = after.analysis.markers.find((m) => m.id === m2.id)
+    expect(m1After.color).not.toBe(m1.color)
+    expect(m2After.color).toBe(m2.color)
+  })
+})


### PR DESCRIPTION
## Summary

Implements feature **161 — Reformat existing markers & harmonics, with a "cross" (symbol-less) style** (from GH issue #198, bullets 4 & 5). Adds the speckit `plan.md`/`tasks.md` alongside the existing `spec.md`.

Two capabilities ship together:

1. **A "cross" (symbol-less) style**, added to the shared symbol catalogue and made the **default**. A `cross` feature draws no filled symbol shape — a harmonic set keeps its pin lines and number labels, a marker keeps its crosshair. The default appearance of new features therefore changes from a circle to no symbol (intended).
2. **In-place reformatting** of an already-placed marker or harmonic set. Selecting a feature (table row or overlay) drives the colour and symbol controls to that feature's current values; changing a control restyles the selected feature instantly on the overlay and in its table, affecting only that feature. With nothing selected, the controls keep setting the style for the **next** created feature.

Markers gain a `symbol` attribute for the first time (default `cross`): a shaped marker is drawn as that colour-coded symbol, a `cross` marker draws the crosshair. A marker's table colour indicator is symbol-dependent — a shaped symbol shows the colour-coded symbol, `cross` shows a filled colour rectangle.

## Changes

- **`src/rendering/symbols.js`** — `cross` in `SYMBOL_CATALOG` (default), `DEFAULT_SYMBOL`, `createSymbolMark()` returns `null` for cross; new shared `createColorIndicator()` (symbol swatch for a shape, filled rectangle for cross).
- **`src/core/keyboardControl.js`** — `getSelectedFeature`/`getActiveStyle`/`applyColorToSelectedFeature`/`applySymbolToSelectedFeature`; `setSelection`/`clearSelection` now sync the style controls.
- **`src/components/ColorPicker.js` / `SymbolPicker.js` / `MainUI.js`** — pickers take the instance, route changes to the selected feature or the next-feature defaults, and register `instance.syncStyleControls`.
- **`src/modes/analysis/AnalysisMode.js`** — markers carry a symbol; render symbol-or-crosshair; table indicator via `createColorIndicator` and refreshed on update.
- **`src/modes/harmonics/HarmonicsMode.js` / `components/HarmonicPanel.js`** — default `cross`; skip the null symbol mark while keeping line + label; table indicator via `createColorIndicator`.
- **`src/core/storage.js` / `main.js`** — additive `symbol` on the stored marker record; restore defaults to `cross` for markers and harmonic sets. No `SCHEMA_VERSION` bump, so legacy records load without error.
- **`src/core/state.js` / `types.js`** — `selectedSymbol` default `cross`; `SymbolType` gains `cross`; marker/instance types updated.

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn test` passes (163/163)
- [x] `yarn build` passes
- [x] New `tests/reformat-markers-harmonics.spec.js` covers US1 (reformat a harmonic set: select → controls reflect, restyle colour/symbol in place, only the selected set changes, cross keeps lines/labels, nothing-selected sets the next feature), US2 (cross is available and the default; new features draw no symbol), and US3 (assign a marker a symbol, revert to cross, colour restyle affects only the selected marker).
- [x] `tests/harmonic-symbols.spec.js` US3 updated: a legacy no-symbol set now loads as `cross` (no pin symbol, filled-rectangle table indicator).
- [x] `tests/harmonic-labels.spec.js` `beforeEach` selects a shaped symbol (the default is now `cross`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3gJjLhAxGdYMUTEqkesoW

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3gJjLhAxGdYMUTEqkesoW)_