### PR TITLE
Add legacy-browser compatibility warning (spec 162)

### DIFF
--- a/src/api/GramFrameAPI.js
+++ b/src/api/GramFrameAPI.js
@@ -12,6 +12,7 @@ import {
   notifyStateListeners
 } from '../core/state.js'
 import { setImageExpanded, isLandscape } from '../components/ExpandToggle.js'
+import { isBrowserSupported, showCompatibilityWarning } from '../core/browserCompatibility.js'
 
 /**
  * Creates the GramFrame public API object
@@ -38,7 +39,21 @@ export function createGramFrameAPI(GramFrame) {
       /** @type {GramFrame[]} */
       const instances = []
       const errors = []
-      
+
+      // Legacy-browser guard: check the required JS/DOM APIs are present before
+      // any GramFrame is constructed. On an unsupported browser, show a clear
+      // "please update your browser" warning in place of each config table
+      // instead of letting the component fail silently mid-render. The check is
+      // feature-detection based, so it runs without throwing on the very
+      // browsers it is meant to catch.
+      if (!isBrowserSupported()) {
+        configTables.forEach(table => {
+          showCompatibilityWarning(/** @type {HTMLElement} */ (table))
+        })
+        this._instances = instances
+        return instances
+      }
+
       configTables.forEach((table, index) => {
         try {
           // Generate unique ID for each component instance

--- a/src/api/GramFrameAPI.js
+++ b/src/api/GramFrameAPI.js
@@ -12,7 +12,7 @@ import {
   notifyStateListeners
 } from '../core/state.js'
 import { setImageExpanded, isLandscape } from '../components/ExpandToggle.js'
-import { isBrowserSupported, showCompatibilityWarning } from '../core/browserCompatibility.js'
+import { isBrowserSupported, showCompatibilityWarning, looksLikeMissingApiError } from '../core/browserCompatibility.js'
 
 /**
  * Creates the GramFrame public API object
@@ -72,9 +72,20 @@ export function createGramFrameAPI(GramFrame) {
           const errorMsg = `Failed to initialize GramFrame for table ${index + 1}: ${error instanceof Error ? error.message : String(error)}`
           console.error('GramFrame Error:', errorMsg, error)
           errors.push({ table, error: errorMsg, index })
-          
-          // Add error indicator to the table (don't replace it)
-          this._addErrorIndicator(/** @type {HTMLTableElement} */ (table), errorMsg)
+
+          // Reactive legacy-browser safety net. Explicit feature detection only
+          // catches APIs we listed; an even-older browser might be missing a
+          // different required method we did not anticipate. When the failure
+          // looks like a missing method/constructor (rather than a config or
+          // logic error), show the same "please update your browser" warning in
+          // place of the component instead of the technical error indicator, so
+          // the analyst gets an actionable message and never a silent failure.
+          if (looksLikeMissingApiError(error)) {
+            showCompatibilityWarning(/** @type {HTMLElement} */ (table))
+          } else {
+            // Add error indicator to the table (don't replace it)
+            this._addErrorIndicator(/** @type {HTMLTableElement} */ (table), errorMsg)
+          }
         }
       })
       

--- a/src/core/browserCompatibility.js
+++ b/src/core/browserCompatibility.js
@@ -91,6 +91,41 @@ export function isBrowserSupported() {
 }
 
 /**
+ * Error-message signatures a JS engine produces when code calls a method or
+ * constructor the browser does not provide. Explicit feature detection can only
+ * catch APIs we thought to list; this lets us also recognise the *class* of
+ * "a required method is missing" at the point an even-older browser actually
+ * throws it, so we can still show the compatibility warning rather than a blank
+ * or broken area. Deliberately narrow: it matches missing-callable signatures
+ * only, so a genuine logic bug (e.g. "cannot read properties of undefined")
+ * does NOT get mislabelled as a browser problem.
+ * @type {RegExp}
+ */
+var MISSING_CALLABLE_MESSAGE = /is not a function|is not a constructor|doesn't support|does not support|undefined is not a function/i
+
+/**
+ * Heuristic: does this error look like it was caused by the browser lacking a
+ * required method/constructor (as opposed to a config-parsing or logic error)?
+ * Used as a reactive safety net around component construction so that older
+ * browsers missing an API we did not explicitly feature-detect still get the
+ * "please update your browser" warning instead of failing silently.
+ * @param {unknown} error - The thrown value to classify
+ * @returns {boolean} True when the error resembles a missing-API failure
+ */
+export function looksLikeMissingApiError(error) {
+  if (!error) {
+    return false
+  }
+  // Treat the thrown value loosely; error shapes vary across engines.
+  var err = /** @type {any} */ (error)
+  // A missing method/constructor is reported as a TypeError across engines.
+  var isTypeError = (typeof TypeError !== 'undefined' && err instanceof TypeError) ||
+    err.name === 'TypeError'
+  var message = err.message ? String(err.message) : String(err)
+  return !!isTypeError && MISSING_CALLABLE_MESSAGE.test(message)
+}
+
+/**
  * The user-facing compatibility message. Names the minimum supported version
  * and asks the user to update. The wording refers to Chrome/Edge because those
  * are the supported/target browsers for the training material, even though the

--- a/src/core/browserCompatibility.js
+++ b/src/core/browserCompatibility.js
@@ -1,0 +1,145 @@
+/**
+ * Browser-compatibility guard for GramFrame.
+ *
+ * GramFrame relies on a small number of modern DOM/JS APIs that are newer than
+ * the legacy baseline (Chrome/Edge 84). On an out-of-date browser these calls
+ * throw during rendering and the component silently fails, leaving the analyst
+ * with a blank or half-rendered area and no explanation.
+ *
+ * This module feature-detects the required APIs *before* any rendering happens
+ * and, when the browser is unsupported, replaces the component's area with a
+ * plain, readable "please update your browser" message instead.
+ *
+ * IMPORTANT: the detection code in this file must not itself use any API that
+ * is absent on the browsers it is meant to catch, or it would reproduce the
+ * very silent failure it exists to prevent. It therefore sticks to long-baseline
+ * DOM APIs only (document.createElement, textContent, appendChild, ...).
+ */
+
+/// <reference path="../types.js" />
+
+/**
+ * @typedef {Object} RequiredApi
+ * @property {string} name - Human-readable API identifier (for debugging/tests)
+ * @property {number} minVersion - Minimum Chrome/Edge version that ships this API
+ * @property {function(): boolean} test - Presence test; must not throw on legacy browsers
+ */
+
+/**
+ * The set of modern JS/DOM capabilities GramFrame depends on without a fallback.
+ *
+ * Presence of all of them is the pass condition; absence of any is the fail
+ * condition. To add a newly-relied-upon API, append an entry here with the
+ * Chrome/Edge version that introduced it — the minimum supported version in the
+ * warning is derived from the highest `minVersion` in this list.
+ *
+ * @type {RequiredApi[]}
+ */
+export const REQUIRED_APIS = [
+  {
+    // Element.replaceChildren() shipped in Chrome/Edge 86. Its absence on
+    // Chrome 84 is the original silent failure this feature guards against
+    // (used by src/utils/secureHTML.js and src/components/HarmonicPanel.js).
+    name: 'Element.prototype.replaceChildren',
+    minVersion: 86,
+    test: function () {
+      return typeof Element !== 'undefined' &&
+        !!Element.prototype &&
+        typeof Element.prototype.replaceChildren === 'function'
+    }
+  }
+]
+
+/**
+ * Minimum supported Chrome/Edge version, derived from the required-API set: it
+ * is the highest browser version any required API needs. Stated in the warning
+ * so an analyst (or their IT support) knows exactly what to update to.
+ * @type {number}
+ */
+export const MIN_BROWSER_VERSION = REQUIRED_APIS.reduce(function (max, api) {
+  return api.minVersion > max ? api.minVersion : max
+}, 0)
+
+/**
+ * Names of any required APIs that are missing in the current browser.
+ * @returns {string[]} Missing API names (empty when the browser is supported)
+ */
+export function getMissingApis() {
+  var missing = []
+  for (var i = 0; i < REQUIRED_APIS.length; i++) {
+    var api = REQUIRED_APIS[i]
+    var present = false
+    try {
+      present = !!api.test()
+    } catch (e) {
+      present = false
+    }
+    if (!present) {
+      missing.push(api.name)
+    }
+  }
+  return missing
+}
+
+/**
+ * Feature-detect whether the current browser has every API GramFrame requires.
+ * Partial support (some APIs present, others missing) counts as unsupported.
+ * @returns {boolean} True when all required APIs are present
+ */
+export function isBrowserSupported() {
+  return getMissingApis().length === 0
+}
+
+/**
+ * The user-facing compatibility message. Names the minimum supported version
+ * and asks the user to update. The wording refers to Chrome/Edge because those
+ * are the supported/target browsers for the training material, even though the
+ * underlying guard is feature-detection based rather than brand sniffing.
+ * @returns {string} Human-readable warning message
+ */
+export function getCompatibilityMessage() {
+  return 'To view this interactive analysis component, at least version ' +
+    MIN_BROWSER_VERSION + ' of Chrome or Edge is required. ' +
+    'Please update your browser.'
+}
+
+/**
+ * Build the warning element shown in place of the component on an unsupported
+ * browser. Uses only long-baseline DOM APIs so it renders on the legacy
+ * browsers this feature targets.
+ * @returns {HTMLDivElement} The warning element
+ */
+export function createCompatibilityWarningElement() {
+  var warning = document.createElement('div')
+  warning.className = 'gram-frame-compat-warning'
+  warning.setAttribute('role', 'alert')
+
+  var heading = document.createElement('strong')
+  heading.className = 'gram-frame-compat-warning-heading'
+  heading.textContent = 'This interactive component needs a newer browser'
+
+  var message = document.createElement('p')
+  message.className = 'gram-frame-compat-warning-message'
+  message.textContent = getCompatibilityMessage()
+
+  warning.appendChild(heading)
+  warning.appendChild(message)
+
+  return warning
+}
+
+/**
+ * Replace a GramFrame config table with the compatibility warning, in place, so
+ * the analyst sees the message exactly where the component would have appeared.
+ * @param {HTMLElement} configTable - The config table to replace
+ * @returns {HTMLDivElement|null} The inserted warning element, or null if the
+ *   table could not be replaced
+ */
+export function showCompatibilityWarning(configTable) {
+  if (!configTable || !configTable.parentNode) {
+    return null
+  }
+  var warning = createCompatibilityWarningElement()
+  configTable.parentNode.replaceChild(warning, configTable)
+  return warning
+}

--- a/src/gramframe.css
+++ b/src/gramframe.css
@@ -740,6 +740,37 @@
     0 1px 2px rgba(0,0,0,0.2);
 }
 
+/* Legacy-browser compatibility warning — shown in place of the component when
+   the browser lacks a required JS/DOM API. Kept legible even in small
+   containers (min sizing, word wrapping) so it is never clipped to nothing. */
+.gram-frame-compat-warning {
+  box-sizing: border-box;
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  margin: 10px 0;
+  padding: 16px 20px;
+  background-color: #fff8e1;
+  border: 2px solid #f0ad4e;
+  border-radius: 4px;
+  color: #663c00;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}
+
+.gram-frame-compat-warning-heading {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 15px;
+}
+
+.gram-frame-compat-warning-message {
+  margin: 0;
+}
+
 /* Rate input UI styles removed - backend functionality preserved */
 
 /* SVG cursor styles removed - using CSS cursor only */

--- a/src/main.js
+++ b/src/main.js
@@ -59,6 +59,11 @@ import {
   cleanupKeyboardControl
 } from './core/keyboardControl.js'
 
+import {
+  isBrowserSupported,
+  showCompatibilityWarning
+} from './core/browserCompatibility.js'
+
 /**
  * GramFrame class - Main component implementation
  */
@@ -131,14 +136,32 @@ export class GramFrame {
   // Whether this instance is a trainer context
   _isTrainerContext;
 
+  // Set when the browser lacks a required API; construction is skipped and a
+  // compatibility warning is shown in place of the component.
+  _unsupportedBrowser;
+
   /**
    * Creates a new GramFrame instance
    * @param {HTMLTableElement} configTable - Configuration table element to replace
    */
   constructor(configTable) {
+    this.configTable = configTable
+
+    // Legacy-browser guard. Run before any rendering so an unsupported browser
+    // never reaches the modern DOM calls (e.g. Element.replaceChildren) that
+    // would throw and fail silently. When the required APIs are missing, show a
+    // clear "please update your browser" warning in place of the component and
+    // stop constructing — the rest of the setup (which relies on those APIs) is
+    // skipped. Callers going through GramFrameAPI.init() are already short-
+    // circuited before this point; this covers direct `new GramFrame(table)` use.
+    if (!isBrowserSupported()) {
+      this._unsupportedBrowser = true
+      showCompatibilityWarning(configTable)
+      return
+    }
+
     // Core state initialization
     this.state = createInitialState()
-    this.configTable = configTable
     this.stateListeners = []
     this.instanceId = ''
 

--- a/tests/browser-compatibility.spec.js
+++ b/tests/browser-compatibility.spec.js
@@ -1,0 +1,141 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * @fileoverview Legacy-browser compatibility warning tests (spec 162).
+ *
+ * Two layers:
+ *  1. Unit tests of src/core/browserCompatibility.js, imported and exercised in
+ *     the browser via page.evaluate against a controlled DOM (mirroring the
+ *     detect-user-context.spec.js pattern).
+ *  2. Integration tests: a modern browser renders normally (no warning), and a
+ *     simulated legacy browser (Element.replaceChildren removed before init)
+ *     shows the warning in place of every GramFrame.
+ */
+
+test.describe('browserCompatibility module (unit)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/tests/fixtures/blank-page.html')
+  })
+
+  test('MIN_BROWSER_VERSION is derived from the required-API set (86)', async ({ page }) => {
+    const version = await page.evaluate(async () => {
+      const mod = await import('/src/core/browserCompatibility.js')
+      return mod.MIN_BROWSER_VERSION
+    })
+    expect(version).toBe(86)
+  })
+
+  test('isBrowserSupported() is true on a modern browser with no missing APIs', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const mod = await import('/src/core/browserCompatibility.js')
+      return { supported: mod.isBrowserSupported(), missing: mod.getMissingApis() }
+    })
+    expect(result.supported).toBe(true)
+    expect(result.missing).toEqual([])
+  })
+
+  test('detects a missing required API and reports it as unsupported', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const mod = await import('/src/core/browserCompatibility.js')
+      // Simulate a legacy browser lacking Element.replaceChildren.
+      const original = Element.prototype.replaceChildren
+      // @ts-ignore - deliberately removing a method for the test
+      delete Element.prototype.replaceChildren
+      const supported = mod.isBrowserSupported()
+      const missing = mod.getMissingApis()
+      // Restore so nothing else in the page breaks.
+      Element.prototype.replaceChildren = original
+      return { supported, missing }
+    })
+    expect(result.supported).toBe(false)
+    expect(result.missing).toContain('Element.prototype.replaceChildren')
+  })
+
+  test('warning message names the minimum version, Chrome/Edge, and asks to update', async ({ page }) => {
+    const message = await page.evaluate(async () => {
+      const mod = await import('/src/core/browserCompatibility.js')
+      return mod.getCompatibilityMessage()
+    })
+    expect(message).toContain('86')
+    expect(message).toContain('Chrome')
+    expect(message).toContain('Edge')
+    expect(message.toLowerCase()).toContain('update')
+  })
+
+  test('createCompatibilityWarningElement() builds a labelled warning node', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const mod = await import('/src/core/browserCompatibility.js')
+      const el = mod.createCompatibilityWarningElement()
+      return {
+        className: el.className,
+        role: el.getAttribute('role'),
+        text: el.textContent
+      }
+    })
+    expect(result.className).toBe('gram-frame-compat-warning')
+    expect(result.role).toBe('alert')
+    expect(result.text).toContain('86')
+    expect(result.text.toLowerCase()).toContain('update')
+  })
+
+  test('showCompatibilityWarning() replaces the table in place', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const mod = await import('/src/core/browserCompatibility.js')
+      document.body.innerHTML =
+        '<div id="host"><table class="gram-config" id="t1"></table></div>'
+      const host = document.getElementById('host')
+      const table = document.getElementById('t1')
+      const inserted = mod.showCompatibilityWarning(table)
+      return {
+        tableStillPresent: !!document.getElementById('t1'),
+        warningInHost: !!host.querySelector('.gram-frame-compat-warning'),
+        returnedWarning: !!inserted && inserted.classList.contains('gram-frame-compat-warning')
+      }
+    })
+    expect(result.tableStillPresent).toBe(false)
+    expect(result.warningInHost).toBe(true)
+    expect(result.returnedWarning).toBe(true)
+  })
+
+  test('showCompatibilityWarning() is a safe no-op for a detached table', async ({ page }) => {
+    const returnedNull = await page.evaluate(async () => {
+      const mod = await import('/src/core/browserCompatibility.js')
+      const detached = document.createElement('table')
+      return mod.showCompatibilityWarning(detached) === null
+    })
+    expect(returnedNull).toBe(true)
+  })
+})
+
+test.describe('Legacy-browser compatibility warning (integration)', () => {
+  test('modern browser renders GramFrames with no warning (US2)', async ({ page }) => {
+    await page.goto('/debug.html')
+    await page.waitForFunction(() => window.GramFrame !== undefined)
+
+    await expect(page.locator('.gram-frame-container')).toBeVisible()
+    await expect(page.locator('.gram-frame-compat-warning')).toHaveCount(0)
+  })
+
+  test('unsupported browser shows the warning in place of every GramFrame (US1, FR-006)', async ({ page }) => {
+    await page.goto('/tests/fixtures/legacy-browser-page.html')
+
+    // Both config tables should be replaced by a warning, none left blank.
+    await expect(page.locator('.gram-frame-compat-warning')).toHaveCount(2)
+
+    // No interactive component should have been constructed.
+    await expect(page.locator('.gram-frame-container')).toHaveCount(0)
+
+    // The original tables are gone (replaced), not merely hidden.
+    await expect(page.locator('table.gram-config')).toHaveCount(0)
+
+    // The warning is actionable: names the version and tells the user to update.
+    const firstWarning = page.locator('.gram-frame-compat-warning').first()
+    const text = (await firstWarning.textContent()) || ''
+    expect(text).toContain('86')
+    expect(text).toContain('Chrome')
+    expect(text.toLowerCase()).toContain('update')
+
+    // And it is visible (not clipped to nothing).
+    await expect(firstWarning).toBeVisible()
+  })
+})

--- a/tests/browser-compatibility.spec.js
+++ b/tests/browser-compatibility.spec.js
@@ -105,6 +105,29 @@ test.describe('browserCompatibility module (unit)', () => {
     })
     expect(returnedNull).toBe(true)
   })
+
+  test('looksLikeMissingApiError() recognises missing-method errors but not others', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const mod = await import('/src/core/browserCompatibility.js')
+      const f = mod.looksLikeMissingApiError
+      return {
+        notAFunction: f(new TypeError("x.replaceChildren is not a function")),
+        notAConstructor: f(new TypeError("ResizeObserver is not a constructor")),
+        legacyIeStyle: f(new TypeError("Object doesn't support property or method 'foo'")),
+        // Genuine logic bug — must NOT be treated as a browser issue.
+        nullDeref: f(new TypeError("Cannot read properties of undefined (reading 'x')")),
+        // Config/validation error — must NOT be treated as a browser issue.
+        configError: f(new Error("Invalid config: missing time-start")),
+        nullish: f(null)
+      }
+    })
+    expect(result.notAFunction).toBe(true)
+    expect(result.notAConstructor).toBe(true)
+    expect(result.legacyIeStyle).toBe(true)
+    expect(result.nullDeref).toBe(false)
+    expect(result.configError).toBe(false)
+    expect(result.nullish).toBe(false)
+  })
 })
 
 test.describe('Legacy-browser compatibility warning (integration)', () => {
@@ -137,5 +160,24 @@ test.describe('Legacy-browser compatibility warning (integration)', () => {
 
     // And it is visible (not clipped to nothing).
     await expect(firstWarning).toBeVisible()
+  })
+
+  test('unanticipated missing API is still caught by the reactive net (class of error)', async ({ page }) => {
+    await page.goto('/tests/fixtures/legacy-browser-unknown-api-page.html')
+
+    // replaceChildren is present (proactive check passes), but a different
+    // required method is missing, so construction throws. The reactive net
+    // should show the compatibility warning rather than a blank/broken area...
+    await expect(page.locator('.gram-frame-compat-warning')).toHaveCount(1)
+
+    // ...and it should NOT fall back to the technical error indicator, since the
+    // failure is a missing-method (browser) error, not a config error.
+    await expect(page.locator('.gramframe-error-indicator')).toHaveCount(0)
+    await expect(page.locator('.gram-frame-container')).toHaveCount(0)
+
+    const warning = page.locator('.gram-frame-compat-warning').first()
+    await expect(warning).toBeVisible()
+    const text = (await warning.textContent()) || ''
+    expect(text.toLowerCase()).toContain('update')
   })
 })

--- a/tests/fixtures/legacy-browser-page.html
+++ b/tests/fixtures/legacy-browser-page.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Legacy Browser Page - Compatibility Warning Test</title>
+  <link rel="stylesheet" href="../../src/gramframe.css" />
+
+  <!--
+    Simulate an out-of-date browser (e.g. Chrome/Edge 84) that lacks
+    Element.replaceChildren() (added in 86). This classic inline script runs
+    during parsing, before the deferred GramFrame module executes, so the
+    compatibility guard sees the API as missing exactly as it would on a real
+    legacy browser. Two config tables are present so we can confirm every
+    GramFrame area shows the warning (none left silently blank).
+  -->
+  <script>
+    try {
+      delete Element.prototype.replaceChildren
+    } catch (e) {
+      Element.prototype.replaceChildren = undefined
+    }
+  </script>
+
+  <script type="module" src="../../src/main.js"></script>
+</head>
+<body>
+  <h1>Legacy Browser Page</h1>
+
+  <div class="component-container">
+    <table class="gram-config" id="config1">
+      <tr>
+        <td colspan="2">
+          <img src="../../sample/mock-gram.png" alt="Sample Spectrogram 1">
+        </td>
+      </tr>
+      <tr><td>time-start</td><td>0</td></tr>
+      <tr><td>time-end</td><td>60</td></tr>
+      <tr><td>freq-start</td><td>0</td></tr>
+      <tr><td>freq-end</td><td>100</td></tr>
+    </table>
+  </div>
+
+  <div class="component-container">
+    <table class="gram-config" id="config2">
+      <tr>
+        <td colspan="2">
+          <img src="../../sample/mock-gram.png" alt="Sample Spectrogram 2">
+        </td>
+      </tr>
+      <tr><td>time-start</td><td>0</td></tr>
+      <tr><td>time-end</td><td>60</td></tr>
+      <tr><td>freq-start</td><td>0</td></tr>
+      <tr><td>freq-end</td><td>100</td></tr>
+    </table>
+  </div>
+</body>
+</html>

--- a/tests/fixtures/legacy-browser-unknown-api-page.html
+++ b/tests/fixtures/legacy-browser-unknown-api-page.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Legacy Browser (Unanticipated Missing API) - Compatibility Warning Test</title>
+  <link rel="stylesheet" href="../../src/gramframe.css" />
+
+  <!--
+    Simulate an even-older browser that is missing a required method the
+    explicit feature-detection list does NOT check for. Element.replaceChildren
+    is left intact (so the proactive check passes), but document.createElementNS
+    (used to build the SVG during construction) is removed. Construction then
+    throws a "not a function" TypeError, which the reactive safety net should
+    recognise as a missing-API failure and handle by showing the compatibility
+    warning — proving the whole *class* of missing-method errors is caught, not
+    just the APIs we enumerated.
+  -->
+  <script>
+    // Shadow the prototype method with an own property so calls throw
+    // "document.createElementNS is not a function".
+    document.createElementNS = undefined
+  </script>
+
+  <script type="module" src="../../src/main.js"></script>
+</head>
+<body>
+  <h1>Legacy Browser Page (unanticipated missing API)</h1>
+
+  <div class="component-container">
+    <table class="gram-config" id="config1">
+      <tr>
+        <td colspan="2">
+          <img src="../../sample/mock-gram.png" alt="Sample Spectrogram">
+        </td>
+      </tr>
+      <tr><td>time-start</td><td>0</td></tr>
+      <tr><td>time-end</td><td>60</td></tr>
+      <tr><td>freq-start</td><td>0</td></tr>
+      <tr><td>freq-end</td><td>100</td></tr>
+    </table>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Implements spec 162 (GH issue #198, review feedback bullet 6): a legacy Chrome (v84) lacked `Element.replaceChildren` (added in v86), so GramFrame silently failed — the analyst saw a blank/half-rendered area with no explanation. This replaces that silent failure with a clear **"please update your browser"** warning shown in place of the component.

It does so with **two complementary layers**:

1. **Proactive feature detection** — before any instance is built, check the modern JS/DOM APIs GramFrame requires. Gives a confident, specific message naming the minimum version.
2. **Reactive safety net** — because a curated API list can only catch what we anticipated, also recognise the *class* of "a required method is missing" at the point construction actually throws it, and show the same warning. This catches even-older browsers missing a different method we didn't enumerate.

## Changes

- **`src/core/browserCompatibility.js`** (new):
  - `REQUIRED_APIS` set, `isBrowserSupported()`, and the warning element/replacement helpers. Detection uses only long-baseline DOM APIs (`createElement`, `textContent`, `appendChild`, …), so it runs without throwing on the very legacy browsers it targets (FR-007).
  - `MIN_BROWSER_VERSION` is **derived** from the highest version any required API needs (currently 86), not hard-coded — add an entry to `REQUIRED_APIS` and the warning text updates itself (FR-009 / SC-006).
  - `looksLikeMissingApiError()` — narrowly classifies a thrown value as a missing-method/constructor failure (missing-callable `TypeError` signatures only), used by the reactive net.
- **`src/api/GramFrameAPI.js`**:
  - Proactive guard in `detectAndReplaceConfigTables()` runs **before** any instance is constructed; on an unsupported browser every config table is replaced with the warning (FR-002, FR-006).
  - Reactive branch in the construction `catch`: a missing-API-shaped error shows the browser-update warning; config/validation errors keep the existing technical indicator, so malformed-config behaviour is unchanged (spec edge case).
- **`src/main.js`**: proactive guard at the top of the `GramFrame` constructor covers direct `new GramFrame(table)` usage.
- **`src/gramframe.css`**: warning styling that stays legible even in small containers (not clipped to nothing).
- **Tests** (`tests/browser-compatibility.spec.js` + 2 fixtures): module unit tests (incl. the error classifier), a modern-browser integration test (no warning, renders normally), a simulated legacy browser (warning per GramFrame, names v86, asks to update), and a fixture that leaves `replaceChildren` intact but removes an *unanticipated* method (`createElementNS`) — proving the reactive net catches the whole class end to end.

## API audit

The only post-Chrome-84 API GramFrame uses that would *throw* is `Element.replaceChildren` (Chrome/Edge 86), so the minimum stated version is 86. A grep sweep found no other post-84 throwing method/syntax. `aspect-ratio` (Chrome 88) appears once in CSS-via-JS but is only ever set to `'unset'` (a silently-ignored no-op on old browsers, with nothing depending on it), so it neither throws nor affects rendering. `?.`/`??` are used but are Chrome 80 — below the 84 baseline.

## Testing

- `yarn build` — succeeds
- `yarn typecheck` — clean
- `tests/browser-compatibility.spec.js` — **11 passed**
- Full Playwright suite — passes apart from 6 pre-existing flaky "Error Recovery / complex operations" tests that also fail on the base branch (unrelated to this change; my changes only affect error paths that don't execute on a modern browser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9wShy5eCECK6gAvLSLgf9