### PR TITLE
Size harmonic pins in pixels so zoom does not stretch them

### DIFF
--- a/src/modes/harmonics/HarmonicsMode.js
+++ b/src/modes/harmonics/HarmonicsMode.js
@@ -8,7 +8,7 @@ import { BaseDragHandler } from '../shared/BaseDragHandler.js'
 import { getUniformTolerance } from '../../utils/tolerance.js'
 import { sampledHarmonics } from '../../utils/harmonicSampling.js'
 import { createSymbolMark } from '../../rendering/symbols.js'
-import { calculateVisibleDataRange } from '../../components/table.js'
+import { calculateVisibleDataRange, getRenderDimensions } from '../../components/table.js'
 
 /**
  * Harmonics mode implementation
@@ -131,6 +131,18 @@ export class HarmonicsMode extends BaseMode {
    * @type {number}
    */
   static SYMBOL_SIZE = 10
+
+  /**
+   * Height of a pin line, as a fraction of the *base* (unzoomed) render height.
+   *
+   * The resulting height is a fixed pixel length, not a span of time: it is
+   * derived from the viewport's base render size (which tracks expand, not zoom)
+   * rather than from the zoomed image element. Pins therefore keep the same
+   * on-screen height at every zoom level, growing/shrinking only when the
+   * component itself is resized.
+   * @type {number}
+   */
+  static PIN_HEIGHT_RATIO = 0.2
 
   /**
    * Font size (px) of a pin's number label; also used as its approximate ascent
@@ -465,27 +477,27 @@ export class HarmonicsMode extends BaseMode {
         // Only consider harmonics within the visible frequency range
         const freqMin = this.instance.state.config.freqMin
         const freqMax = this.instance.state.config.freqMax
-        
+
         const minHarmonic = Math.max(1, Math.ceil(freqMin / harmonicSet.spacing))
         const maxHarmonic = Math.floor(freqMax / harmonicSet.spacing)
-        
+
+        // Pins are a fixed pixel height, so hit-test vertically in SVG pixels
+        // against the same geometry the renderer draws.
+        const { lineHeight, lineTop } = this.calculateHarmonicLineDimensions(harmonicSet)
+
         for (let h = minHarmonic; h <= maxHarmonic; h++) {
           const expectedFreq = h * harmonicSet.spacing
           const tolerance = getUniformTolerance(this.getViewport(), this.instance.spectrogramImage)
-          
+
           if (Math.abs(freq - expectedFreq) < tolerance.freq) {
-            // Also check if cursor is within the vertical range of the harmonic line
-            // Harmonic lines have 20% of SVG height, centered on anchor time
-            const { naturalHeight } = this.instance.state.imageDetails
-            const lineHeight = naturalHeight * 0.2
-            const timeRange = this.instance.state.config.timeMax - this.instance.state.config.timeMin
-            const lineHeightInTime = (lineHeight / naturalHeight) * timeRange
-            
-            const lineStartTime = harmonicSet.anchorTime - lineHeightInTime / 2
-            const lineEndTime = harmonicSet.anchorTime + lineHeightInTime / 2
-            
+            const cursorSVGY = calculateZoomAwarePosition(
+              { freq: expectedFreq, time: cursorTime },
+              this.getViewport(),
+              this.instance.spectrogramImage
+            ).y
+
             // Check if cursor is within the vertical range of the harmonic line
-            if (cursorTime >= lineStartTime && cursorTime <= lineEndTime) {
+            if (cursorSVGY >= lineTop && cursorSVGY <= lineTop + lineHeight) {
               return harmonicSet
             }
           }
@@ -703,16 +715,21 @@ export class HarmonicsMode extends BaseMode {
   }
 
   /**
-   * Calculate harmonic line dimensions and positions
+   * Calculate harmonic line dimensions and positions.
+   *
+   * The height is a fixed pixel length taken from the *base* (unzoomed) render
+   * height, so a pin covers the same number of screen pixels no matter how far
+   * the user has zoomed in — it is not a span of time that stretches with the
+   * image. Only the centre is zoom-aware: the pin stays centred on the set's
+   * anchor time (the original click location), so it tracks the feature while
+   * keeping a constant height.
+   *
    * @param {HarmonicSet} harmonicSet - Harmonic set configuration
-   * @returns {Object} Line dimensions with height and top position
+   * @returns {{lineHeight: number, lineTop: number}} Fixed pixel height and top Y position
    */
   calculateHarmonicLineDimensions(harmonicSet) {
-    // Calculate harmonic line height (20% of spectrogram height). Derive geometry
-    // from the actual rendered image bounds so it stays correct across expand × zoom.
-    const lineHeightRatio = 0.2
-    const imageBounds = getImageBounds(this.getViewport(), this.instance.spectrogramImage)
-    const lineHeight = imageBounds.height * lineHeightRatio
+    const { renderHeight } = getRenderDimensions(this.instance)
+    const lineHeight = renderHeight * HarmonicsMode.PIN_HEIGHT_RATIO
     const anchorPoint = { freq: harmonicSet.spacing, time: harmonicSet.anchorTime }
     const anchorSVG = calculateZoomAwarePosition(anchorPoint, this.getViewport(), this.instance.spectrogramImage)
     const lineTop = anchorSVG.y - lineHeight / 2

--- a/tests/harmonic-pin-height.spec.js
+++ b/tests/harmonic-pin-height.spec.js
@@ -1,0 +1,113 @@
+import { test, expect } from './helpers/fixtures.js'
+
+/**
+ * @fileoverview E2E tests for harmonic pin height sizing.
+ *
+ * Pin lines are sized in screen pixels, not in time units: their height is
+ * derived from the base (unzoomed) render height, so zooming in/out leaves the
+ * on-screen height unchanged while the pin stays centred on the anchor time of
+ * the original click.
+ *
+ * Debug config spans freq 0-100 Hz over time 0-60 s. A 10 Hz set anchored at
+ * t=30 s keeps harmonic 5 (50 Hz) near the centre of the image, so it stays
+ * visible at every zoom level exercised here.
+ */
+
+const ANCHOR_TIME = 30
+const SPACING = 10
+/** Harmonic that sits at the horizontal centre of the span (50 Hz of 0-100). */
+const CENTRE_HARMONIC = 5
+
+/**
+ * Measure a single pin line's client-rect geometry alongside the image's, so the
+ * pin height can be compared against the image height at the same zoom level.
+ * @param {import('./helpers/gram-frame-page.js').GramFramePage} gfp - Page helper
+ * @param {string} setId - Harmonic set id
+ * @param {number} harmonicNumber - Which pin to measure
+ * @returns {Promise<{lineHeight: number, lineCy: number, image: {top: number, height: number}}>}
+ */
+async function readPinGeometry(gfp, setId, harmonicNumber) {
+  return gfp.page.evaluate(([id, num]) => {
+    const line = document.querySelector(
+      `.gram-frame-harmonic-line[data-harmonic-set-id="${id}"][data-harmonic-number="${num}"]`
+    )
+    const imageRect = document.querySelector('.gram-frame-spectrogram-image').getBoundingClientRect()
+    const lineRect = line.getBoundingClientRect()
+    return {
+      lineHeight: lineRect.height,
+      lineCy: (lineRect.top + lineRect.bottom) / 2,
+      image: { top: imageRect.top, height: imageRect.height }
+    }
+  }, [setId, harmonicNumber])
+}
+
+test.describe('Harmonic pin height', () => {
+  test.beforeEach(async ({ gramFramePage }) => {
+    await gramFramePage.page.waitForTimeout(100)
+    await gramFramePage.clickMode('Harmonics')
+    await gramFramePage.waitForImageDimensions()
+  })
+
+  test('pin height in pixels is unchanged by zooming', async ({ gramFramePage }) => {
+    const setId = await gramFramePage.addHarmonicSet(ANCHOR_TIME, SPACING)
+    await gramFramePage.page.waitForTimeout(100)
+
+    const base = await readPinGeometry(gramFramePage, setId, CENTRE_HARMONIC)
+    expect(base.lineHeight).toBeGreaterThan(0)
+
+    for (const level of [2.0, 4.0, 8.0]) {
+      await gramFramePage.setZoom(level, 0.5, 0.5)
+      await gramFramePage.page.waitForTimeout(100)
+
+      const zoomed = await readPinGeometry(gramFramePage, setId, CENTRE_HARMONIC)
+      // The image really did grow — otherwise this test proves nothing.
+      expect(zoomed.image.height).toBeGreaterThan(base.image.height * (level - 0.5))
+      // ...but the pin did not.
+      expect(zoomed.lineHeight).toBeCloseTo(base.lineHeight, 1)
+    }
+  })
+
+  test('pin stays centred on its anchor time while zooming', async ({ gramFramePage }) => {
+    const setId = await gramFramePage.addHarmonicSet(ANCHOR_TIME, SPACING)
+    await gramFramePage.page.waitForTimeout(100)
+
+    for (const level of [1.0, 2.0, 4.0]) {
+      await gramFramePage.setZoom(level, 0.5, 0.5)
+      await gramFramePage.page.waitForTimeout(100)
+
+      const { lineCy, image } = await readPinGeometry(gramFramePage, setId, CENTRE_HARMONIC)
+      // Where the anchor time falls on the (zoomed) image; time axis runs bottom-up.
+      const expectedCy = image.top + (1 - ANCHOR_TIME / 60) * image.height
+      expect(lineCy).toBeCloseTo(expectedCy, 0)
+    }
+  })
+
+  test('a pin can still be grabbed at its anchor time when zoomed in', async ({ gramFramePage }) => {
+    const setId = await gramFramePage.addHarmonicSet(ANCHOR_TIME, SPACING)
+    await gramFramePage.setZoom(4.0, 0.5, 0.5)
+    await gramFramePage.page.waitForTimeout(100)
+
+    // Hit-testing works in the same pixel space as rendering: the anchor time is
+    // inside the pin, a point well below it (in the now-stretched time axis) is not.
+    const hit = await gramFramePage.page.evaluate(([id, num]) => {
+      // @ts-ignore - test-only global
+      const instance = window.GramFrame.__test__getInstances()[0]
+      const mode = instance.modes['harmonics']
+      const freq = num * 10
+      /**
+       * @param {number} time - Time to probe at
+       * @returns {boolean} Whether a harmonic set is found there
+       */
+      const probe = (time) => {
+        instance.state.cursorPosition = {
+          x: 0, y: 0, svgX: 0, svgY: 0, imageX: 0, imageY: 0, freq, time
+        }
+        return mode.findHarmonicSetAtFrequency(freq)?.id === id
+      }
+      return { atAnchor: probe(30), farBelow: probe(10) }
+    }, [setId, CENTRE_HARMONIC])
+
+    expect(hit.atAnchor).toBe(true)
+    expect(hit.farBelow).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem

Harmonic pin lines were effectively sized in **time**, not pixels. `calculateHarmonicLineDimensions()` took 20% of the rendered image height, read from the spectrogram `<image>` element's attributes — and those attributes are scaled by zoom. Zooming in therefore made every pin taller and taller.

## Fix

- **Height is now a fixed pixel length**, derived from the base (unzoomed) render height via `getRenderDimensions()`, which tracks expand but not zoom. Introduced as `HarmonicsMode.PIN_HEIGHT_RATIO`.
- **Centre stays zoom-aware**, so a pin remains centred on its set's anchor time (the original click location) and continues to track the feature — it just no longer grows.
- Appearance at zoom 1.0 is unchanged; the ratio is kept proportional to the base render height rather than hard-coded, so pins stay sensibly sized on spectrograms of different heights and when the image is expanded.

`findHarmonicSetAtFrequency()` made the same assumption in reverse — it converted a 20% share of the image into a time window and compared that against the cursor time, which drifted away from the drawn geometry once zoomed. It now hit-tests vertically in SVG pixels against the same `calculateHarmonicLineDimensions()` output the renderer uses, so grabbing a pin lines up with what's on screen at every zoom level.

## Testing

New `tests/harmonic-pin-height.spec.js` covers:
- pin height in pixels is unchanged across zoom 1×/2×/4×/8× (asserting the image *did* grow, so the test can't pass vacuously);
- the pin stays centred on its anchor time at each zoom level;
- a pin is still grabbable at its anchor time when zoomed in, and not at a point well outside it.

The height test was confirmed to fail against the previous implementation.

- `yarn typecheck` — clean
- `yarn test` — 193 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZKpE9YdtXLyjRs33c9obU)_