### PR TITLE
Experiment: "Large symbols" toggle for choosing the overlay symbol size

### DIFF
--- a/src/components/ColorPicker.js
+++ b/src/components/ColorPicker.js
@@ -7,7 +7,7 @@
 
 /// <reference path="../types.js" />
 
-import { createSymbolSelect } from './SymbolPicker.js'
+import { createSymbolSelect, createLargeSymbolToggle } from './SymbolPicker.js'
 import { getActiveStyle } from '../core/keyboardControl.js'
 
 /**
@@ -92,6 +92,10 @@ export function createColorPicker(instance) {
   // colour readout.
   const symbolSelect = createSymbolSelect(instance)
   paletteContainer.appendChild(symbolSelect)
+
+  // TEMPORARY (size experiment): size toggle beneath the slider/drop-down row,
+  // for feedback on whether the larger symbols read better on a real gram.
+  container.appendChild(createLargeSymbolToggle(instance))
 
   // Add click handler for color selection
   canvas.addEventListener('click', (event) => {

--- a/src/components/ColorPicker.js
+++ b/src/components/ColorPicker.js
@@ -136,11 +136,15 @@ export function createColorPicker(instance) {
   // currently selected, or to the next-feature defaults when nothing is
   // selected (feature 161, FR-004/FR-013).
   instance.syncStyleControls = () => {
-    const { color, symbol } = getActiveStyle(instance)
+    const { color, symbol, largeSymbols } = getActiveStyle(instance)
     showColor(color)
     if (instance._symbolControl) {
       instance._symbolControl.setValue(symbol)
       instance._symbolControl.setTint(color)
+    }
+    // TEMPORARY (size experiment): keep the size toggle in step with selection.
+    if (instance._largeSymbolsControl) {
+      instance._largeSymbolsControl.setValue(largeSymbols)
     }
   }
 

--- a/src/components/SymbolPicker.js
+++ b/src/components/SymbolPicker.js
@@ -13,7 +13,8 @@
 
 /// <reference path="../types.js" />
 
-import { SYMBOL_CATALOG, SYMBOL_DISPLAY_NAMES, DEFAULT_SYMBOL } from '../rendering/symbols.js'
+import { SYMBOL_CATALOG, SYMBOL_DISPLAY_NAMES, DEFAULT_SYMBOL, LARGE_SYMBOL_SCALE } from '../rendering/symbols.js'
+import { notifyStateListeners } from '../core/state.js'
 
 /**
  * Unicode glyph shown for each symbol id in the drop-down. The list is a
@@ -86,4 +87,44 @@ export function createSymbolSelect(instance) {
   }
 
   return select
+}
+
+/**
+ * Create the temporary "Large symbols" toggle for the Symbol panel.
+ *
+ * EXPERIMENT: an on/off switch between the current symbol size and
+ * {@link LARGE_SYMBOL_SCALE}× that size, so analysts can compare the two on a
+ * real gram and tell us which to adopt. Toggling redraws every overlay symbol
+ * (harmonic pins and analysis markers) immediately; the table swatches are
+ * unaffected. The state is in-memory only and is never persisted.
+ *
+ * Once a size is agreed, delete this control along with `state.largeSymbols`
+ * and fold the winning size into the base constants.
+ *
+ * @param {GramFrame} instance - GramFrame instance
+ * @returns {HTMLLabelElement} The toggle (a label wrapping its checkbox)
+ */
+export function createLargeSymbolToggle(instance) {
+  const label = document.createElement('label')
+  label.className = 'gram-frame-large-symbols-toggle'
+  label.title = `Trial: draw symbols at ${LARGE_SYMBOL_SCALE}× their normal size`
+
+  const checkbox = document.createElement('input')
+  checkbox.type = 'checkbox'
+  checkbox.className = 'gram-frame-large-symbols-checkbox'
+  checkbox.checked = !!instance.state.largeSymbols
+
+  checkbox.addEventListener('change', () => {
+    instance.state.largeSymbols = checkbox.checked
+    // Redraw the overlay so the new size applies to every existing feature.
+    if (instance.featureRenderer) {
+      instance.featureRenderer.renderAllPersistentFeatures()
+    }
+    notifyStateListeners(instance.state, instance.stateListeners)
+  })
+
+  label.appendChild(checkbox)
+  label.appendChild(document.createTextNode('Large symbols'))
+
+  return label
 }

--- a/src/components/SymbolPicker.js
+++ b/src/components/SymbolPicker.js
@@ -94,11 +94,14 @@ export function createSymbolSelect(instance) {
  *
  * EXPERIMENT: an on/off switch between the current symbol size and
  * {@link LARGE_SYMBOL_SCALE}× that size, so analysts can compare the two on a
- * real gram and tell us which to adopt. Toggling redraws every overlay symbol
- * (harmonic pins and analysis markers) immediately; the table swatches are
- * unaffected. The state is in-memory only and is never persisted.
+ * real gram and tell us which to adopt. The size is a per-feature property and
+ * the toggle follows the same routing as the colour slider and symbol
+ * drop-down: with a marker or harmonic set selected it resizes THAT feature
+ * only — so both sizes can be on screen at once — and with nothing selected it
+ * sets the size for the next created feature. Table swatches are unaffected,
+ * and the flag is never persisted.
  *
- * Once a size is agreed, delete this control along with `state.largeSymbols`
+ * Once a size is agreed, delete this control along with the per-feature flag
  * and fold the winning size into the base constants.
  *
  * @param {GramFrame} instance - GramFrame instance
@@ -107,7 +110,7 @@ export function createSymbolSelect(instance) {
 export function createLargeSymbolToggle(instance) {
   const label = document.createElement('label')
   label.className = 'gram-frame-large-symbols-toggle'
-  label.title = `Trial: draw symbols at ${LARGE_SYMBOL_SCALE}× their normal size`
+  label.title = `Trial: draw the selected feature's symbols at ${LARGE_SYMBOL_SCALE}× their normal size`
 
   const checkbox = document.createElement('input')
   checkbox.type = 'checkbox'
@@ -115,13 +118,23 @@ export function createLargeSymbolToggle(instance) {
   checkbox.checked = !!instance.state.largeSymbols
 
   checkbox.addEventListener('change', () => {
-    instance.state.largeSymbols = checkbox.checked
-    // Redraw the overlay so the new size applies to every existing feature.
-    if (instance.featureRenderer) {
-      instance.featureRenderer.renderAllPersistentFeatures()
+    // Resize the selected feature when one is selected, otherwise set the size
+    // for the next created feature.
+    if (!instance.applyLargeSymbolsToSelectedFeature ||
+        !instance.applyLargeSymbolsToSelectedFeature(checkbox.checked)) {
+      instance.state.largeSymbols = checkbox.checked
+      notifyStateListeners(instance.state, instance.stateListeners)
     }
-    notifyStateListeners(instance.state, instance.stateListeners)
   })
+
+  // Expose a handle so selection changes reflect the selected feature's size
+  // back into the checkbox (mirrors the symbol drop-down's control handle).
+  instance._largeSymbolsControl = {
+    /** @param {boolean} large */
+    setValue(large) {
+      checkbox.checked = large
+    }
+  }
 
   label.appendChild(checkbox)
   label.appendChild(document.createTextNode('Large symbols'))

--- a/src/core/initialization/EventBindings.js
+++ b/src/core/initialization/EventBindings.js
@@ -9,7 +9,7 @@
 /// <reference path="../../types.js" />
 
 import { setupEventListeners, setupResizeObserver } from '../events.js'
-import { initializeKeyboardControl, setSelection, clearSelection, updateSelectionVisuals, removeHarmonicSet, applyColorToSelectedFeature, applySymbolToSelectedFeature } from '../keyboardControl.js'
+import { initializeKeyboardControl, setSelection, clearSelection, updateSelectionVisuals, removeHarmonicSet, applyColorToSelectedFeature, applySymbolToSelectedFeature, applyLargeSymbolsToSelectedFeature } from '../keyboardControl.js'
 import { getGlobalStateListeners } from '../state.js'
 
 /**
@@ -33,6 +33,7 @@ export function setupAllEventListeners(instance) {
   instance.removeHarmonicSet = (id) => removeHarmonicSet(instance, id)
   instance.applyColorToSelectedFeature = (color) => applyColorToSelectedFeature(instance, color)
   instance.applySymbolToSelectedFeature = (symbol) => applySymbolToSelectedFeature(instance, symbol)
+  instance.applyLargeSymbolsToSelectedFeature = (large) => applyLargeSymbolsToSelectedFeature(instance, large)
 }
 
 /**

--- a/src/core/keyboardControl.js
+++ b/src/core/keyboardControl.js
@@ -430,20 +430,25 @@ export function getSelectedFeature(instance) {
 /**
  * Get the colour/symbol the style controls should currently show: the selected
  * feature's when one is selected, otherwise the next-feature defaults.
+ *
+ * `largeSymbols` is part of the temporary symbol-size experiment and follows the
+ * same rule, so the toggle always reflects whatever the controls would restyle.
  * @param {GramFrame} instance - GramFrame instance
- * @returns {{color: string, symbol: SymbolType}} Active style
+ * @returns {{color: string, symbol: SymbolType, largeSymbols: boolean}} Active style
  */
 export function getActiveStyle(instance) {
   const selected = getSelectedFeature(instance)
   if (selected) {
     return {
       color: selected.feature.color,
-      symbol: /** @type {SymbolType} */ (selected.feature.symbol || DEFAULT_SYMBOL)
+      symbol: /** @type {SymbolType} */ (selected.feature.symbol || DEFAULT_SYMBOL),
+      largeSymbols: !!selected.feature.largeSymbols
     }
   }
   return {
     color: instance.state.selectedColor,
-    symbol: instance.state.selectedSymbol
+    symbol: instance.state.selectedSymbol,
+    largeSymbols: !!instance.state.largeSymbols
   }
 }
 
@@ -500,6 +505,27 @@ export function applySymbolToSelectedFeature(instance, symbol) {
     return false
   }
   selected.feature.symbol = symbol
+  refreshFeatureVisuals(instance, selected.type)
+  return true
+}
+
+/**
+ * Apply the large-symbol size to the currently selected feature, updating the
+ * overlay instantly. No-op when nothing is selected.
+ *
+ * EXPERIMENT (temporary): the size is per-feature so two sets can be shown at
+ * different sizes side by side for comparison. Delete with the rest of the
+ * experiment once a size is agreed.
+ * @param {GramFrame} instance - GramFrame instance
+ * @param {boolean} large - Whether the feature draws its symbol at the large size
+ * @returns {boolean} True if a feature was restyled
+ */
+export function applyLargeSymbolsToSelectedFeature(instance, large) {
+  const selected = getSelectedFeature(instance)
+  if (!selected) {
+    return false
+  }
+  selected.feature.largeSymbols = large
   refreshFeatureVisuals(instance, selected.type)
   return true
 }

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -43,6 +43,10 @@ export const initialState = {
   rate: 1,
   selectedColor: '#ff6b6b', // Currently selected color for new features across all modes
   selectedSymbol: 'cross', // Currently selected symbol; 'cross' (default) means no drawn symbol shape (feature 161)
+  // EXPERIMENT (temporary): draw overlay symbols at double size, toggled from
+  // the Symbol panel. In-memory only, default off, never persisted — it exists
+  // to gather feedback on the preferred symbol size.
+  largeSymbols: false,
   cursorPosition: null,
   cursors: [],
   imageDetails: {

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -43,9 +43,10 @@ export const initialState = {
   rate: 1,
   selectedColor: '#ff6b6b', // Currently selected color for new features across all modes
   selectedSymbol: 'cross', // Currently selected symbol; 'cross' (default) means no drawn symbol shape (feature 161)
-  // EXPERIMENT (temporary): draw overlay symbols at double size, toggled from
-  // the Symbol panel. In-memory only, default off, never persisted — it exists
-  // to gather feedback on the preferred symbol size.
+  // EXPERIMENT (temporary): large-symbol size for the NEXT created feature, set
+  // from the Symbol panel's toggle when nothing is selected (with a feature
+  // selected, the toggle resizes that feature instead). In-memory only, default
+  // off, never persisted — it exists to gather feedback on the preferred size.
   largeSymbols: false,
   cursorPosition: null,
   cursors: [],

--- a/src/gramframe.css
+++ b/src/gramframe.css
@@ -348,6 +348,26 @@
   cursor: pointer;
 }
 
+/* TEMPORARY (symbol-size experiment): "Large symbols" toggle under the colour
+   slider. Remove together with the control once a symbol size is agreed. */
+.gram-frame-large-symbols-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 6px;
+  font-size: 10px;
+  color: #00ff00;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.gram-frame-large-symbols-checkbox {
+  margin: 0;
+  cursor: pointer;
+}
+
 .gram-frame-color-canvas {
   width: 140px;
   max-width: 140px;

--- a/src/main.js
+++ b/src/main.js
@@ -127,10 +127,14 @@ export class GramFrame {
   // Reformatting (feature 161): restyle the selected feature in place
   applyColorToSelectedFeature;
   applySymbolToSelectedFeature;
+  // EXPERIMENT (temporary): resize the selected feature's symbols
+  applyLargeSymbolsToSelectedFeature;
   // Sync the colour/symbol controls to the current selection
   syncStyleControls;
   // Symbol drop-down control handle (registered by the symbol picker)
   _symbolControl;
+  // EXPERIMENT (temporary): "Large symbols" checkbox handle
+  _largeSymbolsControl;
   
   // ResizeObserver
   resizeObserver;

--- a/src/modes/analysis/AnalysisMode.js
+++ b/src/modes/analysis/AnalysisMode.js
@@ -217,7 +217,10 @@ export class AnalysisMode extends BaseMode {
       color,
       time: dataCoords.time,
       freq: dataCoords.freq,
-      symbol
+      symbol,
+      // EXPERIMENT (temporary): symbol size is carried per marker, seeded from
+      // the toggle's next-feature default, so both sizes can coexist.
+      largeSymbols: !!this.instance.state.largeSymbols
     }
     
     // Add marker to state
@@ -265,7 +268,7 @@ export class AnalysisMode extends BaseMode {
     // A marker carrying a shaped symbol is drawn as that colour-coded symbol
     // (feature 161, FR-009); a marker with the `cross` (symbol-less) style
     // continues to render as the crosshair.
-    const symbolSize = AnalysisMode.MARKER_SYMBOL_SIZE * resolveSymbolScale(this.instance.state)
+    const symbolSize = AnalysisMode.MARKER_SYMBOL_SIZE * resolveSymbolScale(marker)
     const symbolMark = createSymbolMark(marker.symbol, currentX, currentY, symbolSize, marker.color)
 
     if (symbolMark) {

--- a/src/modes/analysis/AnalysisMode.js
+++ b/src/modes/analysis/AnalysisMode.js
@@ -4,7 +4,7 @@ import { formatTime } from '../../utils/timeFormatter.js'
 import { calculateZoomAwarePosition } from '../../utils/coordinateTransformations.js'
 import { BaseDragHandler } from '../shared/BaseDragHandler.js'
 import { getUniformTolerance, isWithinToleranceRadius } from '../../utils/tolerance.js'
-import { createSymbolMark, createColorIndicator } from '../../rendering/symbols.js'
+import { createSymbolMark, createColorIndicator, resolveSymbolScale } from '../../rendering/symbols.js'
 
 /**
  * Analysis mode implementation
@@ -12,8 +12,10 @@ import { createSymbolMark, createColorIndicator } from '../../rendering/symbols.
  */
 export class AnalysisMode extends BaseMode {
   /**
-   * Pixel size (width/height) of a marker's symbol mark when it carries a
+   * Base pixel size (width/height) of a marker's symbol mark when it carries a
    * shaped symbol (feature 161). Roughly matches the crosshair's visual weight.
+   * The drawn size is this scaled by the temporary "Large symbols" toggle, so a
+   * marker's symbol tracks the harmonic pins' symbols.
    * @type {number}
    */
   static MARKER_SYMBOL_SIZE = 14
@@ -263,7 +265,8 @@ export class AnalysisMode extends BaseMode {
     // A marker carrying a shaped symbol is drawn as that colour-coded symbol
     // (feature 161, FR-009); a marker with the `cross` (symbol-less) style
     // continues to render as the crosshair.
-    const symbolMark = createSymbolMark(marker.symbol, currentX, currentY, AnalysisMode.MARKER_SYMBOL_SIZE, marker.color)
+    const symbolSize = AnalysisMode.MARKER_SYMBOL_SIZE * resolveSymbolScale(this.instance.state)
+    const symbolMark = createSymbolMark(marker.symbol, currentX, currentY, symbolSize, marker.color)
 
     if (symbolMark) {
       // Use a marker-specific class so the harmonics renderer's symbol cleanup

--- a/src/modes/harmonics/HarmonicsMode.js
+++ b/src/modes/harmonics/HarmonicsMode.js
@@ -386,7 +386,10 @@ export class HarmonicsMode extends BaseMode {
       color,
       anchorTime,
       spacing,
-      symbol
+      symbol,
+      // EXPERIMENT (temporary): symbol size is carried per set, seeded from the
+      // toggle's next-feature default, so sets at both sizes can coexist.
+      largeSymbols: !!this.instance.state.largeSymbols
     }
     
     this.instance.state.harmonics.harmonicSets.push(harmonicSet)
@@ -794,13 +797,15 @@ export class HarmonicsMode extends BaseMode {
   }
 
   /**
-   * Effective pixel size of a pin's symbol mark, i.e. the base size scaled by the
-   * temporary "Large symbols" toggle. The whole label/symbol stack layout derives
-   * from this, so the label spacing and top-edge clamping follow the chosen size.
+   * Effective pixel size of a set's symbol marks: the base size scaled by that
+   * set's own "Large symbols" flag, so sets at both sizes can share a gram. The
+   * whole label/symbol stack layout derives from this, so the label spacing and
+   * top-edge clamping follow the set's chosen size.
+   * @param {HarmonicSet} harmonicSet - Harmonic set configuration
    * @returns {number} Symbol diameter in px
    */
-  symbolSize() {
-    return HarmonicsMode.SYMBOL_SIZE * resolveSymbolScale(this.instance.state)
+  symbolSize(harmonicSet) {
+    return HarmonicsMode.SYMBOL_SIZE * resolveSymbolScale(harmonicSet)
   }
 
   /**
@@ -818,7 +823,7 @@ export class HarmonicsMode extends BaseMode {
    */
   createHarmonicSymbol(harmonicSet, lineX, symbolCy) {
     const symbol = createSymbolMark(
-      harmonicSet.symbol, lineX, symbolCy, this.symbolSize(), harmonicSet.color
+      harmonicSet.symbol, lineX, symbolCy, this.symbolSize(harmonicSet), harmonicSet.color
     )
     // `cross` sets draw no symbol shape (the pin keeps its line and label).
     if (!symbol) {
@@ -839,10 +844,11 @@ export class HarmonicsMode extends BaseMode {
    *
    * @param {number} lineTop - Top Y position of the pin lines (SVG coords)
    * @param {number} imageTop - Top edge of the spectrogram image in SVG coords
+   * @param {HarmonicSet} harmonicSet - Harmonic set being laid out (its symbol size drives the stack)
    * @returns {{symbolCy: number, labelY: number}} Symbol centre and label baseline Y
    */
-  calculateLabelStackPositions(lineTop, imageTop) {
-    const r = this.symbolSize() / 2
+  calculateLabelStackPositions(lineTop, imageTop, harmonicSet) {
+    const r = this.symbolSize(harmonicSet) / 2
     const gap = HarmonicsMode.LABEL_GAP
     const fontSize = HarmonicsMode.LABEL_FONT_SIZE
 
@@ -906,7 +912,7 @@ export class HarmonicsMode extends BaseMode {
     // Draw labels + symbols only on the thinned major subset (FR-002), stacked
     // above each pin line with a shared, on-screen vertical layout.
     const labelledHarmonics = this.getLabelledHarmonics(minHarmonic, maxHarmonic)
-    const { symbolCy, labelY } = this.calculateLabelStackPositions(lineTop, imageTop)
+    const { symbolCy, labelY } = this.calculateLabelStackPositions(lineTop, imageTop, harmonicSet)
 
     labelledHarmonics.forEach(harmonicNumber => {
       const lineX = this.harmonicLineX(harmonicSet, harmonicNumber)

--- a/src/modes/harmonics/HarmonicsMode.js
+++ b/src/modes/harmonics/HarmonicsMode.js
@@ -7,7 +7,7 @@ import { calculateZoomAwarePosition, getImageBounds } from '../../utils/coordina
 import { BaseDragHandler } from '../shared/BaseDragHandler.js'
 import { getUniformTolerance } from '../../utils/tolerance.js'
 import { sampledHarmonics } from '../../utils/harmonicSampling.js'
-import { createSymbolMark } from '../../rendering/symbols.js'
+import { createSymbolMark, resolveSymbolScale } from '../../rendering/symbols.js'
 import { calculateVisibleDataRange } from '../../components/table.js'
 
 /**
@@ -127,7 +127,9 @@ export class HarmonicsMode extends BaseMode {
   static harmonicColors = ['#ff6b6b', '#2ecc71', '#f39c12', '#9b59b6', '#ffc93c', '#ff9ff3', '#45b7d1', '#e67e22']
 
   /**
-   * Pixel size (width/height) of a pin's symbol mark.
+   * Base pixel size (width/height) of a pin's symbol mark. The effective size is
+   * this scaled by the "Large symbols" experiment toggle — use
+   * {@link HarmonicsMode#symbolSize} rather than reading this directly.
    * @type {number}
    */
   static SYMBOL_SIZE = 10
@@ -775,6 +777,16 @@ export class HarmonicsMode extends BaseMode {
   }
 
   /**
+   * Effective pixel size of a pin's symbol mark, i.e. the base size scaled by the
+   * temporary "Large symbols" toggle. The whole label/symbol stack layout derives
+   * from this, so the label spacing and top-edge clamping follow the chosen size.
+   * @returns {number} Symbol diameter in px
+   */
+  symbolSize() {
+    return HarmonicsMode.SYMBOL_SIZE * resolveSymbolScale(this.instance.state)
+  }
+
+  /**
    * Create the filled symbol mark drawn between a pin's number label and the top
    * of its line.
    *
@@ -789,7 +801,7 @@ export class HarmonicsMode extends BaseMode {
    */
   createHarmonicSymbol(harmonicSet, lineX, symbolCy) {
     const symbol = createSymbolMark(
-      harmonicSet.symbol, lineX, symbolCy, HarmonicsMode.SYMBOL_SIZE, harmonicSet.color
+      harmonicSet.symbol, lineX, symbolCy, this.symbolSize(), harmonicSet.color
     )
     // `cross` sets draw no symbol shape (the pin keeps its line and label).
     if (!symbol) {
@@ -813,7 +825,7 @@ export class HarmonicsMode extends BaseMode {
    * @returns {{symbolCy: number, labelY: number}} Symbol centre and label baseline Y
    */
   calculateLabelStackPositions(lineTop, imageTop) {
-    const r = HarmonicsMode.SYMBOL_SIZE / 2
+    const r = this.symbolSize() / 2
     const gap = HarmonicsMode.LABEL_GAP
     const fontSize = HarmonicsMode.LABEL_FONT_SIZE
 

--- a/src/rendering/symbols.js
+++ b/src/rendering/symbols.js
@@ -57,16 +57,21 @@ export const SYMBOL_DISPLAY_NAMES = {
 export const LARGE_SYMBOL_SCALE = 2
 
 /**
- * Resolve the symbol size multiplier for an instance's current state.
+ * Resolve the symbol size multiplier carried by a feature.
+ *
+ * The flag is per-feature (a marker or a harmonic set), so sets drawn at both
+ * sizes can be compared side by side on the same gram. Passing the GramFrame
+ * state instead yields the default for the NEXT created feature, which is how
+ * the toggle behaves when nothing is selected.
  *
  * Applies to the overlay marks only (harmonic pins and analysis markers) — the
  * table swatches keep their fixed box size so row heights do not jump.
  *
- * @param {GramFrameState|null|undefined} state - GramFrame state
+ * @param {{largeSymbols?: boolean}|null|undefined} source - Feature (or state) carrying the flag
  * @returns {number} `LARGE_SYMBOL_SCALE` when large symbols are on, else 1
  */
-export function resolveSymbolScale(state) {
-  return state && state.largeSymbols ? LARGE_SYMBOL_SCALE : 1
+export function resolveSymbolScale(source) {
+  return source && source.largeSymbols ? LARGE_SYMBOL_SCALE : 1
 }
 
 /**

--- a/src/rendering/symbols.js
+++ b/src/rendering/symbols.js
@@ -47,6 +47,29 @@ export const SYMBOL_DISPLAY_NAMES = {
 }
 
 /**
+ * EXPERIMENT (temporary — feature-feedback trial): multiplier applied to the
+ * on-image symbol marks when the "Large symbols" toggle in the Symbol panel is
+ * on. It exists only so analysts can compare the two sizes and tell us which to
+ * keep; once a size is chosen, fold the winner into the base sizes and delete
+ * both this constant and the toggle.
+ * @type {number}
+ */
+export const LARGE_SYMBOL_SCALE = 2
+
+/**
+ * Resolve the symbol size multiplier for an instance's current state.
+ *
+ * Applies to the overlay marks only (harmonic pins and analysis markers) — the
+ * table swatches keep their fixed box size so row heights do not jump.
+ *
+ * @param {GramFrameState|null|undefined} state - GramFrame state
+ * @returns {number} `LARGE_SYMBOL_SCALE` when large symbols are on, else 1
+ */
+export function resolveSymbolScale(state) {
+  return state && state.largeSymbols ? LARGE_SYMBOL_SCALE : 1
+}
+
+/**
  * Build a `points` attribute string from an array of [x, y] pairs.
  * @param {Array<[number, number]>} pts - Point pairs
  * @returns {string} Space-separated "x,y" points

--- a/src/types.js
+++ b/src/types.js
@@ -183,6 +183,7 @@
  * @property {number} rate - Rate value affecting frequency calculations (Hz/s)
  * @property {string} selectedColor - Colour for the NEXT created feature (when nothing is selected); when a feature is selected the picker restyles it instead
  * @property {SymbolType} selectedSymbol - Symbol for the NEXT created harmonic set or marker (when nothing is selected); when a feature is selected the picker restyles it instead
+ * @property {boolean} largeSymbols - EXPERIMENT (temporary): draw overlay symbols at double size; in-memory only, never persisted
  * @property {CursorPosition|null} cursorPosition - Current cursor position data
  * @property {Array<CursorPosition>} cursors - Array of cursor positions (future use)
  * @property {HarmonicsState} harmonics - Harmonics mode state

--- a/src/types.js
+++ b/src/types.js
@@ -72,6 +72,7 @@
  * @property {number} time - Time coordinate
  * @property {number} freq - Frequency coordinate
  * @property {SymbolType} [symbol] - Marker symbol; `cross` (default) draws a crosshair, a shaped symbol draws that mark
+ * @property {boolean} [largeSymbols] - EXPERIMENT (temporary): draw this marker's symbol at the large size; not persisted
  */
 
 /**
@@ -106,6 +107,7 @@
  * @property {number} anchorTime - Time position (Y-axis) in seconds
  * @property {number} spacing - Frequency spacing between harmonics in Hz
  * @property {SymbolType} symbol - Filled shape drawn at the top of each pin and shown in the harmonics table
+ * @property {boolean} [largeSymbols] - EXPERIMENT (temporary): draw this set's pin symbols at the large size; not persisted
  */
 
 /**
@@ -183,7 +185,7 @@
  * @property {number} rate - Rate value affecting frequency calculations (Hz/s)
  * @property {string} selectedColor - Colour for the NEXT created feature (when nothing is selected); when a feature is selected the picker restyles it instead
  * @property {SymbolType} selectedSymbol - Symbol for the NEXT created harmonic set or marker (when nothing is selected); when a feature is selected the picker restyles it instead
- * @property {boolean} largeSymbols - EXPERIMENT (temporary): draw overlay symbols at double size; in-memory only, never persisted
+ * @property {boolean} largeSymbols - EXPERIMENT (temporary): large-symbol size for the NEXT created feature (when nothing is selected); in-memory only, never persisted
  * @property {CursorPosition|null} cursorPosition - Current cursor position data
  * @property {Array<CursorPosition>} cursors - Array of cursor positions (future use)
  * @property {HarmonicsState} harmonics - Harmonics mode state
@@ -357,7 +359,9 @@
  * @property {function(string): boolean} [applyColorToSelectedFeature] - Restyle the selected feature's colour in place (feature 161)
  * @property {function(SymbolType): boolean} [applySymbolToSelectedFeature] - Restyle the selected feature's symbol in place (feature 161)
  * @property {function(): void} [syncStyleControls] - Sync the colour/symbol controls to the current selection (feature 161)
+ * @property {function(boolean): boolean} [applyLargeSymbolsToSelectedFeature] - EXPERIMENT (temporary): resize the selected feature's symbols in place
  * @property {{setValue: function(SymbolType): void, setTint: function(string): void}|null} [_symbolControl] - Symbol drop-down control handle
+ * @property {{setValue: function(boolean): void}|null} [_largeSymbolsControl] - EXPERIMENT (temporary): "Large symbols" checkbox handle
  * @property {function(): void} [createUnifiedLayout] - Create unified layout
  */
 


### PR DESCRIPTION
A temporary trial control so we can decide what size the symbols should be, rather than guessing.

## What this adds

A **Large symbols** checkbox in the Symbol panel, under the colour slider. The size is a **per-feature** property, so both sizes can be on screen at once for a real side-by-side comparison.

The checkbox follows the same routing as the colour slider and symbol drop-down:
- with a marker or harmonic set **selected** → it resizes **that feature only**;
- with **nothing selected** → it sets the size for the **next created** feature.

Selecting a feature reflects its current size back into the checkbox, so the control always shows what it would change.

Sizes when on (`LARGE_SYMBOL_SCALE = 2`):
- harmonic pin symbols 10px → 20px — the label/symbol stack layout derives from the set's own symbol size, so pin numbers and top-edge clamping follow it per set;
- analysis marker symbols 14px → 28px.

Table swatches keep their fixed box size so row heights don't jump. The flag is in-memory only and is not persisted — a reload returns everything to the default size.

## Implementation

- `src/rendering/symbols.js` — `LARGE_SYMBOL_SCALE` and `resolveSymbolScale(source)`, which reads the flag off a feature (passing the state instead yields the next-feature default).
- `src/core/keyboardControl.js` — `applyLargeSymbolsToSelectedFeature()`; `getActiveStyle()` reports `largeSymbols` alongside colour/symbol.
- `src/modes/harmonics/HarmonicsMode.js` — `symbolSize(harmonicSet)` drives both the mark and `calculateLabelStackPositions()`.
- `src/modes/analysis/AnalysisMode.js` — marker symbols scaled from the marker's own flag.
- `src/components/SymbolPicker.js` / `ColorPicker.js` / `gramframe.css` — the toggle, its selection sync, and styling.
- New sets/markers seed their flag from the next-feature default.

Everything experimental is commented as temporary: once a size is agreed, fold the winner into `SYMBOL_SIZE` / `MARKER_SYMBOL_SIZE` and delete the toggle, the per-feature flag, and the scale helper.

## Testing

- `yarn typecheck` — clean.
- Full Playwright suite: 187 passed. The 6 failures are pre-existing in this container (a `state.version` metadata assertion) and fail identically on a clean tree.
- Manual check in `debug.html`: two harmonic sets shown simultaneously at both sizes (circles normal, diamonds large); the checkbox tracks selection in both directions.

`main` has been merged in (the conflict was the import line in `HarmonicsMode.js`, alongside #206's pixel-sized pins).