### PR TITLE
Add harmonic pin visibility toggle to the Symbol panel

### DIFF
--- a/src/components/ColorPicker.js
+++ b/src/components/ColorPicker.js
@@ -2,12 +2,14 @@
  * Combined colour + symbol picker for GramFrame
  *
  * Provides colour selection (gradient slider) and, alongside it, the symbol
- * drop-down for harmonic overlays, under a single "Symbol" panel.
+ * drop-down for harmonic overlays, plus a harmonic-pin visibility toggle, under
+ * a single "Symbol" panel.
  */
 
 /// <reference path="../types.js" />
 
 import { createSymbolSelect } from './SymbolPicker.js'
+import { createPinToggle } from './PinToggle.js'
 import { getActiveStyle } from '../core/keyboardControl.js'
 
 /**
@@ -93,6 +95,9 @@ export function createColorPicker(instance) {
   const symbolSelect = createSymbolSelect(instance)
   paletteContainer.appendChild(symbolSelect)
 
+  // Harmonic-pin visibility toggle, below the colour/symbol row.
+  container.appendChild(createPinToggle(instance))
+
   // Add click handler for color selection
   canvas.addEventListener('click', (event) => {
     const rect = canvas.getBoundingClientRect()
@@ -132,11 +137,16 @@ export function createColorPicker(instance) {
   // currently selected, or to the next-feature defaults when nothing is
   // selected (feature 161, FR-004/FR-013).
   instance.syncStyleControls = () => {
-    const { color, symbol } = getActiveStyle(instance)
+    const { color, symbol, showPin, pinApplies } = getActiveStyle(instance)
     showColor(color)
     if (instance._symbolControl) {
       instance._symbolControl.setValue(symbol)
       instance._symbolControl.setTint(color)
+    }
+    if (instance._pinControl) {
+      instance._pinControl.setValue(showPin)
+      // Markers have no pin, so the toggle is disabled while one is selected.
+      instance._pinControl.setEnabled(pinApplies)
     }
   }
 

--- a/src/components/PinToggle.js
+++ b/src/components/PinToggle.js
@@ -1,0 +1,76 @@
+/**
+ * Harmonic-pin visibility toggle for GramFrame overlays.
+ *
+ * A checkbox in the combined "Symbol" panel (see ColorPicker.js) that controls
+ * whether a harmonic set draws its vertical pin lines. With the pin off, a set
+ * renders as its symbols and numbers alone — the style experienced analysts use
+ * to stack many harmonic sets over dense data without the lines swamping it.
+ *
+ * When a harmonic set is selected, toggling restyles that set in place;
+ * otherwise the choice is written to `state.showHarmonicPin` and applied to the
+ * next created set. The preference is on at the start of each browser session
+ * and remembered (sessionStorage) for the rest of it.
+ *
+ * The toggle has no meaning for analysis markers (they have no pin), so it is
+ * disabled while a marker is selected.
+ */
+
+/// <reference path="../types.js" />
+
+import { savePinPreference } from '../core/storage.js'
+
+/**
+ * Create the harmonic-pin toggle row.
+ * @param {GramFrame} instance - GramFrame instance
+ * @returns {HTMLLabelElement} The toggle row element
+ */
+export function createPinToggle(instance) {
+  const state = instance.state
+
+  const row = document.createElement('label')
+  row.className = 'gram-frame-pin-toggle'
+  row.title = 'Show the vertical pin lines of harmonic sets'
+
+  const checkbox = document.createElement('input')
+  checkbox.type = 'checkbox'
+  checkbox.className = 'gram-frame-pin-toggle-input'
+  checkbox.checked = state.showHarmonicPin !== false
+  checkbox.setAttribute('aria-label', 'Show harmonic pin')
+
+  const text = document.createElement('span')
+  text.className = 'gram-frame-pin-toggle-label'
+  text.textContent = 'Pin'
+
+  row.appendChild(checkbox)
+  row.appendChild(text)
+
+  checkbox.addEventListener('change', () => {
+    const showPin = checkbox.checked
+    // Route to the selected harmonic set when one is selected (restyle in
+    // place), otherwise set the style for the next created set and remember it
+    // for the rest of the session.
+    if (!instance.applyPinToSelectedFeature || !instance.applyPinToSelectedFeature(showPin)) {
+      state.showHarmonicPin = showPin
+      savePinPreference(showPin)
+    }
+  })
+
+  // Expose a control handle so selection changes can reflect the selected
+  // set's pin state back into the checkbox.
+  instance._pinControl = {
+    /** @param {boolean} showPin */
+    setValue(showPin) {
+      checkbox.checked = showPin
+    },
+    /** @param {boolean} enabled */
+    setEnabled(enabled) {
+      checkbox.disabled = !enabled
+      row.classList.toggle('gram-frame-pin-toggle-disabled', !enabled)
+      row.title = enabled
+        ? 'Show the vertical pin lines of harmonic sets'
+        : 'Pins apply to harmonic sets only'
+    }
+  }
+
+  return row
+}

--- a/src/core/initialization/EventBindings.js
+++ b/src/core/initialization/EventBindings.js
@@ -9,7 +9,7 @@
 /// <reference path="../../types.js" />
 
 import { setupEventListeners, setupResizeObserver } from '../events.js'
-import { initializeKeyboardControl, setSelection, clearSelection, updateSelectionVisuals, removeHarmonicSet, applyColorToSelectedFeature, applySymbolToSelectedFeature } from '../keyboardControl.js'
+import { initializeKeyboardControl, setSelection, clearSelection, updateSelectionVisuals, removeHarmonicSet, applyColorToSelectedFeature, applySymbolToSelectedFeature, applyPinToSelectedFeature } from '../keyboardControl.js'
 import { getGlobalStateListeners } from '../state.js'
 
 /**
@@ -33,6 +33,7 @@ export function setupAllEventListeners(instance) {
   instance.removeHarmonicSet = (id) => removeHarmonicSet(instance, id)
   instance.applyColorToSelectedFeature = (color) => applyColorToSelectedFeature(instance, color)
   instance.applySymbolToSelectedFeature = (symbol) => applySymbolToSelectedFeature(instance, symbol)
+  instance.applyPinToSelectedFeature = (showPin) => applyPinToSelectedFeature(instance, showPin)
 }
 
 /**

--- a/src/core/keyboardControl.js
+++ b/src/core/keyboardControl.js
@@ -428,22 +428,34 @@ export function getSelectedFeature(instance) {
 }
 
 /**
- * Get the colour/symbol the style controls should currently show: the selected
- * feature's when one is selected, otherwise the next-feature defaults.
+ * Get the colour/symbol/pin state the style controls should currently show: the
+ * selected feature's when one is selected, otherwise the next-feature defaults.
+ *
+ * `showPin` only means anything for harmonic sets (markers have no pin), so
+ * `pinApplies` tells the panel whether to offer the pin toggle at all: false
+ * while a marker is selected, true otherwise.
  * @param {GramFrame} instance - GramFrame instance
- * @returns {{color: string, symbol: SymbolType}} Active style
+ * @returns {{color: string, symbol: SymbolType, showPin: boolean, pinApplies: boolean}} Active style
  */
 export function getActiveStyle(instance) {
   const selected = getSelectedFeature(instance)
   if (selected) {
+    const isHarmonicSet = selected.type === 'harmonicSet'
     return {
       color: selected.feature.color,
-      symbol: /** @type {SymbolType} */ (selected.feature.symbol || DEFAULT_SYMBOL)
+      symbol: /** @type {SymbolType} */ (selected.feature.symbol || DEFAULT_SYMBOL),
+      // A harmonic set without an explicit `showPin` (legacy/restored) is pinned.
+      showPin: isHarmonicSet
+        ? /** @type {HarmonicSet} */ (selected.feature).showPin !== false
+        : instance.state.showHarmonicPin !== false,
+      pinApplies: isHarmonicSet
     }
   }
   return {
     color: instance.state.selectedColor,
-    symbol: instance.state.selectedSymbol
+    symbol: instance.state.selectedSymbol,
+    showPin: instance.state.showHarmonicPin !== false,
+    pinApplies: true
   }
 }
 
@@ -500,6 +512,25 @@ export function applySymbolToSelectedFeature(instance, symbol) {
     return false
   }
   selected.feature.symbol = symbol
+  refreshFeatureVisuals(instance, selected.type)
+  return true
+}
+
+/**
+ * Show or hide the vertical pin lines of the currently selected harmonic set,
+ * updating the overlay and table instantly. No-op (returns false) when nothing
+ * is selected or when the selection is a marker, which has no pin — the caller
+ * then treats the change as setting the session default instead.
+ * @param {GramFrame} instance - GramFrame instance
+ * @param {boolean} showPin - Whether the set should draw its pin lines
+ * @returns {boolean} True if a harmonic set was restyled
+ */
+export function applyPinToSelectedFeature(instance, showPin) {
+  const selected = getSelectedFeature(instance)
+  if (!selected || selected.type !== 'harmonicSet') {
+    return false
+  }
+  /** @type {HarmonicSet} */ (selected.feature).showPin = !!showPin
   refreshFeatureVisuals(instance, selected.type)
   return true
 }

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -43,6 +43,10 @@ export const initialState = {
   rate: 1,
   selectedColor: '#ff6b6b', // Currently selected color for new features across all modes
   selectedSymbol: 'cross', // Currently selected symbol; 'cross' (default) means no drawn symbol shape (feature 161)
+  // Whether the NEXT created harmonic set draws its vertical pin lines. Shown
+  // as a toggle in the Symbol panel; on by default at the start of a browser
+  // session and remembered (sessionStorage) for the rest of it.
+  showHarmonicPin: true,
   cursorPosition: null,
   cursors: [],
   imageDetails: {

--- a/src/core/storage.js
+++ b/src/core/storage.js
@@ -47,6 +47,18 @@ export const STUDENT_TTL_MS = 24 * 60 * 60 * 1000
 const KEY_PREFIX = 'gramframe::'
 
 /**
+ * Storage key for the harmonic-pin visibility preference.
+ *
+ * Deliberately NOT page-scoped: the preference follows the analyst across the
+ * topics of a training package. It is also deliberately kept in sessionStorage
+ * for BOTH contexts (trainer and student) — unlike annotations — so it starts
+ * every browser session at its default (pins shown) while staying put for the
+ * rest of that session.
+ * @type {string}
+ */
+const PIN_PREF_KEY = `${KEY_PREFIX}pref::harmonicPin`
+
+/**
  * CSS selector matching the explicit trainer-persistence flag. Accepts the
  * id, class, or data-attribute form. Exported for unit testing.
  * @type {string}
@@ -141,6 +153,40 @@ export function buildStorageKey(instanceIndex) {
 }
 
 /**
+ * Read the harmonic-pin visibility preference for this browser session.
+ *
+ * Defaults to `true` (pins shown) whenever nothing has been stored yet, storage
+ * is unavailable, or the stored value is not one of the two recognised strings —
+ * so a fresh session always starts with pins visible.
+ * @returns {boolean} True when new/edited harmonic sets should show their pin
+ */
+export function loadPinPreference() {
+  try {
+    const raw = sessionStorage.getItem(PIN_PREF_KEY)
+    if (raw === 'false') return false
+    return true
+  } catch {
+    return true
+  }
+}
+
+/**
+ * Store the harmonic-pin visibility preference for the rest of this browser
+ * session. Failures (private mode, quota) are swallowed — the in-memory state
+ * still holds for the current page.
+ * @param {boolean} showPin - Whether pins should be shown
+ * @returns {boolean} True if the preference was written
+ */
+export function savePinPreference(showPin) {
+  try {
+    sessionStorage.setItem(PIN_PREF_KEY, showPin ? 'true' : 'false')
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
  * Extract annotation data from GramFrame state and save to storage.
  * Only writes when there is at least one annotation present.
  * @param {GramFrameState} state - Current component state
@@ -191,7 +237,11 @@ export function saveAnnotations(state, instanceIndex) {
           // loadAnnotations would otherwise discard all pre-existing v1 records.
           // Legacy records simply lack this key and default to 'cross' (the
           // symbol-less default, feature 161) on restore.
-          symbol: hs.symbol || 'cross'
+          symbol: hs.symbol || 'cross',
+          // `showPin` is likewise ADDITIVE (harmonic-pin toggle) and MUST NOT
+          // bump SCHEMA_VERSION. Records written before it simply lack the key
+          // and restore as `true` (pin shown), matching their original look.
+          showPin: hs.showPin !== false
         }))
       },
       doppler: {

--- a/src/gramframe.css
+++ b/src/gramframe.css
@@ -348,6 +348,39 @@
   cursor: pointer;
 }
 
+/* Harmonic-pin visibility toggle, below the colour slider / symbol row. */
+.gram-frame-pin-toggle {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 6px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.gram-frame-pin-toggle-input {
+  margin: 0;
+  cursor: pointer;
+  accent-color: #00ff00;
+}
+
+.gram-frame-pin-toggle-label {
+  font-size: 10px;
+  color: #00ff00;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-weight: bold;
+}
+
+.gram-frame-pin-toggle-disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.gram-frame-pin-toggle-disabled .gram-frame-pin-toggle-input {
+  cursor: default;
+}
+
 .gram-frame-color-canvas {
   width: 140px;
   max-width: 140px;

--- a/src/main.js
+++ b/src/main.js
@@ -52,7 +52,8 @@ import {
   saveAnnotations,
   loadAnnotations,
   clearAnnotations,
-  detectUserContext
+  detectUserContext,
+  loadPinPreference
 } from './core/storage.js'
 
 import {
@@ -127,10 +128,14 @@ export class GramFrame {
   // Reformatting (feature 161): restyle the selected feature in place
   applyColorToSelectedFeature;
   applySymbolToSelectedFeature;
-  // Sync the colour/symbol controls to the current selection
+  // Show/hide the selected harmonic set's pin lines
+  applyPinToSelectedFeature;
+  // Sync the colour/symbol/pin controls to the current selection
   syncStyleControls;
   // Symbol drop-down control handle (registered by the symbol picker)
   _symbolControl;
+  // Pin toggle control handle (registered by the pin toggle)
+  _pinControl;
   
   // ResizeObserver
   resizeObserver;
@@ -177,6 +182,10 @@ export class GramFrame {
 
     // Core state initialization
     this.state = createInitialState()
+    // Harmonic-pin visibility is a per-session preference: on at the start of
+    // each browser session, then remembered across page loads within it. Read
+    // before any UI is built so the toggle renders in the right position.
+    this.state.showHarmonicPin = loadPinPreference()
     this.stateListeners = []
     this.instanceId = ''
 
@@ -377,7 +386,10 @@ export class GramFrame {
     if (saved.harmonics && Array.isArray(saved.harmonics.harmonicSets)) {
       this.state.harmonics.harmonicSets = saved.harmonics.harmonicSets.map(hs => ({
         ...hs,
-        symbol: hs.symbol || 'cross'
+        symbol: hs.symbol || 'cross',
+        // Records saved before the pin toggle have no `showPin`; those sets were
+        // drawn with pins, so they restore as pinned.
+        showPin: hs.showPin !== false
       }))
     }
 

--- a/src/modes/harmonics/HarmonicsMode.js
+++ b/src/modes/harmonics/HarmonicsMode.js
@@ -366,13 +366,18 @@ export class HarmonicsMode extends BaseMode {
     // Use selected symbol from global state, defaulting to the symbol-less cross
     const symbol = this.instance.state.selectedSymbol || 'cross'
 
+    // Use the session's pin-visibility preference (on unless the analyst turned
+    // it off via the Symbol panel toggle)
+    const showPin = this.instance.state.showHarmonicPin !== false
+
     /** @type {HarmonicSet} */
     const harmonicSet = {
       id,
       color,
       anchorTime,
       spacing,
-      symbol
+      symbol,
+      showPin
     }
     
     this.instance.state.harmonics.harmonicSets.push(harmonicSet)
@@ -852,6 +857,12 @@ export class HarmonicsMode extends BaseMode {
    * symbol only for the thinned "major" subset so the overlay stays readable.
    * Lines are appended first so the labels/symbols paint on top of them.
    *
+   * A set with `showPin === false` skips the lines entirely and renders as its
+   * symbols and numbers alone — the low-clutter style for stacking many sets over
+   * dense data. The label/symbol geometry is unchanged, so toggling the pin adds
+   * or removes the lines without moving anything else, and the set stays
+   * draggable over the same region.
+   *
    * @param {HarmonicSet} harmonicSet - Harmonic set to render
    */
   renderHarmonicSet(harmonicSet) {
@@ -867,11 +878,14 @@ export class HarmonicsMode extends BaseMode {
     const { lineHeight, lineTop } = this.calculateHarmonicLineDimensions(harmonicSet)
     const imageTop = getImageBounds(this.getViewport(), this.instance.spectrogramImage).top
 
-    // Draw every pin line in the visible span (FR-001).
-    for (let harmonicNumber = minHarmonic; harmonicNumber <= maxHarmonic; harmonicNumber++) {
-      const lineX = this.harmonicLineX(harmonicSet, harmonicNumber)
-      const line = this.createHarmonicLine(harmonicNumber, harmonicSet, lineX, lineTop, lineHeight)
-      this.instance.cursorGroup.appendChild(line)
+    // Draw every pin line in the visible span (FR-001) — unless this set is set
+    // to hide its pin. Sets restored from storage without the flag are pinned.
+    if (harmonicSet.showPin !== false) {
+      for (let harmonicNumber = minHarmonic; harmonicNumber <= maxHarmonic; harmonicNumber++) {
+        const lineX = this.harmonicLineX(harmonicSet, harmonicNumber)
+        const line = this.createHarmonicLine(harmonicNumber, harmonicSet, lineX, lineTop, lineHeight)
+        this.instance.cursorGroup.appendChild(line)
+      }
     }
 
     // Draw labels + symbols only on the thinned major subset (FR-002), stacked

--- a/src/types.js
+++ b/src/types.js
@@ -106,6 +106,7 @@
  * @property {number} anchorTime - Time position (Y-axis) in seconds
  * @property {number} spacing - Frequency spacing between harmonics in Hz
  * @property {SymbolType} symbol - Filled shape drawn at the top of each pin and shown in the harmonics table
+ * @property {boolean} [showPin] - Whether the vertical pin lines are drawn; absent (legacy/restored) means shown
  */
 
 /**
@@ -183,6 +184,7 @@
  * @property {number} rate - Rate value affecting frequency calculations (Hz/s)
  * @property {string} selectedColor - Colour for the NEXT created feature (when nothing is selected); when a feature is selected the picker restyles it instead
  * @property {SymbolType} selectedSymbol - Symbol for the NEXT created harmonic set or marker (when nothing is selected); when a feature is selected the picker restyles it instead
+ * @property {boolean} showHarmonicPin - Pin visibility for the NEXT created harmonic set; session preference, on by default
  * @property {CursorPosition|null} cursorPosition - Current cursor position data
  * @property {Array<CursorPosition>} cursors - Array of cursor positions (future use)
  * @property {HarmonicsState} harmonics - Harmonics mode state
@@ -259,6 +261,7 @@
  * @property {number} anchorTime - Y-axis position in seconds
  * @property {number} spacing - Frequency spacing between harmonics in Hz
  * @property {SymbolType} [symbol] - Persisted symbol; ABSENT in legacy (pre-feature) records
+ * @property {boolean} [showPin] - Persisted pin visibility; ABSENT in records saved before the pin toggle (restores as shown)
  */
 
 /**
@@ -355,8 +358,10 @@
  * @property {function(string): void} [removeHarmonicSet] - Remove harmonic set by ID
  * @property {function(string): boolean} [applyColorToSelectedFeature] - Restyle the selected feature's colour in place (feature 161)
  * @property {function(SymbolType): boolean} [applySymbolToSelectedFeature] - Restyle the selected feature's symbol in place (feature 161)
- * @property {function(): void} [syncStyleControls] - Sync the colour/symbol controls to the current selection (feature 161)
+ * @property {function(boolean): boolean} [applyPinToSelectedFeature] - Show/hide the selected harmonic set's pin lines in place
+ * @property {function(): void} [syncStyleControls] - Sync the colour/symbol/pin controls to the current selection (feature 161)
  * @property {{setValue: function(SymbolType): void, setTint: function(string): void}|null} [_symbolControl] - Symbol drop-down control handle
+ * @property {{setValue: function(boolean): void, setEnabled: function(boolean): void}|null} [_pinControl] - Pin toggle control handle
  * @property {function(): void} [createUnifiedLayout] - Create unified layout
  */
 

--- a/tests/harmonic-pin-toggle.spec.js
+++ b/tests/harmonic-pin-toggle.spec.js
@@ -1,0 +1,271 @@
+import { test, expect } from './helpers/fixtures.js'
+import { GramFramePage } from './helpers/gram-frame-page.js'
+
+/**
+ * @fileoverview E2E tests for the harmonic-pin visibility toggle in the Symbol
+ * panel. Covers the default-on session preference, pin-less creation, editing an
+ * existing set in place, persistence within the browser session, and the
+ * restore of harmonic sets saved before the toggle existed.
+ */
+
+/**
+ * Read the app state from a trainer/student fixture page (which exposes the
+ * test-only instance registry rather than the debug #state-display element).
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<any>}
+ */
+async function getStateFromPage(page) {
+  return page.evaluate(() => {
+    // @ts-ignore - test-only global
+    const instances = window.GramFrame && window.GramFrame.__test__getInstances()
+    if (instances && instances.length > 0) {
+      return JSON.parse(JSON.stringify(instances[0].state))
+    }
+    return null
+  })
+}
+
+// ──────────────────────────────────────────────────────────────
+// User Story 1 — Create harmonic sets without the vertical pin
+// ──────────────────────────────────────────────────────────────
+
+test.describe('US1: Pin toggle governs newly created harmonic sets', () => {
+  test.beforeEach(async ({ gramFramePage }) => {
+    await gramFramePage.page.waitForTimeout(100)
+    await gramFramePage.clickMode('Harmonics')
+  })
+
+  test('the toggle is present and on at the start of a session', async ({ gramFramePage }) => {
+    const toggle = gramFramePage.page.locator('.gram-frame-pin-toggle-input')
+    await expect(toggle).toBeVisible()
+
+    const { checked, disabled } = await gramFramePage.getPinToggleState()
+    expect(checked).toBe(true)
+    expect(disabled).toBe(false)
+
+    const state = await gramFramePage.getState()
+    expect(state.showHarmonicPin).toBe(true)
+  })
+
+  test('with the toggle on, a new set draws its pin lines', async ({ gramFramePage }) => {
+    const setId = await gramFramePage.addHarmonicSet(5, 100)
+    await gramFramePage.page.waitForTimeout(200)
+
+    const state = await gramFramePage.getState()
+    const set = state.harmonics.harmonicSets.find((s) => s.id === setId)
+    expect(set.showPin).toBe(true)
+    expect(await gramFramePage.getHarmonicLineCount(setId)).toBeGreaterThan(0)
+  })
+
+  test('with the toggle off, a new set renders symbols and numbers but no pin lines', async ({ gramFramePage }) => {
+    await gramFramePage.selectSymbol('square')
+    await gramFramePage.setPinToggle(false)
+
+    const setId = await gramFramePage.addHarmonicSet(5, 100)
+    await gramFramePage.page.waitForTimeout(200)
+
+    const state = await gramFramePage.getState()
+    expect(state.showHarmonicPin).toBe(false)
+    const set = state.harmonics.harmonicSets.find((s) => s.id === setId)
+    expect(set.showPin).toBe(false)
+
+    // No pin lines, but the symbols and number labels are still drawn
+    expect(await gramFramePage.getHarmonicLineCount(setId)).toBe(0)
+    const symbols = await gramFramePage.getPinSymbols(setId)
+    expect(symbols.length).toBeGreaterThan(0)
+    for (const s of symbols) {
+      expect(s.symbol).toBe('square')
+    }
+    const labels = await gramFramePage.getHarmonicLabelNumbers(setId)
+    expect(labels.length).toBeGreaterThan(0)
+  })
+
+  test('the toggle applies per set, so pinned and pin-less sets coexist', async ({ gramFramePage }) => {
+    // First set with the pin on
+    const pinnedId = await gramFramePage.addHarmonicSet(5, 100)
+    // Deselect the newly created set so the toggle targets the session default
+    await gramFramePage.page.evaluate(() => {
+      // @ts-ignore - test-only global
+      window.GramFrame.__test__getInstances()[0].clearSelection()
+    })
+    await gramFramePage.setPinToggle(false)
+    const pinlessId = await gramFramePage.addHarmonicSet(5, 150)
+    await gramFramePage.page.waitForTimeout(200)
+
+    expect(await gramFramePage.getHarmonicLineCount(pinnedId)).toBeGreaterThan(0)
+    expect(await gramFramePage.getHarmonicLineCount(pinlessId)).toBe(0)
+  })
+})
+
+// ──────────────────────────────────────────────────────────────
+// User Story 2 — Edit an existing harmonic set's pin
+// ──────────────────────────────────────────────────────────────
+
+test.describe('US2: Toggling restyles the selected harmonic set in place', () => {
+  test.beforeEach(async ({ gramFramePage }) => {
+    await gramFramePage.page.waitForTimeout(100)
+    await gramFramePage.clickMode('Harmonics')
+  })
+
+  test('turning the pin off and on again updates the selected set only', async ({ gramFramePage }) => {
+    const setId = await gramFramePage.addHarmonicSet(5, 100)
+    await gramFramePage.page.waitForTimeout(200)
+    const pinnedCount = await gramFramePage.getHarmonicLineCount(setId)
+    expect(pinnedCount).toBeGreaterThan(0)
+
+    // The set is auto-selected on creation, so the toggle targets it
+    await gramFramePage.setPinToggle(false)
+    await gramFramePage.page.waitForTimeout(150)
+
+    let state = await gramFramePage.getState()
+    expect(state.harmonics.harmonicSets.find((s) => s.id === setId).showPin).toBe(false)
+    expect(await gramFramePage.getHarmonicLineCount(setId)).toBe(0)
+    // Restyling a selected set must not change the session default
+    expect(state.showHarmonicPin).toBe(true)
+
+    // Turn it back on
+    await gramFramePage.setPinToggle(true)
+    await gramFramePage.page.waitForTimeout(150)
+
+    state = await gramFramePage.getState()
+    expect(state.harmonics.harmonicSets.find((s) => s.id === setId).showPin).toBe(true)
+    expect(await gramFramePage.getHarmonicLineCount(setId)).toBe(pinnedCount)
+  })
+
+  test('selecting a set reflects its pin state back into the toggle', async ({ gramFramePage }) => {
+    // A pin-less set, then a pinned one
+    await gramFramePage.setPinToggle(false)
+    const pinlessId = await gramFramePage.addHarmonicSet(5, 100)
+    await gramFramePage.page.evaluate(() => {
+      // @ts-ignore - test-only global
+      window.GramFrame.__test__getInstances()[0].clearSelection()
+    })
+    await gramFramePage.setPinToggle(true)
+    const pinnedId = await gramFramePage.addHarmonicSet(5, 150)
+    await gramFramePage.page.waitForTimeout(200)
+
+    // The pinned set is selected (created last)
+    expect((await gramFramePage.getPinToggleState()).checked).toBe(true)
+
+    // Select the pin-less set via its table row
+    await gramFramePage.page.locator(`tr[data-harmonic-id="${pinlessId}"]`).click()
+    await gramFramePage.page.waitForTimeout(150)
+    expect((await gramFramePage.getPinToggleState()).checked).toBe(false)
+
+    // Back to the pinned set
+    await gramFramePage.page.locator(`tr[data-harmonic-id="${pinnedId}"]`).click()
+    await gramFramePage.page.waitForTimeout(150)
+    expect((await gramFramePage.getPinToggleState()).checked).toBe(true)
+  })
+
+  test('the toggle is disabled while an analysis marker is selected', async ({ gramFramePage }) => {
+    await gramFramePage.clickMode('Cross Cursor')
+    await gramFramePage.svg.scrollIntoViewIfNeeded()
+    const svgBox = await gramFramePage.svg.boundingBox()
+    if (!svgBox) throw new Error('SVG not found')
+    await gramFramePage.page.mouse.click(svgBox.x + 200, svgBox.y + 150)
+    await gramFramePage.page.waitForTimeout(200)
+
+    const state = await gramFramePage.getState()
+    expect(state.analysis.markers.length).toBeGreaterThan(0)
+    expect((await gramFramePage.getPinToggleState()).disabled).toBe(true)
+  })
+})
+
+// ──────────────────────────────────────────────────────────────
+// User Story 3 — The preference lasts for the browser session
+// ──────────────────────────────────────────────────────────────
+
+test.describe('US3: Pin preference persists within the session', () => {
+  test('the choice survives a reload and applies to sets created afterwards', async ({ gramFramePage }) => {
+    await gramFramePage.clickMode('Harmonics')
+    await gramFramePage.setPinToggle(false)
+    await gramFramePage.page.waitForTimeout(100)
+
+    await gramFramePage.page.reload()
+    await gramFramePage.waitForComponentLoad()
+    await gramFramePage.page.waitForTimeout(300)
+
+    // The toggle comes back off, and so does the state it drives
+    expect((await gramFramePage.getPinToggleState()).checked).toBe(false)
+    const state = await gramFramePage.getState()
+    expect(state.showHarmonicPin).toBe(false)
+
+    await gramFramePage.clickMode('Harmonics')
+    const setId = await gramFramePage.addHarmonicSet(5, 100)
+    await gramFramePage.page.waitForTimeout(200)
+    expect(await gramFramePage.getHarmonicLineCount(setId)).toBe(0)
+  })
+
+  test('a set keeps its own pin state across a save/reload round-trip', async ({ page }) => {
+    const gfp = new GramFramePage(page)
+    await page.goto('/tests/fixtures/trainer-page.html')
+    await page.evaluate(() => localStorage.clear())
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+    await page.waitForTimeout(300)
+
+    await page.locator('.gram-frame-mode-btn:text("Harmonics")').click()
+    await page.locator('.gram-frame-symbol-select').selectOption('star')
+    await page.locator('.gram-frame-pin-toggle-input').uncheck()
+    const setId = await gfp.addHarmonicSet(5, 100)
+    await page.waitForTimeout(300)
+
+    await page.reload()
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+    await page.waitForTimeout(500)
+
+    const after = await getStateFromPage(page)
+    const set = after.harmonics.harmonicSets.find((s) => s.id === setId)
+    expect(set).toBeTruthy()
+    expect(set.showPin).toBe(false)
+    expect(await gfp.getHarmonicLineCount(setId)).toBe(0)
+    const symbols = await gfp.getPinSymbols(setId)
+    expect(symbols.length).toBeGreaterThan(0)
+  })
+})
+
+// ──────────────────────────────────────────────────────────────
+// User Story 4 — Harmonic sets saved before the toggle keep their pins
+// ──────────────────────────────────────────────────────────────
+
+test.describe('US4: Legacy harmonic sets restore with pins shown', () => {
+  test('a stored set without showPin loads as pinned, with no console error', async ({ page }) => {
+    /** @type {string[]} */
+    const consoleErrors = []
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text())
+    })
+
+    await page.goto('/tests/fixtures/trainer-page.html')
+    await page.evaluate(() => localStorage.clear())
+
+    // Seed a record whose harmonic set predates the pin toggle
+    await page.evaluate(() => {
+      const key = 'gramframe::' + window.location.pathname
+      localStorage.setItem(key, JSON.stringify({
+        version: 1,
+        savedAt: new Date().toISOString(),
+        analysis: { markers: [] },
+        harmonics: {
+          harmonicSets: [
+            { id: 'legacy-pin-1', color: '#00ff00', anchorTime: 5, spacing: 100, symbol: 'circle' }
+          ]
+        },
+        doppler: { fPlus: null, fMinus: null, fZero: null, color: null }
+      }))
+    })
+
+    await page.reload()
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+    await page.waitForTimeout(500)
+
+    const gfp = new GramFramePage(page)
+    const state = await getStateFromPage(page)
+    const legacySet = state.harmonics.harmonicSets.find((s) => s.id === 'legacy-pin-1')
+    expect(legacySet).toBeTruthy()
+    expect(legacySet.showPin).toBe(true)
+    expect(await gfp.getHarmonicLineCount('legacy-pin-1')).toBeGreaterThan(0)
+
+    expect(consoleErrors).toEqual([])
+  })
+})

--- a/tests/helpers/gram-frame-page.js
+++ b/tests/helpers/gram-frame-page.js
@@ -608,6 +608,34 @@ class GramFramePage {
   }
 
   /**
+   * Set the harmonic-pin toggle in the Symbol panel.
+   * @param {boolean} checked - Desired checkbox state
+   * @returns {Promise<void>}
+   */
+  async setPinToggle(checked) {
+    const toggle = this.page.locator('.gram-frame-pin-toggle-input')
+    if (checked) {
+      await toggle.check()
+    } else {
+      await toggle.uncheck()
+    }
+  }
+
+  /**
+   * Read the harmonic-pin toggle's current state.
+   * @returns {Promise<{checked: boolean, disabled: boolean}>}
+   */
+  async getPinToggleState() {
+    return this.page.evaluate(() => {
+      const el = /** @type {HTMLInputElement|null} */ (
+        document.querySelector('.gram-frame-pin-toggle-input')
+      )
+      if (!el) return { checked: false, disabled: false }
+      return { checked: el.checked, disabled: el.disabled }
+    })
+  }
+
+  /**
    * Read the pin symbol marks rendered on the spectrogram overlay.
    * @param {string} [harmonicSetId] - Optional filter to a single set's marks
    * @returns {Promise<Array<{symbol: string, fill: string, tag: string}>>}


### PR DESCRIPTION
Adds a **Pin** toggle to the Symbol styling panel so a harmonic set can be drawn as its symbols and numbers alone, without the vertical pin lines — the low-clutter style for stacking many sets over dense data.

### Behaviour

- **New sets**: each harmonic set carries a `showPin` flag taken from the toggle at creation (click/drag and `+ Manual` alike). With the pin off, the set renders its symbols and number labels but no lines.
- **Editing an existing set**: with a harmonic set selected, toggling restyles that set in place — the same routing the colour slider and symbol drop-down already use. Selecting a set reflects its pin state back into the checkbox. Markers have no pin, so the toggle is disabled while one is selected.
- **Session preference**: on by default at the start of each browser session, then remembered for the rest of it. Stored in `sessionStorage` for both trainer and student contexts (deliberately *not* `localStorage`, so it never carries over into a new session), and not page-scoped, so it follows the analyst across topics.
- **Geometry unchanged**: the label/symbol stack keeps its position, so toggling only adds or removes the lines, nothing moves, and the set stays draggable over the same region.

### Persistence

`showPin` is an additive persisted field on harmonic sets, like `symbol` before it — **no `SCHEMA_VERSION` bump**. Records written before this change lack the key and restore as pinned, matching their original appearance.

### Changes

- `src/components/PinToggle.js` (new) — the toggle control and its selection-aware change handler
- `src/components/ColorPicker.js` — mounts the toggle in the Symbol panel; `syncStyleControls` now syncs pin state and enablement
- `src/core/keyboardControl.js` — `applyPinToSelectedFeature()`; `getActiveStyle()` returns `showPin` / `pinApplies`
- `src/core/storage.js` — `loadPinPreference()` / `savePinPreference()`; persists `showPin` per set
- `src/core/state.js`, `src/main.js` — `showHarmonicPin` state, loaded from the session preference; restores `showPin` on load
- `src/modes/harmonics/HarmonicsMode.js` — sets `showPin` on creation; skips pin lines when off
- `src/gramframe.css`, `src/types.js` — styling and JSDoc types

### Testing

- `tests/harmonic-pin-toggle.spec.js` — 10 new E2E tests covering the default-on state, pin-less creation, pinned/pin-less sets coexisting, in-place restyle of a selected set, selection sync, marker-disabled state, reload persistence within a session, per-set persistence across a save/reload, and legacy records restoring as pinned. All pass.
- `yarn typecheck` clean.
- Full suite: 194 passed, 6 pre-existing failures unrelated to this change (they assert a semver `state.version` and fail on any dev checkout, where `VERSION` is the literal `'DEV'`).

Visual check on `debug.html`: a pinned set and a pin-less set rendered side by side, the latter showing only its squares and numbers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01531zV3ZgwxpXHz3KBoUWsc)_