### PR TITLE
Draw harmonic pin labels as haloed text so they read on any background

### DIFF
--- a/src/gramframe.css
+++ b/src/gramframe.css
@@ -792,8 +792,11 @@
   font-size: 12px;
   font-weight: bold;
   pointer-events: none;
-  /* Add text shadow for readability */
-  filter: drop-shadow(1px 1px 1px rgba(0, 0, 0, 0.5));
+  /*
+   * Legibility comes from the halo (black glyphs inside a white outline) set as
+   * presentation attributes by applyTextHalo() in src/utils/svg.js — see the
+   * fill/stroke/paint-order there. No drop-shadow: it only blurred the outline.
+   */
 }
 
 /* SVG Harmonic Set styles (new system) */

--- a/src/modes/harmonics/HarmonicsMode.js
+++ b/src/modes/harmonics/HarmonicsMode.js
@@ -8,6 +8,7 @@ import { BaseDragHandler } from '../shared/BaseDragHandler.js'
 import { getUniformTolerance } from '../../utils/tolerance.js'
 import { sampledHarmonics } from '../../utils/harmonicSampling.js'
 import { createSymbolMark } from '../../rendering/symbols.js'
+import { applyTextHalo } from '../../utils/svg.js'
 import { calculateVisibleDataRange } from '../../components/table.js'
 
 /**
@@ -752,6 +753,11 @@ export class HarmonicsMode extends BaseMode {
    * positioned above the pin's symbol (baseline at `labelY`), so the vertical
    * stack over a pin reads label -> symbol -> line (spec 159, FR-009/FR-010).
    *
+   * The digits are drawn black inside a white halo rather than in the set's
+   * colour: a single colour is only legible over part of a gram, whereas the
+   * halo reads over both dark and light backgrounds. Set identity is still
+   * carried by the pin's line and symbol colour.
+   *
    * @param {number} harmonicNumber - Harmonic number
    * @param {HarmonicSet} harmonicSet - Harmonic set configuration
    * @param {number} lineX - X position of the pin line (label is centred on it)
@@ -766,8 +772,8 @@ export class HarmonicsMode extends BaseMode {
     label.setAttribute('x', String(lineX)) // centred on the pin line
     label.setAttribute('y', String(labelY)) // above the symbol
     label.setAttribute('text-anchor', 'middle')
-    label.setAttribute('fill', harmonicSet.color)
-    label.setAttribute('font-size', '12')
+    applyTextHalo(/** @type {SVGTextElement} */ (label))
+    label.setAttribute('font-size', String(HarmonicsMode.LABEL_FONT_SIZE))
     label.setAttribute('font-weight', 'bold')
     label.setAttribute('font-family', 'Arial, sans-serif')
     label.textContent = String(harmonicNumber)

--- a/src/utils/svg.js
+++ b/src/utils/svg.js
@@ -42,6 +42,58 @@ export function createSVGText(x, y, textContent, className, textAnchor = 'start'
 
 
 /**
+ * Default halo geometry/colours for in-gram text labels.
+ *
+ * A halo (also "text casing" or, in GIS, a label buffer) is a contrasting
+ * outline drawn behind the glyphs so a label stays legible over an unknown
+ * background: the white ring carries the digits over dark spectrogram pixels,
+ * the black core carries them over light ones. This replaces colour-coded label
+ * text, which is only readable over part of a gram.
+ *
+ * `width` is ~25% of the 12px label font — thick enough to survive over noisy
+ * pixels without closing up the counters of the digits.
+ * @type {{fill: string, haloColor: string, width: number}}
+ */
+export const TEXT_HALO = {
+  fill: '#000',
+  haloColor: '#fff',
+  width: 3
+}
+
+/**
+ * Apply a halo (contrasting outline) to an SVG text element so it reads against
+ * any background.
+ *
+ * The stroke is painted BEHIND the fill via `paint-order`; without that the
+ * stroke straddles the glyph outline and eats half of each letterform. All
+ * current browsers support `paint-order` on text (Chrome 35+, Firefox 60+,
+ * Safari 8+); older engines still show the text, just with thinner-looking
+ * glyphs, so no duplicate-text-node fallback is drawn.
+ *
+ * Set as presentation attributes (not CSS) so the halo travels with the element
+ * wherever it is rendered, while remaining overridable by a stylesheet.
+ *
+ * @param {SVGTextElement} text - Text element to style (mutated in place)
+ * @param {Object} [options] - Halo overrides
+ * @param {string} [options.fill] - Glyph colour (the halo's core)
+ * @param {string} [options.haloColor] - Outline colour drawn behind the glyphs
+ * @param {number} [options.width] - Outline width in px (total, centred on the glyph outline)
+ * @returns {SVGTextElement} The same element, for chaining
+ */
+export function applyTextHalo(text, options = {}) {
+  const { fill = TEXT_HALO.fill, haloColor = TEXT_HALO.haloColor, width = TEXT_HALO.width } = options
+  text.setAttribute('fill', fill)
+  text.setAttribute('stroke', haloColor)
+  text.setAttribute('stroke-width', String(width))
+  // Round joins keep the outline smooth at sharp glyph corners.
+  text.setAttribute('stroke-linejoin', 'round')
+  // Paint the halo behind the glyphs so the letterforms stay full-weight.
+  text.setAttribute('paint-order', 'stroke fill')
+  return text
+}
+
+
+/**
  * Creates an SVG circle element with the specified coordinates and class
  * @param {number} cx - Center x coordinate
  * @param {number} cy - Center y coordinate

--- a/tests/harmonic-label-halo.spec.js
+++ b/tests/harmonic-label-halo.spec.js
@@ -1,0 +1,111 @@
+import { test, expect } from './helpers/fixtures.js'
+
+/**
+ * @fileoverview E2E tests for the harmonic pin label halo — the number labels
+ * are drawn as black digits inside a white outline ("halo"/text casing) instead
+ * of in the harmonic set's colour, so they stay legible over both dark and
+ * light areas of a gram.
+ *
+ * Set identity must still be carried by the pin's line (and symbol) colour, so
+ * these tests also assert the line keeps the set colour.
+ *
+ * Debug config spans freq 0-100 Hz over time 0-60 s, so a 20 Hz set places
+ * harmonics 1..5 — every pin labelled.
+ */
+
+const BLACK = 'rgb(0, 0, 0)'
+const WHITE = 'rgb(255, 255, 255)'
+
+/**
+ * Set the colour the next created feature will take (the colour picker's
+ * selection), via the test-only instance registry.
+ * @param {import('./helpers/gram-frame-page.js').GramFramePage} gfp - Page helper
+ * @param {string} color - Hex colour
+ * @returns {Promise<void>}
+ */
+async function setSelectedColor(gfp, color) {
+  await gfp.page.evaluate((c) => {
+    // @ts-ignore - test-only global
+    const instance = window.GramFrame.__test__getInstances()[0]
+    instance.state.selectedColor = c
+  }, color)
+}
+
+test.describe('Harmonic pin label halo', () => {
+  test.beforeEach(async ({ gramFramePage }) => {
+    await gramFramePage.page.waitForTimeout(100)
+    await gramFramePage.clickMode('Harmonics')
+    await gramFramePage.waitForImageDimensions()
+  })
+
+  test('every pin number label is black digits inside a white halo', async ({ gramFramePage }) => {
+    const setId = await gramFramePage.addHarmonicSet(30, 20)
+    await gramFramePage.page.waitForTimeout(100)
+
+    const styles = await gramFramePage.getHarmonicLabelStyles(setId)
+    expect(styles.length).toBeGreaterThan(0)
+
+    for (const style of styles) {
+      expect(style.fill).toBe(BLACK)
+      expect(style.stroke).toBe(WHITE)
+      // A halo wide enough to read over noise, but not so wide it closes up the digits
+      expect(parseFloat(style.strokeWidth)).toBeGreaterThan(1)
+      expect(parseFloat(style.strokeWidth)).toBeLessThanOrEqual(4)
+      expect(style.strokeLinejoin).toBe('round')
+      // The halo must be painted BEHIND the fill, or the stroke eats the glyphs
+      expect(style.paintOrder).toMatch(/^stroke/)
+    }
+  })
+
+  test('label paint is independent of the set colour, which stays on the pin line', async ({ gramFramePage }) => {
+    // A new set takes the currently selected colour, so pick a different one
+    // before each add to get two visibly distinct sets.
+    await setSelectedColor(gramFramePage, '#ff6b6b')
+    const firstId = await gramFramePage.addHarmonicSet(20, 20)
+    await setSelectedColor(gramFramePage, '#45b7d1')
+    const secondId = await gramFramePage.addHarmonicSet(40, 25)
+    await gramFramePage.page.waitForTimeout(100)
+
+    const state = await gramFramePage.getState()
+    const sets = state.harmonics.harmonicSets
+    expect(sets.length).toBe(2)
+    const colors = sets.map((/** @type {any} */ s) => String(s.color).toLowerCase())
+    expect(colors[0]).not.toBe(colors[1])
+
+    // Both sets' labels are painted identically — colour no longer distinguishes them
+    for (const setId of [firstId, secondId]) {
+      const styles = await gramFramePage.getHarmonicLabelStyles(setId)
+      expect(styles.length).toBeGreaterThan(0)
+      for (const style of styles) {
+        expect(style.fill).toBe(BLACK)
+        expect(style.stroke).toBe(WHITE)
+      }
+    }
+
+    // ...because set identity is carried by the pin lines, which keep the colour
+    const lineColors = await gramFramePage.page.evaluate((ids) => {
+      return ids.map((id) => {
+        const line = document.querySelector(`.gram-frame-harmonic-line[data-harmonic-set-id="${id}"]`)
+        return line ? String(line.getAttribute('stroke')).toLowerCase() : null
+      })
+    }, [firstId, secondId])
+    expect(lineColors[0]).toBe(colors[sets.findIndex((/** @type {any} */ s) => s.id === firstId)])
+    expect(lineColors[1]).toBe(colors[sets.findIndex((/** @type {any} */ s) => s.id === secondId)])
+  })
+
+  test('labels stay haloed after a zoom re-render', async ({ gramFramePage }) => {
+    const setId = await gramFramePage.addHarmonicSet(30, 20)
+    await gramFramePage.page.waitForTimeout(100)
+
+    await gramFramePage.setZoom(2.0, 0.5, 0.5)
+    await gramFramePage.page.waitForTimeout(100)
+
+    const styles = await gramFramePage.getHarmonicLabelStyles(setId)
+    expect(styles.length).toBeGreaterThan(0)
+    for (const style of styles) {
+      expect(style.fill).toBe(BLACK)
+      expect(style.stroke).toBe(WHITE)
+      expect(style.paintOrder).toMatch(/^stroke/)
+    }
+  })
+})

--- a/tests/helpers/gram-frame-page.js
+++ b/tests/helpers/gram-frame-page.js
@@ -568,6 +568,31 @@ class GramFramePage {
   }
 
   /**
+   * Read the resolved paint of every rendered harmonic number label, optionally
+   * scoped to a single set. Uses computed style (not attributes) so a CSS rule
+   * overriding the halo would be caught.
+   * @param {string} [setId] - Restrict to one harmonic set
+   * @returns {Promise<Array<{fill: string, stroke: string, strokeWidth: string, strokeLinejoin: string, paintOrder: string}>>}
+   */
+  async getHarmonicLabelStyles(setId) {
+    const selector = setId
+      ? `.gram-frame-harmonic-number[data-harmonic-set-id="${setId}"]`
+      : '.gram-frame-harmonic-number'
+    return this.page.evaluate((sel) => {
+      return Array.from(document.querySelectorAll(sel)).map((el) => {
+        const style = window.getComputedStyle(el)
+        return {
+          fill: style.fill,
+          stroke: style.stroke,
+          strokeWidth: style.strokeWidth,
+          strokeLinejoin: style.strokeLinejoin,
+          paintOrder: style.paintOrder
+        }
+      })
+    }, selector)
+  }
+
+  /**
    * Programmatically add a harmonic set via the test instance API.
    * @param {number} anchorTime - Time position in seconds
    * @param {number} spacing - Frequency spacing in Hz


### PR DESCRIPTION
## Problem

Harmonic pin number labels were painted in the harmonic set's colour. A colour that reads well over one part of a gram vanishes over another, so labels became unreadable as soon as a pin landed on a bright or busy region.

## Approach

Draw the digits as **black glyphs inside a white outline** — a *halo* (also known as text casing, or a label buffer in GIS tools). The white ring carries the digits over dark pixels; the black core carries them over light ones, so one style works everywhere on the gram.

Set identity is unchanged: the pin's line and symbol still carry the set colour, so only the digits changed appearance.

## Changes

- `src/utils/svg.js` — new `applyTextHalo()` helper and `TEXT_HALO` defaults (black fill, white outline, 3px). The stroke is painted *behind* the fill via `paint-order`; without that the stroke straddles the glyph outline and eats half of each letterform. Applied as presentation attributes so the halo travels with the element.
- `src/modes/harmonics/HarmonicsMode.js` — `createHarmonicLabel()` uses the halo instead of `harmonicSet.color`, and takes its font size from the existing `LABEL_FONT_SIZE` constant rather than a literal `12`.
- `src/gramframe.css` — dropped the now-redundant `drop-shadow` filter on `.gram-frame-harmonic-number`, which only blurred the outline.
- `tests/harmonic-label-halo.spec.js` — new spec: labels are black-on-white with a behind-the-fill paint order, label paint is independent of the set colour while the pin line keeps that colour, and the halo survives a zoom re-render.
- `tests/helpers/gram-frame-page.js` — `getHarmonicLabelStyles()` reads label paint from *computed* style, so a stylesheet override of the halo would fail the test.

Analysis markers and Doppler curves draw no text in the gram (markers render a symbol or crosshair), so there were no other in-image labels to restyle. Axis labels sit on the dark margin outside the image and are left as white text.

## Verification

- `npx playwright test tests/harmonic-label-halo.spec.js` — 3 passed.
- Full suite: 187 passed, 6 failed. All six failures are pre-existing and unrelated — they assert `state.version` matches semver, but the dev server reports `"DEV"`; they fail the same way on `main`.
- `yarn typecheck` reports only the pre-existing `src/index.js` CSS side-effect-import error, unchanged by this branch.
- Visually confirmed on `debug.html` with two sets: labels stay legible over the blue background and over the bright yellow/red vertical streaks.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLyzbTKjygciJUNnoY3vVB)_