### PR TITLE
Fixed-height markers/harmonics tables with a scrolling body and pinned header

### DIFF
--- a/src/components/HarmonicPanel.js
+++ b/src/components/HarmonicPanel.js
@@ -19,10 +19,19 @@ function createSymbolSwatch(harmonicSet) {
 
 /**
  * Create harmonic management panel
+ *
+ * The panel is mounted inside a `gram-frame-table-area` wrapper: the wrapper
+ * takes whatever vertical space the column has, and the panel fills it
+ * absolutely, so however many harmonic sets exist the panel scrolls instead of
+ * growing the page layout (the header row stays pinned via sticky `th`).
+ *
  * @param {HTMLElement} container - Container element to append the panel to
  * @returns {HTMLElement} The created panel element
  */
 export function createHarmonicPanel(container) {
+  const area = document.createElement('div')
+  area.className = 'gram-frame-table-area'
+
   const panel = document.createElement('div')
   panel.className = 'gram-frame-table-container'
   panel.innerHTML = `
@@ -40,7 +49,8 @@ export function createHarmonicPanel(container) {
     </table>
   `
   
-  container.appendChild(panel)
+  area.appendChild(panel)
+  container.appendChild(area)
   return panel
 }
 

--- a/src/gramframe.css
+++ b/src/gramframe.css
@@ -399,27 +399,97 @@
 }
 
 /* Unified table styles for both markers and harmonics */
+
+/*
+ * Fixed-height home for a markers/harmonics table.
+ *
+ * It claims the column's remaining height (flex: 1) but contributes nothing to
+ * the layout's intrinsic height, because its only child is absolutely
+ * positioned. That is what keeps the panels a constant size however many rows
+ * they hold: the tables can no longer push the readout row taller (untidy
+ * layout) nor steal vertical space from an expanded spectrogram image.
+ */
+.gram-frame-table-area {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
 .gram-frame-table-container {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  box-sizing: border-box;
   padding: 0;
   background: linear-gradient(135deg, #1a1a1a 0%, #000 50%, #0a0a0a 100%);
   border: 2px solid #333;
   border-radius: 4px;
-  box-shadow: 
+  box-shadow:
     inset 0 2px 6px rgba(0,0,0,0.8),
     inset 0 -1px 2px rgba(255,255,255,0.05),
     0 2px 4px rgba(0,0,0,0.5);
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
+  /* Permanent vertical scrollbar so the gutter never appears/disappears as rows
+     are added or removed (no reflow of the table columns). */
+  overflow-y: scroll;
+  overflow-x: hidden;
+  /* Dark-theme scrollbar (Firefox) */
+  scrollbar-width: thin;
+  scrollbar-color: #555 #111;
 }
 
-.gram-frame-table {
+/* Dark-theme scrollbar (WebKit/Blink) */
+.gram-frame-table-container::-webkit-scrollbar {
+  width: 10px;
+}
+
+.gram-frame-table-container::-webkit-scrollbar-track {
+  background: #111;
+}
+
+.gram-frame-table-container::-webkit-scrollbar-thumb {
+  background: #555;
+  border-radius: 5px;
+  border: 2px solid #111;
+}
+
+.gram-frame-table-container::-webkit-scrollbar-thumb:hover {
+  background: #6a6a6a;
+}
+
+/*
+ * Separate (not collapsed) borders: sticky header cells are unreliable with
+ * border-collapse, so each cell draws its own right/bottom edge and the first
+ * column/header row close the outer edges. Visually identical to the collapsed
+ * 1px grid, because border-spacing is zero.
+ *
+ * Element-qualified because the `gram-frame-table` class is also carried by the
+ * component's outer frame <div> (display: table), which must keep its own
+ * border. Zeroing the border here matters for the sticky header too — a border
+ * on the table box offsets the header cells from the scrollport, which makes
+ * them jump when the body first scrolls.
+ */
+table.gram-frame-table {
   width: 100%;
-  border-collapse: collapse;
+  border: 0;
+  border-collapse: separate;
+  border-spacing: 0;
   font-size: 10px;
   color: #ccc;
   table-layout: fixed;
+}
+
+.gram-frame-table th,
+.gram-frame-table td {
+  border: 0;
+  border-right: 1px solid #444;
+  border-bottom: 1px solid #444;
+}
+
+.gram-frame-table th:first-child,
+.gram-frame-table td:first-child {
+  border-left: 1px solid #444;
 }
 
 .gram-frame-table th {
@@ -427,16 +497,20 @@
   color: #00ff00;
   padding: 4px;
   text-align: center;
-  border: 1px solid #444;
+  border-top: 1px solid #444;
   font-weight: bold;
   text-transform: uppercase;
   letter-spacing: 0.5px;
+  /* Header row stays pinned while the body scrolls beneath it. The z-index sits
+     above the positioned body rows, including a selected row's cells (11). */
+  position: sticky;
+  top: 0;
+  z-index: 20;
 }
 
 .gram-frame-table td {
   padding: 4px;
   text-align: center;
-  border: 1px solid #444;
   background: #1a1a1a;
 }
 

--- a/src/modes/analysis/AnalysisMode.js
+++ b/src/modes/analysis/AnalysisMode.js
@@ -348,6 +348,12 @@ export class AnalysisMode extends BaseMode {
 
   /**
    * Create markers table for displaying active markers
+   *
+   * The table wrapper sits inside a `gram-frame-table-area` element that claims
+   * the column's remaining height; the wrapper fills it absolutely and scrolls,
+   * so adding markers never grows the surrounding layout (the header row stays
+   * pinned via sticky `th`).
+   *
    * @param {HTMLElement} markersContainer - Persistent container for markers (already has label)
    */
   createMarkersTable(markersContainer) {
@@ -355,12 +361,15 @@ export class AnalysisMode extends BaseMode {
     if (markersContainer.querySelector('.gram-frame-table')) {
       return
     }
-    
+
     // The container already has a label, so we just add the table wrapper
-    
+
+    const tableArea = document.createElement('div')
+    tableArea.className = 'gram-frame-table-area'
+
     const tableWrapper = document.createElement('div')
     tableWrapper.className = 'gram-frame-table-container'
-    
+
     const table = document.createElement('table')
     table.className = 'gram-frame-table'
     
@@ -396,7 +405,8 @@ export class AnalysisMode extends BaseMode {
     table.appendChild(tbody)
     
     tableWrapper.appendChild(table)
-    markersContainer.appendChild(tableWrapper)
+    tableArea.appendChild(tableWrapper)
+    markersContainer.appendChild(tableArea)
     
     // Store all UI elements for proper cleanup
     this.uiElements.markersTable = table

--- a/tests/helpers/gram-frame-page.js
+++ b/tests/helpers/gram-frame-page.js
@@ -568,6 +568,23 @@ class GramFramePage {
   }
 
   /**
+   * Programmatically add an analysis marker via the test instance API.
+   * @param {number} time - Time position in seconds
+   * @param {number} freq - Frequency in Hz
+   * @returns {Promise<string>} The created marker's id
+   */
+  async addMarker(time, freq) {
+    return this.page.evaluate(([t, f]) => {
+      // @ts-ignore - test-only global
+      const instances = window.GramFrame.__test__getInstances()
+      const instance = instances[0]
+      instance.modes['analysis'].createMarkerAtPosition({ time: t, freq: f })
+      const markers = instance.state.analysis.markers
+      return markers[markers.length - 1].id
+    }, [time, freq])
+  }
+
+  /**
    * Programmatically add a harmonic set via the test instance API.
    * @param {number} anchorTime - Time position in seconds
    * @param {number} spacing - Frequency spacing in Hz

--- a/tests/table-scroll.spec.js
+++ b/tests/table-scroll.spec.js
@@ -1,0 +1,176 @@
+import { test, expect } from '@playwright/test'
+import { GramFramePage } from './helpers/gram-frame-page.js'
+
+/**
+ * Acceptance tests for the fixed-height, scrolling markers/harmonics tables.
+ *
+ * The panels must keep a constant height however many rows they hold: growing
+ * tables previously pushed the readout row taller (untidy layout) and stole
+ * vertical space from an expanded spectrogram image. The table body scrolls
+ * instead, with the header row pinned outside the scroll.
+ */
+
+const LANDSCAPE_PAGE = '/sample/pub10-gram1.html'
+
+/** How many rows to add — comfortably more than any panel can show at once. */
+const MANY_ROWS = 15
+
+const MARKERS_TABLE = '.gram-frame-middle-column .gram-frame-table-container'
+const HARMONICS_TABLE = '.gram-frame-right-column .gram-frame-table-container'
+
+/**
+ * Navigate to the demonstrator page and wait for GramFrame to initialise.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<GramFramePage>}
+ */
+async function gotoDemo(page) {
+  const gfp = new GramFramePage(page)
+  await page.setViewportSize({ width: 1600, height: 900 })
+  await page.goto(LANDSCAPE_PAGE)
+  await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+  await page.waitForFunction(() => {
+    const sd = document.getElementById('state-display')
+    if (!sd || !sd.textContent) return false
+    try {
+      const s = JSON.parse(sd.textContent)
+      return s.imageDetails && s.imageDetails.naturalWidth > 0
+    } catch {
+      return false
+    }
+  }, {}, { timeout: 10000 })
+  return gfp
+}
+
+/**
+ * Bounding-box height of an element, rounded.
+ * @param {import('@playwright/test').Page} page
+ * @param {string} selector
+ * @returns {Promise<number>}
+ */
+async function heightOf(page, selector) {
+  return page.evaluate((sel) => {
+    const el = document.querySelector(sel)
+    return el ? Math.round(el.getBoundingClientRect().height) : -1
+  }, selector)
+}
+
+/**
+ * Top edge of the spectrogram SVG in viewport coordinates, rounded.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<number>}
+ */
+async function svgTop(page) {
+  return page.evaluate(() => Math.round(document.querySelector('.gram-frame-svg').getBoundingClientRect().top))
+}
+
+/**
+ * Add markers and harmonic sets to both panels.
+ * @param {GramFramePage} gfp
+ * @param {number} count - How many of each to add
+ * @returns {Promise<void>}
+ */
+async function fillBothPanels(gfp, count) {
+  for (let i = 0; i < count; i++) {
+    await gfp.addMarker(i * 2, 100 + i * 10)
+    await gfp.addHarmonicSet(i * 2, 50 + i * 5)
+  }
+  await gfp.page.waitForTimeout(150)
+}
+
+test.describe('Markers/harmonics tables: fixed height with a scrolling body', () => {
+  test('panel heights and the image position are unchanged as rows are added', async ({ page }) => {
+    const gfp = await gotoDemo(page)
+
+    const before = {
+      markers: await heightOf(page, MARKERS_TABLE),
+      harmonics: await heightOf(page, HARMONICS_TABLE),
+      layout: await heightOf(page, '.gram-frame-unified-layout'),
+      svgTop: await svgTop(page)
+    }
+    expect(before.markers).toBeGreaterThan(0)
+
+    await fillBothPanels(gfp, MANY_ROWS)
+
+    expect(await heightOf(page, MARKERS_TABLE)).toBe(before.markers)
+    expect(await heightOf(page, HARMONICS_TABLE)).toBe(before.harmonics)
+    expect(await heightOf(page, '.gram-frame-unified-layout')).toBe(before.layout)
+    expect(await svgTop(page)).toBe(before.svgTop)
+  })
+
+  test('each table body has a permanent scrollbar and scrolls once it overflows', async ({ page }) => {
+    const gfp = await gotoDemo(page)
+
+    for (const selector of [MARKERS_TABLE, HARMONICS_TABLE]) {
+      const overflowY = await page.evaluate(
+        (sel) => window.getComputedStyle(document.querySelector(sel)).overflowY,
+        selector
+      )
+      expect(overflowY).toBe('scroll')
+    }
+
+    await fillBothPanels(gfp, MANY_ROWS)
+
+    for (const selector of [MARKERS_TABLE, HARMONICS_TABLE]) {
+      const metrics = await page.evaluate((sel) => {
+        const el = document.querySelector(sel)
+        el.scrollTop = 1000
+        return { scrollHeight: el.scrollHeight, clientHeight: el.clientHeight, scrollTop: el.scrollTop }
+      }, selector)
+
+      // Content overflows, and the body really did scroll
+      expect(metrics.scrollHeight).toBeGreaterThan(metrics.clientHeight)
+      expect(metrics.scrollTop).toBeGreaterThan(0)
+    }
+  })
+
+  test('the header row stays pinned while the body scrolls under it', async ({ page }) => {
+    const gfp = await gotoDemo(page)
+    await fillBothPanels(gfp, MANY_ROWS)
+
+    for (const selector of [MARKERS_TABLE, HARMONICS_TABLE]) {
+      const result = await page.evaluate((sel) => {
+        const container = document.querySelector(sel)
+        const table = container.querySelector('.gram-frame-table')
+        // The sticky boxes are the header cells themselves
+        const headerCell = table.tHead.rows[0].cells[1]
+        const containerTop = container.getBoundingClientRect().top
+        const headerTopBefore = headerCell.getBoundingClientRect().top
+        const firstRowBefore = table.tBodies[0].rows[0].getBoundingClientRect().top
+
+        container.scrollTop = 60
+
+        return {
+          containerTop,
+          headerTopBefore,
+          headerTopAfter: headerCell.getBoundingClientRect().top,
+          headerHeight: headerCell.getBoundingClientRect().height,
+          firstRowBefore,
+          firstRowAfter: table.tBodies[0].rows[0].getBoundingClientRect().top
+        }
+      }, selector)
+
+      // Header did not move (it is not part of the scrolled content)
+      expect(Math.abs(result.headerTopAfter - result.headerTopBefore)).toBeLessThanOrEqual(1)
+      // ...and it is still pinned to the top of the scroll container
+      expect(result.headerTopAfter - result.containerTop).toBeLessThanOrEqual(3)
+      // The body content did scroll
+      expect(result.firstRowBefore - result.firstRowAfter).toBeGreaterThan(50)
+    }
+  })
+
+  test('an expanded image keeps its size as rows are added', async ({ page }) => {
+    const gfp = await gotoDemo(page)
+
+    await gfp.clickExpandToggle()
+    await page.waitForTimeout(200)
+
+    const expanded = await gfp.getState()
+    expect(expanded.imageExpanded).toBe(true)
+    const renderHeightBefore = expanded.imageDetails.renderHeight
+
+    await fillBothPanels(gfp, MANY_ROWS)
+
+    const after = await gfp.getState()
+    expect(after.imageDetails.renderHeight).toBe(renderHeightBefore)
+  })
+})


### PR DESCRIPTION
## Problem

Two symptoms from the same cause:

1. The page layout looked untidy as the markers/harmonics tables grew taller.
2. With the image expanded, adding rows shrank the image vertically.

The tables live in the readout row **above** the spectrogram, so each added row grew that row and pushed the image down. Expanded height is computed as `window.innerHeight − imageTop − …`, so a lower image top means a shorter image.

Measured on `sample/pub10-gram1.html` at 1600×900 with 12 markers + 12 harmonic sets:

| | before | after |
|---|---|---|
| readout row height | 212 → 455 px | 212 px (constant) |
| spectrogram top | 346 → 589 px | 346 px (constant) |

## Change

- Each table is mounted in a new `gram-frame-table-area` wrapper that claims the column's remaining height but contributes nothing to the layout's intrinsic height (its only child is absolutely positioned). The panels therefore keep a constant size however many rows they hold.
- The table container scrolls with a permanent scrollbar (`overflow-y: scroll`), styled for the dark theme in both Firefox and WebKit/Blink. Permanent rather than automatic so the gutter never appears/disappears and reflows the columns.
- Header rows are excluded from the scroll: `th` cells are `position: sticky; top: 0` and sit above the positioned body rows (a selected row's cells use `z-index: 11`).

Two supporting fixes were needed to make the sticky header behave:

- The tables move from `border-collapse: collapse` to `border-collapse: separate; border-spacing: 0`, with each cell drawing its right/bottom edge and the first column/header row closing the outer edges. Sticky cells render incorrectly with collapsed borders — body rows painted through the header. The 1px grid is visually unchanged.
- The data tables no longer inherit the `3px` border that the component's outer frame `<div>` carries under the same `gram-frame-table` class (the rule is now element-qualified). A border on the table box offsets the header cells from the scrollport, which made the header jump 3px on the first scroll. The outer frame keeps its border.

## Tests

New `tests/table-scroll.spec.js` covers:

- Panel heights, the readout row height, and the spectrogram's top edge are unchanged after adding 15 markers and 15 harmonic sets.
- Each table body reports `overflow-y: scroll` and really scrolls once content overflows.
- The header cells do not move when the body is scrolled, stay pinned to the top of the scroll container, and the body content moves beneath them.
- An expanded image keeps its exact `renderHeight` as rows are added.

Also adds a `addMarker(time, freq)` test helper alongside the existing `addHarmonicSet`.

`yarn typecheck` passes. Full suite: **188 passed, 6 failed** — the same 6 failures occur on unmodified `main` (verified by stashing), all in the "state consistency during complex operations" / "error recovery" groups, and are unrelated to this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGD5oeN2M3RJbnNRipe7cF)_