### PR TITLE
Clear the selected marker/harmonic on any mode-button click

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -474,12 +474,12 @@ export class GramFrame {
     this.state.dragState.originalAnchorTime = null
     this.state.dragState.clickedHarmonicNumber = null
 
-    // Changing mode signals the analyst is about to add something new, so drop
+    // Choosing a mode signals the analyst is about to add something new, so drop
     // any selected marker/harmonic. This returns the colour/symbol controls to
     // targeting the NEXT created feature instead of restyling the previously
-    // selected one (feature 161).
-    const modeChanged = this.state.previousMode !== mode
-    if (modeChanged && this.state.selection && this.state.selection.selectedType && this.clearSelection) {
+    // selected one (feature 161). Re-clicking the already-active mode counts too:
+    // it is the natural gesture for "deselect and start fresh".
+    if (this.state.selection && this.state.selection.selectedType && this.clearSelection) {
       this.clearSelection()
     }
 

--- a/tests/reformat-markers-harmonics.spec.js
+++ b/tests/reformat-markers-harmonics.spec.js
@@ -271,6 +271,34 @@ test.describe('Switching mode clears the current selection', () => {
     state = await gramFramePage.getState()
     expect(state.harmonics.harmonicSets.find((s) => s.id === setId).color).toBe(colorBefore)
   })
+
+  test('re-clicking the already-active mode also clears the selection', async ({ gramFramePage }) => {
+    const page = gramFramePage.page
+
+    await gramFramePage.clickMode('Harmonics')
+    await page.waitForTimeout(100)
+    const setId = await gramFramePage.addHarmonicSet(30, 20)
+    await page.waitForTimeout(100)
+
+    let state = await gramFramePage.getState()
+    expect(state.selection.selectedType).toBe('harmonicSet')
+    expect(state.selection.selectedId).toBe(setId)
+    const colorBefore = state.harmonics.harmonicSets.find((s) => s.id === setId).color
+
+    // Clicking Harmonics again - the mode does not change, but the selection drops
+    await gramFramePage.clickMode('Harmonics')
+    await page.waitForTimeout(150)
+    state = await gramFramePage.getState()
+    expect(state.mode).toBe('harmonics')
+    expect(state.selection.selectedType).toBeNull()
+    expect(state.selection.selectedId).toBeNull()
+
+    // The colour picker now arms the next set rather than restyling the placed one
+    await page.locator(COLOR_CANVAS).click({ position: { x: 4, y: 10 } })
+    await page.waitForTimeout(100)
+    state = await gramFramePage.getState()
+    expect(state.harmonics.harmonicSets.find((s) => s.id === setId).color).toBe(colorBefore)
+  })
 })
 
 // ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Choosing a mode already dropped the current selection, but only when the mode actually *changed* (the `modeChanged` guard added with feature 161). If a marker or harmonic set was selected and you clicked the mode you were already in — or simply never left it — the selection persisted, so picking a colour for the feature you were *about to* place silently restyled the previously selected one instead.

## Change

`src/main.js` — `_switchMode()` now clears the selection on every mode-button click, not just on an actual mode change. Re-clicking the already-active mode is the natural "deselect and start fresh" gesture, and with nothing selected the colour/symbol controls revert to arming the next created feature (FR-013).

The clearing path itself is unchanged: it still goes through `instance.clearSelection()`, which resets `state.selection`, refreshes the selection visuals, re-syncs the style controls, and notifies listeners.

## Tests

Added `re-clicking the already-active mode also clears the selection` to `tests/reformat-markers-harmonics.spec.js`, alongside the existing mode-switch test. It places a harmonic set, re-clicks Harmonics, asserts the mode is unchanged while `selection.selectedType`/`selectedId` are null, then picks a colour and asserts the placed set's colour is untouched.

- `yarn typecheck` — clean
- Full Playwright suite — 201 passed, 6 failed; all 6 failures are the pre-existing `state.version` assertion (`"DEV"` under the dev server vs. the expected semver pattern), reproduced on the unmodified tree.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jppd63Gb8yg9KbebbkHnbg)_