### PR TITLE
Make a harmonic set grabbable wherever it is drawn

### DIFF
--- a/src/modes/harmonics/HarmonicsMode.js
+++ b/src/modes/harmonics/HarmonicsMode.js
@@ -155,6 +155,13 @@ export class HarmonicsMode extends BaseMode {
   static LABEL_FONT_SIZE = 12
 
   /**
+   * Approximate width of one label digit as a fraction of the label font size,
+   * used to size the label's grab region (bold Arial digits are ~0.6 em wide).
+   * @type {number}
+   */
+  static LABEL_CHAR_WIDTH_RATIO = 0.6
+
+  /**
    * Vertical gap (px) between the pin's number label and its symbol.
    * @type {number}
    */
@@ -473,15 +480,22 @@ export class HarmonicsMode extends BaseMode {
   }
 
   /**
-   * Find harmonic set containing given frequency coordinate
+   * Find harmonic set containing given frequency coordinate.
+   *
+   * Hit-testing follows exactly what is drawn — nothing more, nothing less.
+   * Every visible part of a pin grabs it: the pin line's fixed-pixel span AND
+   * the number label + symbol stacked above it. A set with its pin hidden is
+   * grabbable by its label/symbol stack alone; the span where its line would
+   * have been is empty on screen, so it is empty to the mouse too.
+   *
    * @param {number} freq - Frequency in Hz to check
    * @returns {HarmonicSet|null} The harmonic set if found, null otherwise
    */
   findHarmonicSetAtFrequency(freq) {
     if (!this.instance.state.cursorPosition) return null
-    
+
     const cursorTime = this.instance.state.cursorPosition.time
-    
+
     for (const harmonicSet of this.instance.state.harmonics.harmonicSets) {
       // Check if frequency is close to any harmonic line in this set
       if (harmonicSet.spacing > 0) {
@@ -495,22 +509,34 @@ export class HarmonicsMode extends BaseMode {
         // Pins are a fixed pixel height, so hit-test vertically in SVG pixels
         // against the same geometry the renderer draws.
         const { lineHeight, lineTop } = this.calculateHarmonicLineDimensions(harmonicSet)
+        const stack = this.calculateLabelStackBounds(lineTop, harmonicSet)
+        // Only the thinned subset is labelled, so only those pins carry a stack.
+        const labelled = new Set(this.getLabelledHarmonics(minHarmonic, maxHarmonic))
+        // A hidden pin draws no lines, so its line span is not a grab region.
+        const pinDrawn = harmonicSet.showPin !== false
+
+        const tolerance = getUniformTolerance(this.getViewport(), this.instance.spectrogramImage)
+        const cursorSVG = calculateZoomAwarePosition(
+          { freq, time: cursorTime },
+          this.getViewport(),
+          this.instance.spectrogramImage
+        )
 
         for (let h = minHarmonic; h <= maxHarmonic; h++) {
           const expectedFreq = h * harmonicSet.spacing
-          const tolerance = getUniformTolerance(this.getViewport(), this.instance.spectrogramImage)
 
-          if (Math.abs(freq - expectedFreq) < tolerance.freq) {
-            const cursorSVGY = calculateZoomAwarePosition(
-              { freq: expectedFreq, time: cursorTime },
-              this.getViewport(),
-              this.instance.spectrogramImage
-            ).y
+          // The pin line: frequency tolerance horizontally, the line span vertically.
+          if (pinDrawn && Math.abs(freq - expectedFreq) < tolerance.freq &&
+              cursorSVG.y >= lineTop && cursorSVG.y <= lineTop + lineHeight) {
+            return harmonicSet
+          }
 
-            // Check if cursor is within the vertical range of the harmonic line
-            if (cursorSVGY >= lineTop && cursorSVGY <= lineTop + lineHeight) {
-              return harmonicSet
-            }
+          // The label/symbol stack above the line: measured in SVG pixels, since
+          // the digits and symbol are a fixed pixel size regardless of zoom.
+          if (labelled.has(h) &&
+              cursorSVG.y >= stack.top && cursorSVG.y <= stack.bottom &&
+              Math.abs(cursorSVG.x - this.harmonicLineX(harmonicSet, h)) <= this.labelStackHalfWidth(harmonicSet, h)) {
+            return harmonicSet
           }
         }
       }
@@ -880,6 +906,50 @@ export class HarmonicsMode extends BaseMode {
   }
 
   /**
+   * Vertical extent (SVG coords) of a pin's label/symbol stack, for hit-testing.
+   *
+   * Derived from the same {@link calculateLabelStackPositions} layout the
+   * renderer uses, so the grab region tracks the drawn stack — including the
+   * downward nudge applied near the image's top edge. The bottom is clamped to
+   * the pin line's top so the stack region and the line region always meet with
+   * no dead gap between them.
+   *
+   * @param {number} lineTop - Top Y position of the pin lines (SVG coords)
+   * @param {HarmonicSet} harmonicSet - Harmonic set being hit-tested
+   * @returns {{top: number, bottom: number}} Top and bottom Y of the stack region
+   */
+  calculateLabelStackBounds(lineTop, harmonicSet) {
+    const imageTop = getImageBounds(this.getViewport(), this.instance.spectrogramImage).top
+    const { symbolCy, labelY } = this.calculateLabelStackPositions(lineTop, imageTop, harmonicSet)
+    const r = this.symbolSize(harmonicSet) / 2
+
+    return {
+      // One ascent above the label's baseline is the top of the digits.
+      top: labelY - HarmonicsMode.LABEL_FONT_SIZE,
+      bottom: Math.max(lineTop, symbolCy + r)
+    }
+  }
+
+  /**
+   * Half-width (SVG px) of a pin's label/symbol stack, for hit-testing.
+   *
+   * The wider of the symbol mark and the number label, so both are grabbable:
+   * a `cross` set has no symbol but still shows its digits, and a "Large
+   * symbols" set's mark is wider than its digits. Label width is estimated from
+   * the digit count rather than measured, which is ample for a grab region.
+   *
+   * @param {HarmonicSet} harmonicSet - Harmonic set being hit-tested
+   * @param {number} harmonicNumber - Harmonic number whose label is drawn
+   * @returns {number} Half-width in SVG pixels
+   */
+  labelStackHalfWidth(harmonicSet, harmonicNumber) {
+    const digits = String(harmonicNumber).length
+    const labelHalfWidth = digits * HarmonicsMode.LABEL_FONT_SIZE * HarmonicsMode.LABEL_CHAR_WIDTH_RATIO / 2
+
+    return Math.max(this.symbolSize(harmonicSet) / 2, labelHalfWidth)
+  }
+
+  /**
    * Compute the SVG x-coordinate of a harmonic's vertical pin line.
    * @param {HarmonicSet} harmonicSet - Harmonic set configuration
    * @param {number} harmonicNumber - Harmonic number
@@ -901,8 +971,8 @@ export class HarmonicsMode extends BaseMode {
    * A set with `showPin === false` skips the lines entirely and renders as its
    * symbols and numbers alone — the low-clutter style for stacking many sets over
    * dense data. The label/symbol geometry is unchanged, so toggling the pin adds
-   * or removes the lines without moving anything else, and the set stays
-   * draggable over the same region.
+   * or removes the lines without moving anything else; the set is then grabbed
+   * by its label/symbol stack, since hit-testing only covers what is drawn.
    *
    * @param {HarmonicSet} harmonicSet - Harmonic set to render
    */

--- a/tests/harmonic-hotspot.spec.js
+++ b/tests/harmonic-hotspot.spec.js
@@ -1,0 +1,170 @@
+import { test, expect } from './helpers/fixtures.js'
+
+/**
+ * @fileoverview E2E tests for the grab region ("hotspot") of an existing
+ * harmonic set.
+ *
+ * Everything drawn for a pin should grab it: the pin line, and the number label
+ * and symbol stacked above the line's top. Previously only the line's own span
+ * was live, so the digits and symbol were dead space — and a set with its pin
+ * hidden could only be grabbed in the blank gap below its digits, where the
+ * (undrawn) line would have been.
+ *
+ * Debug config spans freq 0-100 Hz over time 0-60 s.
+ */
+
+const ANCHOR_TIME = 30
+const SPACING = 10
+/** Harmonic near the horizontal centre of the span (50 Hz of 0-100). */
+const CENTRE_HARMONIC = 5
+
+/**
+ * Probe the harmonics hit-test at the centre of a rendered element, converting
+ * that element's on-screen position back into data coordinates the same way a
+ * mouse over it would resolve.
+ *
+ * @param {import('./helpers/gram-frame-page.js').GramFramePage} gfp - Page helper
+ * @param {string} selector - CSS selector of the element to probe over
+ * @param {number} [dy=0] - Extra vertical offset in client px (+ve = downwards)
+ * @returns {Promise<string|null>} Id of the harmonic set found there, if any
+ */
+async function probeAt(gfp, selector, dy = 0) {
+  return gfp.page.evaluate(([sel, offsetY]) => {
+    const el = document.querySelector(sel)
+    if (!el) return 'ELEMENT_NOT_FOUND'
+    const rect = el.getBoundingClientRect()
+    const imageRect = document.querySelector('.gram-frame-spectrogram-image').getBoundingClientRect()
+
+    const cx = (rect.left + rect.right) / 2
+    const cy = (rect.top + rect.bottom) / 2 + offsetY
+    // Debug config: 0-100 Hz across the image, 0-60 s bottom-up.
+    const freq = 100 * (cx - imageRect.left) / imageRect.width
+    const time = 60 * (1 - (cy - imageRect.top) / imageRect.height)
+
+    // @ts-ignore - test-only global
+    const instance = window.GramFrame.__test__getInstances()[0]
+    instance.state.cursorPosition = { freq, time, x: 0, y: 0, svgX: 0, svgY: 0, imageX: 0, imageY: 0 }
+    const found = instance.modes['harmonics'].findHarmonicSetAtFrequency(freq)
+    return found ? found.id : null
+  }, [selector, dy])
+}
+
+/**
+ * Probe the harmonics hit-test directly at a data coordinate.
+ *
+ * @param {import('./helpers/gram-frame-page.js').GramFramePage} gfp - Page helper
+ * @param {number} freq - Frequency in Hz
+ * @param {number} time - Time in seconds
+ * @returns {Promise<string|null>} Id of the harmonic set found there, if any
+ */
+async function probeAtData(gfp, freq, time) {
+  return gfp.page.evaluate(([f, t]) => {
+    // @ts-ignore - test-only global
+    const instance = window.GramFrame.__test__getInstances()[0]
+    instance.state.cursorPosition = { freq: f, time: t, x: 0, y: 0, svgX: 0, svgY: 0, imageX: 0, imageY: 0 }
+    const found = instance.modes['harmonics'].findHarmonicSetAtFrequency(f)
+    return found ? found.id : null
+  }, [freq, time])
+}
+
+/**
+ * Set properties on an existing harmonic set through the mode's own updater, so
+ * the overlay re-renders exactly as it would after a control-panel edit.
+ * @param {import('./helpers/gram-frame-page.js').GramFramePage} gfp - Page helper
+ * @param {string} setId - Harmonic set id
+ * @param {Object} updates - Properties to apply
+ * @returns {Promise<void>}
+ */
+async function updateSet(gfp, setId, updates) {
+  await gfp.page.evaluate(([id, patch]) => {
+    // @ts-ignore - test-only global
+    const instance = window.GramFrame.__test__getInstances()[0]
+    instance.modes['harmonics'].updateHarmonicSet(id, patch)
+  }, [setId, updates])
+}
+
+/**
+ * Selector for a pin's number label.
+ * @param {string} setId - Harmonic set id
+ * @param {number} harmonicNumber - Harmonic number
+ * @returns {string} CSS selector
+ */
+const labelSelector = (setId, harmonicNumber) =>
+  `.gram-frame-harmonic-number[data-harmonic-set-id="${setId}"][data-harmonic-number="${harmonicNumber}"]`
+
+test.describe('Harmonic set hotspot', () => {
+  test.beforeEach(async ({ gramFramePage }) => {
+    await gramFramePage.page.waitForTimeout(100)
+    await gramFramePage.clickMode('Harmonics')
+    await gramFramePage.waitForImageDimensions()
+  })
+
+  test('the number label grabs its harmonic set', async ({ gramFramePage }) => {
+    const setId = await gramFramePage.addHarmonicSet(ANCHOR_TIME, SPACING)
+    await gramFramePage.page.waitForTimeout(100)
+
+    expect(await probeAt(gramFramePage, labelSelector(setId, CENTRE_HARMONIC))).toBe(setId)
+  })
+
+  test('the symbol grabs its harmonic set', async ({ gramFramePage }) => {
+    const setId = await gramFramePage.addHarmonicSet(ANCHOR_TIME, SPACING)
+    await updateSet(gramFramePage, setId, { symbol: 'circle' })
+    await gramFramePage.page.waitForTimeout(100)
+
+    const symbol = `.gram-frame-harmonic-symbol[data-harmonic-set-id="${setId}"]`
+    expect(await probeAt(gramFramePage, symbol)).toBe(setId)
+  })
+
+  test('the pin line itself still grabs its harmonic set', async ({ gramFramePage }) => {
+    const setId = await gramFramePage.addHarmonicSet(ANCHOR_TIME, SPACING)
+    await gramFramePage.page.waitForTimeout(100)
+
+    const line = `.gram-frame-harmonic-line[data-harmonic-set-id="${setId}"][data-harmonic-number="${CENTRE_HARMONIC}"]`
+    expect(await probeAt(gramFramePage, line)).toBe(setId)
+  })
+
+  test('with the pin hidden, the number label alone grabs the set', async ({ gramFramePage }) => {
+    const setId = await gramFramePage.addHarmonicSet(ANCHOR_TIME, SPACING)
+    await updateSet(gramFramePage, setId, { showPin: false })
+    await gramFramePage.page.waitForTimeout(100)
+
+    // No lines are drawn, so the label/symbol stack is the whole feature.
+    expect(await gramFramePage.page.locator(
+      `.gram-frame-harmonic-line[data-harmonic-set-id="${setId}"]`
+    ).count()).toBe(0)
+
+    expect(await probeAt(gramFramePage, labelSelector(setId, CENTRE_HARMONIC))).toBe(setId)
+  })
+
+  test('with the pin hidden, the blank span below the label does not grab the set', async ({ gramFramePage }) => {
+    const setId = await gramFramePage.addHarmonicSet(ANCHOR_TIME, SPACING)
+    await gramFramePage.page.waitForTimeout(100)
+
+    // The anchor time is the vertical centre of the pin line — and the only
+    // place a pin-less set used to be grabbable, well below its digits.
+    const probe = () => probeAtData(gramFramePage, CENTRE_HARMONIC * SPACING, ANCHOR_TIME)
+
+    // While the pin is drawn, that point is on the line and grabs the set...
+    expect(await probe()).toBe(setId)
+
+    // ...once the pin is hidden it is blank space, and grabs nothing.
+    await updateSet(gramFramePage, setId, { showPin: false })
+    await gramFramePage.page.waitForTimeout(100)
+    expect(await probe()).toBeNull()
+  })
+
+  test('the stack and the line meet with no dead gap between them', async ({ gramFramePage }) => {
+    const setId = await gramFramePage.addHarmonicSet(ANCHOR_TIME, SPACING)
+    await gramFramePage.page.waitForTimeout(100)
+
+    // Just below the digits is where the symbol sits and the line begins.
+    expect(await probeAt(gramFramePage, labelSelector(setId, CENTRE_HARMONIC), 6)).toBe(setId)
+  })
+
+  test('empty space well above the stack does not grab the set', async ({ gramFramePage }) => {
+    const setId = await gramFramePage.addHarmonicSet(ANCHOR_TIME, SPACING)
+    await gramFramePage.page.waitForTimeout(100)
+
+    expect(await probeAt(gramFramePage, labelSelector(setId, CENTRE_HARMONIC), -60)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Problem

Selecting/dragging an existing harmonic set only worked over the pin **line's** vertical span (a fixed-pixel height centred on the set's anchor time). Two consequences:

- The number label and symbol stacked **above** the line's top were dead space — pointing at the digits or the symbol gave no drag cursor and no selection.
- With the pin hidden (`showPin: false`), nothing is drawn where the line would be, yet that invisible span was still the *only* grab region. Analysts had to click in apparently blank space below the digits to select or drag the set.

## Change

`HarmonicsMode.findHarmonicSetAtFrequency()` now hit-tests exactly what is rendered:

- **The label/symbol stack is a grab region.** Its bounds come from the same `calculateLabelStackPositions()` layout the renderer uses, so it tracks the drawn stack — including the downward nudge applied near the image's top edge — and its bottom is clamped to the line's top so there is no dead gap between the two regions. Only the thinned subset of harmonics that actually carries a label/symbol is included.
- **The line's span is a grab region only when the pin is drawn.** A pin-less set is grabbed by its digits and symbol alone; the empty span below them is empty to the mouse too.

Horizontally the stack uses SVG pixels (the wider of the symbol mark and the estimated label width) rather than the frequency tolerance, so both a `cross` set's digits and a "Large symbols" set's mark are fully covered.

New helpers on `HarmonicsMode`: `calculateLabelStackBounds()`, `labelStackHalfWidth()`, plus a `LABEL_CHAR_WIDTH_RATIO` constant.

## Tests

New `tests/harmonic-hotspot.spec.js` (7 tests) probes the hit-test at the centre of the actually-rendered elements, converted back to data coordinates:

- the number label grabs its set
- the symbol grabs its set
- the pin line still grabs its set (regression)
- with the pin hidden, the label alone grabs the set
- with the pin hidden, the blank span at the anchor time grabs nothing
- the stack and the line meet with no dead gap
- empty space well above the stack grabs nothing

Four of these fail on `main` and pass with the change.

`yarn typecheck` clean. Full suite: 212 passed, 6 failed — the same 6 failures are present on an unmodified tree (`analysis-mode`, `doppler-mode`, `harmonics-mode` "state consistency" and three `mode-integration` cases), so they are pre-existing and unrelated.

---
_Generated by [Claude Code](https://claude.ai/code/session_018St5abtGEeiM9c7H27iZx6)_