### PR TITLE
Add SessionStart hook so web sessions can actually run the test suite

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# SessionStart hook for Claude Code on the web.
+#
+# Prepares a freshly-cloned container so that `yarn test` and `yarn typecheck`
+# work straight away:
+#
+#   1. Installs node_modules (a fresh clone has none).
+#   2. Downloads the Playwright browser build that the pinned @playwright/test
+#      actually asks for.
+#
+# Step 2 is the important one. The web container pre-seeds
+# PLAYWRIGHT_BROWSERS_PATH (/opt/pw-browsers) with whatever Chromium build was
+# current when the image was baked. When that build number differs from the one
+# the repo's pinned Playwright expects, every browser test dies at launch with
+#
+#   Error: browserType.launch: Executable doesn't exist at
+#   /opt/pw-browsers/chromium_headless_shell-<N>/chrome-linux/headless_shell
+#
+# All 200+ tests fail identically, which reads like a broken main branch rather
+# than a broken environment. `playwright install` is version-aware and idempotent:
+# it fetches the expected build if missing and is a no-op once present.
+
+set -euo pipefail
+
+# Local checkouts manage their own toolchain; this is a web-container fix only.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$(dirname "$0")/../..}"
+
+echo "[session-start] Installing node modules..."
+yarn install --frozen-lockfile
+
+echo "[session-start] Ensuring the pinned Playwright Chromium build is present..."
+if ! npx playwright install chromium; then
+  echo "[session-start] ERROR: could not provision Chromium for Playwright." >&2
+  echo "[session-start] Browser tests will fail at launch until this is resolved." >&2
+  echo "[session-start] PLAYWRIGHT_BROWSERS_PATH=${PLAYWRIGHT_BROWSERS_PATH:-<unset>}" >&2
+  exit 1
+fi
+
+echo "[session-start] Ready: yarn typecheck and yarn test should both run."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Background

Feature-branch sessions have repeatedly reported "pre-existing test failures on `main`". I checked, and **`main` is not broken**:

| Check on `main` @ `66fea4c` | Result |
|---|---|
| `yarn test` | **211 passed, 0 failed** |
| `yarn typecheck` | Clean |
| Actions `Tests` workflow | `success` on all 15 most recent pushes to `main` |

## The actual cause

A fresh web container has no `node_modules`, and its pre-seeded `PLAYWRIGHT_BROWSERS_PATH` (`/opt/pw-browsers`) holds whatever Chromium build was current when the image was baked — currently build **1194**. The repo pins `@playwright/test@^1.54.1`, which resolves build **1181**. Nothing bridges the two, so every browser test dies before executing:

```
Error: browserType.launch: Executable doesn't exist at
/opt/pw-browsers/chromium_headless_shell-1181/chrome-linux/headless_shell
```

That produces **202 failed / 9 passed** — the 9 survivors being `harmonic-sampling-unit.spec.js`, the only tests that never open a page. A wall of 202 identical failures reads like a broken branch, so sessions report it as pre-existing breakage and discount their own test results.

CI never hits this because `test.yml` runs `npx playwright install --with-deps chromium`, which fetches the matching build.

## The change

Adds `.claude/hooks/session-start.sh` plus `.claude/settings.json` registering it as a `SessionStart` hook. The script:

1. Runs `yarn install --frozen-lockfile`.
2. Runs `npx playwright install chromium`.

`playwright install` is version-aware and idempotent — it fetches whatever build the pinned Playwright asks for and no-ops once present. That means this **self-corrects on future Playwright bumps** rather than hard-coding a second version number to keep in sync.

The script is guarded on `CLAUDE_CODE_REMOTE`, so local checkouts exit 0 immediately and keep managing their own toolchain.

## Validation

Run from a genuinely clean state — `node_modules` deleted and the matching browser build removed from `/opt/pw-browsers`:

- ✅ Hook exits 0 and provisions both deps and Chromium 139.0.7258.5 (build 1181)
- ✅ `yarn typecheck` — clean
- ✅ `npx playwright test tests/basic-functionality.spec.js` — 5/5 passed
- ✅ Re-run is a fast no-op (`yarn` 0.16s, browser install silent) — idempotent
- ✅ With `CLAUDE_CODE_REMOTE` unset, exits 0 silently

No application code is touched; the diff is confined to `.claude/`.

## Note

This only takes effect for sessions started **after** it lands on the default branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsNJcTJoXSriCbkAtAxiVr)_