### PR TITLE
Show a loading placeholder instead of the raw config table

### DIFF
--- a/docs/HTML-Integration-Guide.md
+++ b/docs/HTML-Integration-Guide.md
@@ -36,6 +36,12 @@ The standalone bundle includes CSS inlined automatically — no separate stylesh
 
 On `DOMContentLoaded`, GramFrame scans the page for all `<table class="gram-config">` elements and replaces each one with an interactive spectrogram viewer.
 
+### Before the Component Appears
+
+Until that scan runs, a config table is ordinary HTML, so on a cold load (large spectrogram, slow network) the browser paints it before GramFrame replaces it. The stylesheet dresses that gap up as a loading placeholder: the parameter rows are hidden, the spectrogram is dimmed back and a "Loading spectrogram" caption sits over it. The same caption then covers the component's image panel until the spectrogram's dimensions are known; if the image never loads, it is replaced with a plain failure message.
+
+For the placeholder to be in effect at first paint, the styling must reach the browser before the config table does — put the `<link rel="stylesheet">` (or, for the standalone bundle, the `<script>` that inlines the CSS) in `<head>` rather than at the end of `<body>`.
+
 ## Parameter Reference
 
 The configuration table uses a 2-column format: `parameter | value`.

--- a/preview-student.html
+++ b/preview-student.html
@@ -12,6 +12,7 @@
         .nav { margin-bottom: 15px; font-size: 14px; }
         .nav a { color: #1a73e8; }
     </style>
+    <script src="./gramframe.bundle.js"></script>
 </head>
 <body>
     <h1>GramFrame Student Demo <span class="badge">sessionStorage</span></h1>
@@ -46,6 +47,5 @@
         </ol>
     </div>
 
-    <script src="./gramframe.bundle.js"></script>
 </body>
 </html>

--- a/preview-trainer.html
+++ b/preview-trainer.html
@@ -12,6 +12,7 @@
         .nav { margin-bottom: 15px; font-size: 14px; }
         .nav a { color: #1a73e8; }
     </style>
+    <script src="./gramframe.bundle.js"></script>
 </head>
 <body>
     <h1>GramFrame Trainer Demo <span class="badge">localStorage</span></h1>
@@ -51,6 +52,5 @@
         </ol>
     </div>
 
-    <script src="./gramframe.bundle.js"></script>
 </body>
 </html>

--- a/src/api/GramFrameAPI.js
+++ b/src/api/GramFrameAPI.js
@@ -274,6 +274,10 @@ export function createGramFrameAPI(GramFrame) {
      */
     _addErrorIndicator(table, errorMsg) {
       try {
+        // The table stays on the page next to the error, so drop the
+        // pre-conversion placeholder styling and let its config show plainly
+        table.classList.add('gram-frame-config-error')
+
         // Create error overlay
         const errorDiv = document.createElement('div')
         errorDiv.className = 'gramframe-error-indicator'

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -32,10 +32,13 @@ export function getRenderDimensions(instance) {
  * @returns {TableElements} Object containing all created DOM elements
  */
 export function createComponentStructure(instance) {
-  // Create a container to replace the table
+  // Create a container to replace the table. It starts in the loading state:
+  // the SVG has no dimensions until the spectrogram's natural size is known, so
+  // the panel would otherwise be an unexplained empty black rectangle until the
+  // image arrives. setupSpectrogramImage() clears the class on load.
   instance.container = document.createElement('div')
-  instance.container.className = 'gram-frame-container'
-  
+  instance.container.className = 'gram-frame-container gram-frame-loading'
+
   // Create table structure for proper resizing
   instance.table = document.createElement('div')
   instance.table.className = 'gram-frame-table'
@@ -147,6 +150,9 @@ export function setupSpectrogramImage(instance, imageUrl) {
   // Load image to get natural dimensions
   const tempImg = new Image()
   tempImg.onload = function() {
+    // Dimensions are known, so the panel is about to render for real
+    instance.container.classList.remove('gram-frame-loading')
+
     // Get original dimensions
     let imageWidth = tempImg.naturalWidth
     let imageHeight = tempImg.naturalHeight
@@ -181,6 +187,13 @@ export function setupSpectrogramImage(instance, imageUrl) {
 
     // Notify listeners of updated dimensions
     notifyStateListeners(instance.state, instance.stateListeners)
+  }
+  tempImg.onerror = function() {
+    // Without dimensions nothing can be rendered, so replace the loading
+    // caption with a failure one instead of leaving it spinning forever
+    console.error(`GramFrame: Failed to load spectrogram image: ${imageUrl}`)
+    instance.container.classList.remove('gram-frame-loading')
+    instance.container.classList.add('gram-frame-image-error')
   }
   tempImg.src = imageUrl
 }

--- a/src/gramframe.css
+++ b/src/gramframe.css
@@ -2,6 +2,90 @@
  * GramFrame Component Styles - Military/Industrial Theme
  */
 
+/* ---------------------------------------------------------------------------
+ * Pre-conversion placeholder
+ *
+ * A `table.gram-config` is ordinary HTML until GramFrame replaces it, so on a
+ * cold load (large spectrogram, slow network, unbundled dev modules) the raw
+ * table is painted first: a stretched image followed by the time/freq parameter
+ * rows in whatever table styling the host page uses. These rules dress that
+ * intermediate state as a loading placeholder in the component's own dark
+ * styling - the parameter rows are hidden, the image is dimmed back, and a
+ * "Loading spectrogram" caption sits over the top. They stop applying the
+ * moment the table is swapped for .gram-frame-container.
+ *
+ * Selectors are deliberately more specific than a bare `table.gram-config td`
+ * so host-page table styling (borders, padding, stretched images) does not show
+ * through the placeholder.
+ * ------------------------------------------------------------------------- */
+table.gram-config {
+  border-collapse: collapse;
+  background: linear-gradient(135deg, #2a2a2a 0%, #1a1a1a 50%, #0f0f0f 100%);
+  border: 3px solid #444;
+  border-radius: 8px;
+  box-shadow:
+    inset 0 2px 4px rgba(255,255,255,0.1),
+    inset 0 -2px 4px rgba(0,0,0,0.3),
+    0 4px 8px rgba(0,0,0,0.5);
+}
+
+/* Per the config format, the first row holds the image and every later row is a
+   parameter definition - configuration, not content, so hide those rows */
+table.gram-config tr:not(:first-child) {
+  display: none;
+}
+
+table.gram-config tr:first-child td {
+  position: relative;
+  padding: 15px;
+  border: 0;
+  background: none;
+}
+
+table.gram-config tr:first-child img {
+  display: block;
+  width: auto;
+  max-width: 100%;
+  height: auto;
+  opacity: 0.25;
+}
+
+table.gram-config tr:first-child td::after {
+  content: 'Loading spectrogram';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  font-family: 'Courier New', monospace;
+  font-size: 14px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: #00ff00;
+  text-shadow: 0 0 6px rgba(0, 255, 0, 0.6);
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+/* Initialisation failed: the table is kept in place beside the error message,
+   so drop the placeholder styling and show the config as plain content again */
+table.gram-config.gram-frame-config-error {
+  background: none;
+  border: 0;
+  box-shadow: none;
+}
+
+table.gram-config.gram-frame-config-error tr:not(:first-child) {
+  display: table-row;
+}
+
+table.gram-config.gram-frame-config-error tr:first-child img {
+  opacity: 1;
+}
+
+table.gram-config.gram-frame-config-error tr:first-child td::after {
+  content: none;
+}
+
 /* Container that replaces the config table */
 .gram-frame-container {
   position: relative;
@@ -74,6 +158,38 @@
   border: 1px solid #666;
   border-radius: 4px;
   pointer-events: none;
+}
+
+/* The SVG has no size until the spectrogram's natural dimensions are known, so
+   the panel is an empty black rectangle between the table being replaced and
+   the image arriving. Caption that gap, and say so plainly if the image never
+   arrives, rather than leaving the analyst looking at a silent black box. */
+.gram-frame-container.gram-frame-loading .gram-frame-main-panel,
+.gram-frame-container.gram-frame-image-error .gram-frame-main-panel {
+  min-height: 120px;
+}
+
+.gram-frame-container.gram-frame-loading .gram-frame-main-panel::after,
+.gram-frame-container.gram-frame-image-error .gram-frame-main-panel::after {
+  content: 'Loading spectrogram';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  font-family: 'Courier New', monospace;
+  font-size: 14px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: #00ff00;
+  text-shadow: 0 0 6px rgba(0, 255, 0, 0.6);
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.gram-frame-container.gram-frame-image-error .gram-frame-main-panel::after {
+  content: 'Spectrogram image could not be loaded';
+  color: #ff6b6b;
+  text-shadow: none;
 }
 
 /* Expand/collapse image toggle — floats at the top-left of the image region,


### PR DESCRIPTION
## Problem

On first load of a demo page there are two visually rough phases before the component is interactive:

1. **Raw config table.** A `table.gram-config` is ordinary HTML until GramFrame replaces it, so the browser paints it first — spectrogram stretched to the container width, followed by the `time-start` / `time-end` / `freq-start` / `freq-end` rows in whatever table styling the host page uses. On the trainer debug page that's ~1.3s in dev.
2. **Empty image panel.** After the swap, the SVG has no dimensions until the spectrogram's natural size is known, so the main panel is a silent black rectangle for the rest of the image load — and stays that way forever if the image never arrives.

## Changes

- **`src/gramframe.css`** — an unconverted `table.gram-config` now renders as a loading placeholder in the component's own dark styling: parameter rows hidden, image shown at natural size and dimmed back, `LOADING SPECTROGRAM` caption over the top. Selectors are deliberately more specific than a bare `table.gram-config td` so host-page borders, padding and stretched images don't show through.
- **Loading / failure state on the component** — the same caption covers the main panel while the image loads (`gram-frame-loading`), replaced by a red `SPECTROGRAM IMAGE COULD NOT BE LOADED` if the image errors (`gram-frame-image-error`) instead of an unexplained black box.
- **`src/components/table.js`** — container is created in the loading state; `setupSpectrogramImage()` clears it on load and switches it to the error state (plus a console error) on failure.
- **`src/api/GramFrameAPI.js`** — a table whose initialisation failed gets `gram-frame-config-error`, dropping the placeholder styling so its config stays readable next to the error indicator.
- **`preview-trainer.html` / `preview-student.html`** — bundle `<script>` moved into `<head>`; the placeholder only helps if the styling reaches the browser before the config table does. Documented in the integration guide.

## Scope note

This removes the ugliness, not the delay itself. The ~1.3s gap on the debug pages is Vite serving ~50 separate modules in dev; the production standalone build is a single bundle, so that part doesn't reproduce in the field.

## Testing

- `yarn typecheck` — clean
- `yarn test` — 218/218 passing
- Manually verified against a live dev server: placeholder state, image-pending state, image-failure state and normal render.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpTMNiXR3UxnuzcKYbSmYj)_