### PR TITLE
chore(release): bump version to 0.1.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spectro-component",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "type": "module",
   "scripts": {
     "generate-version": "node scripts/generate-version.js",


### PR DESCRIPTION
Prepares the v0.1.14 release by bumping `package.json` from `0.1.13` to `0.1.14`. This is the only change — `src/utils/version.js` keeps its `DEV` placeholder, which `yarn generate-version` stamps during the build/test/release steps.

Once this merges, pushing the `v0.1.14` tag to `main` triggers `.github/workflows/release.yml`, which typechecks, builds the standalone bundle, runs the tests, and publishes the GitHub release with `gramframe-0.1.14.zip`.

## What has landed since v0.1.13

73 commits, headline items:

- Harmonic pins: symbols on pins, pin sampling/cap for dense sets, pixel-sized pins that survive zoom, haloed labels, visibility toggle
- Markers/harmonics: in-place reformatting (colour + symbol) with a `cross` symbol-less default, selection cleared on mode switch, harmonic sets grabbable anywhere they are drawn
- Navigation: mouse-wheel pan and zoom, start in Pan mode, consolidated wheel guidance
- Persistence: browser-storage annotations with a 24-hour student expiry and trainer permanence
- UI: fixed-height scrolling markers/harmonics tables, loading placeholder instead of the raw config table, legacy-browser compatibility warning
- Infra: version stamped before build and test, SessionStart hook for web sessions

## Verification

- `yarn typecheck` — clean
- `yarn build:standalone` — 282.96 kB bundle, above the workflow's 100 kB floor
- `yarn test` — 218 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqHingUZnq8BrhJJVgekre)_