### PR TITLE
chore(release): bump version to 0.1.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spectro-component",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "type": "module",
   "scripts": {
     "generate-version": "node scripts/generate-version.js",


### PR DESCRIPTION
Bumps `package.json` from `0.1.14` to `0.1.15` so that `v0.1.15` can be tagged and released.

## Why

The v0.1.14 release never got its build asset. [Run 30628687592](https://github.com/DeepBlueCLtd/GramFrame/actions/runs/30628687592) built and zipped the bundle fine, then failed at the final step:

```
🚀 Creating GitHub release...
a release with the same tag name already exists: v0.1.14
##[error]Process completed with exit code 1
```

A release for the tag had been created in the web UI beforehand, so `gh release create` refused and `gramframe-0.1.14.zip` was never uploaded. The [v0.1.14 release](https://github.com/DeepBlueCLtd/GramFrame/releases/tag/v0.1.14) consequently has zero assets — the only download offered is GitHub's auto-generated source archive, `GramFrame-0.1.14.zip` at 5.6 MB, versus the 516 KB build asset people expect. That size difference is what prompted this investigation; it is not bundle bloat. A local `build:standalone` on this commit produces a 283 KB `gramframe.bundle.js`, in line with previous releases.

## Why a version bump is required

`release.yml` does not bump `package.json` — it only reads and verifies it. The "Update version for release" step runs `generate-version` (which stamps `src/utils/version.js` from `package.json`) and then asserts the result equals the version parsed from the tag, aborting on mismatch. Tagging `v0.1.15` against `package.json@0.1.14` would fail that guard.

## Scope

`main` is currently at the exact commit `v0.1.14` points to (`a27d884`), so no code has changed between the two versions. 0.1.15 re-releases identical code solely to produce a working artifact.

## Release procedure after merging

Tag the merge commit and push the tag **without** creating a release in the web UI first — the workflow creates the release itself:

```bash
git checkout main && git pull
git tag v0.1.15
git push origin v0.1.15
```

Expect roughly four minutes before the asset appears.

## Not included

Two follow-ups discussed but deliberately left out to keep this release-blocking change minimal:

- making the final step idempotent (`gh release create ... || gh release upload "$TAG" --clobber ...`) so a UI-created release no longer breaks the run
- adding a `workflow_dispatch` trigger with a tag input, which would allow re-running the workflow against `v0.1.14` to backfill its missing asset

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMMJYyix43DcuP51i2FMKp)_