### PR TITLE
docs(166): implementation plan for Phase 2 consolidation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,8 +210,11 @@ There is no visual/screenshot regression testing — see
 - N/A — purely presentational; no persisted data or new state (158-harmonic-pin-sampling)
 - JavaScript ES2020+, JSDoc-typed (no TS compilation) + None at runtime (zero runtime deps); Vite for build (161-reformat-markers-harmonics)
 - Browser Web Storage — additive `symbol` field on markers; `cross` (symbol-less) default; no schema bump (161-reformat-markers-harmonics)
+- JavaScript ES2020+, JSDoc-typed, no TypeScript compilation + None at runtime (zero runtime deps); Vite 5 for build (166-consolidation)
+- Unchanged — Web Storage (`localStorage` trainer / `sessionStorage` student) (166-consolidation)
 
 ## Recent Changes
+- 166-consolidation: Planned Phase 2 consolidation — one coordinate pipeline, one drag engine, batched notifications, one diffing table, deterministic tests
 - 165-quick-fixes: Truthful published state and loud failures, dead-code sweep, docs corrected against the code
 - 161-reformat-markers-harmonics: Added a `cross` (symbol-less) default style and in-place restyling of selected markers/harmonic sets (colour + symbol)
 - 154-enrich-docs: Added Markdown documentation (no code changes) + N/A (documentation-only feature)

--- a/specs/166-consolidation/contracts/coordinates.md
+++ b/specs/166-consolidation/contracts/coordinates.md
@@ -1,0 +1,94 @@
+# Contract — Canonical coordinate module
+
+**Module**: `src/utils/coordinates.js` (constitution Principle I names this path)
+**Replaces**: `src/utils/coordinateTransformations.js`, the private
+`dataToSVGCoordinates` / `svgToDataCoordinates` in `src/core/keyboardControl.js`,
+and the inline `screenToDataWithZoom` in `src/core/events.js`.
+
+## Invariants
+
+- **I1** Every screen ↔ SVG ↔ image ↔ data conversion in `src/` routes through
+  this module (FR-002). No caller re-derives a transform inline.
+- **I2** The module is zoom-, expand-, render-size- and margin-aware (FR-003).
+  Callers do **not** compensate externally — in particular, `keyboardControl.js`
+  stops dividing its increment by the zoom level.
+- **I3** Where a spectrogram image element is supplied, its live `x`/`y`/
+  `width`/`height` attributes are the source of truth (they already encode
+  expand × zoom). `imageDetails.renderWidth/renderHeight`, defaulting to
+  `naturalWidth/naturalHeight`, are the fallback when no element is present.
+- **I4** `rate` is a frequency divider applied on the data side only; SVG and
+  image space are rate-free.
+- **I5** Bounds handling is explicit and separate from transformation. Transform
+  functions never silently clamp *and* never return `null`; callers that need a
+  bounds decision call the predicate.
+
+## Surface
+
+```js
+/** Viewport bundle every transform takes. */
+/**
+ * @typedef {Object} Viewport
+ * @property {AxesMargins} margins
+ * @property {ImageDetails} imageDetails
+ * @property {Config} config
+ * @property {number} rate
+ */
+
+/** Screen (client) point relative to the SVG element's bounding box. */
+screenToSVG(screenX, screenY, svg) -> SVGCoordinates
+
+/** SVG point -> image-relative point, in render-pixel space. */
+svgToImage(svgX, svgY, viewport, spectrogramImage?) -> ImageCoordinates
+
+/** Image-relative point -> data. Rate applied here. */
+imageToData(imageX, imageY, viewport) -> DataCoordinates
+
+/** Data -> SVG. Inverse of screenToSVG ∘ svgToImage ∘ imageToData. */
+dataToSVG(dataPoint, viewport, spectrogramImage?) -> SVGCoordinates
+
+/** Convenience composition used by pointer and wheel handlers. */
+screenToData(clientX, clientY, svg, viewport, spectrogramImage?)
+  -> { data: DataCoordinates, image: ImageCoordinates, svg: SVGCoordinates }
+
+/** Live image bounds in SVG space (element attributes when present). */
+getImageBounds(viewport, spectrogramImage?) -> { left, top, width, height }
+
+/** Bounds predicate — the only place "is this point over the image" is decided. */
+isWithinImage(svgPoint, viewport, spectrogramImage?) -> boolean
+```
+
+## Behavioural equivalences the pin grid asserts (AS-2.1)
+
+For every cell of the grid in research.md §R2 — zoom ∈ {1, 1.5, 2, 4} ×
+expand ∈ {off, on} × render size ∈ {natural, 2×, non-uniform} × margins ∈
+{default, zero, asymmetric} × rate ∈ {1, 2}:
+
+| # | Assertion | Tolerance |
+|---|---|---|
+| E1 | `screenToData` agrees with today's `events.js:screenToDataWithZoom` for in-bounds points | 1e-9 relative |
+| E2 | `dataToSVG` agrees with today's `coordinateTransformations.js:dataToSVG` | 1e-9 relative |
+| E3 | `dataToSVG` agrees with today's `keyboardControl.js:dataToSVGCoordinates` **at zoom 1, expand off** — the conditions under which the keyboard path is currently correct | 1e-9 relative |
+| E4 | `imageToData` agrees with today's `coordinates.js:imageToDataCoordinates` | 1e-9 relative |
+| E5 | `dataToSVG(imageToData(p)) ≈ p` round-trips for in-bounds points | 1e-9 relative |
+| E6 | `isWithinImage` agrees with the bounds predicate inside `screenToDataWithZoom` | exact |
+
+E3 is deliberately narrower than E1/E2/E4: the keyboard path is not
+zoom/expand-aware and compensates externally (GF-01ᴿ). Outside zoom 1 / expand
+off the grid records the *rendered-pixels-per-keypress* equivalence instead —
+one keypress must move a marker the same number of rendered pixels before and
+after consolidation, which is what the user actually experiences and what
+`tests/keyboard-movement.spec.js` asserts in a real browser.
+
+If any grid cell fails **before** consolidation, the pin is not faithful:
+triage the divergence as a bug in its own issue and do not proceed to deletion
+(spec Assumptions, AS-2.1).
+
+## Post-consolidation gate
+
+- Vitest grid green (now run against the canonical module only).
+- `tests/keyboard-movement.spec.js` green.
+- Full Playwright suite green with **zero spec diffs** (SC-002).
+- `yarn hygiene`: madge cycle count not increased (AS-2.3); baselines lowered
+  where the deletions allow.
+- Mouse, keyboard, wheel-zoom and expand report identical data coordinates for
+  the same physical point (AS-2.4, SC-003).

--- a/specs/166-consolidation/contracts/diffing-table.md
+++ b/specs/166-consolidation/contracts/diffing-table.md
@@ -1,0 +1,56 @@
+# Contract — Shared diffing table
+
+**Module**: `src/components/DiffingTable.js` (new)
+**Replaces**: the row-diffing engine in `AnalysisMode.js:577-717` (markers
+table) and `HarmonicPanel.js:62-232` (harmonics panel), including the
+fixed-height scroll wrapper duplicated at `AnalysisMode.js:373-377` /
+`HarmonicPanel.js:32-36`.
+
+## Division of responsibility
+
+**The component owns** (the part that is provably identical today):
+
+- fixed-height scroll wrapper and header construction
+- update-in-place for rows whose key is unchanged
+- rebuild-from-index when keys diverge
+- trailing-row removal when the list shrinks
+- click-to-select row handling and selected-row styling
+- delete-button rendering and click propagation
+
+**The consumer owns** (the part that legitimately differs):
+
+- column labels and order
+- cell content and formatting
+- row identity (`rowKey`)
+- what selection and deletion *mean*
+
+## Surface
+
+```js
+/**
+ * @param {HTMLElement} container
+ * @param {TableSpec} spec   // see data-model.md §3
+ * @returns {{ update(rows: any[]): void, destroy(): void, element: HTMLTableElement }}
+ */
+export function createDiffingTable(container, spec)
+```
+
+`update(rows)` is idempotent and diff-based: calling it twice with equal input
+performs no DOM writes.
+
+## Invariants
+
+- **T1** One engine serves both tables (FR-009).
+- **T2** Rendered DOM structure — element tags, class names, row/cell order — is
+  unchanged for both tables, so existing specs and CSS selectors keep working
+  (AS-5.1).
+- **T3** A change to table *mechanism* is made in one module and appears in both
+  tables (AS-5.2). Demonstrated in the PR by making one such change (selected-row
+  styling) once.
+- **T4** No cell formatting lives in the component.
+
+## Gate
+
+Existing markers-table and harmonics-panel specs pass **unchanged** across add,
+update, remove, select and delete in both tables. `yarn hygiene` baselines
+lowered by the deletion where applicable; net lines removed (SC-006).

--- a/specs/166-consolidation/contracts/drag-engine.md
+++ b/specs/166-consolidation/contracts/drag-engine.md
@@ -1,0 +1,89 @@
+# Contract — Shared drag engine
+
+**Module**: `src/modes/shared/BaseDragHandler.js` (extended, not replaced)
+**Absorbs**: `PanMode`'s hand-rolled drag (`PanMode.js:17-21,57-134`), the
+Harmonics creation machine (`HarmonicsMode.js:202-210,255-261,551-599`), the
+Doppler placement machine (`DopplerMode.js:256-260,288-310,322-354`), and the
+middle-button wheel-pan on `instance._wheelPan` (`events.js:115-120,208-217,
+264-280,300-304,323-326`).
+
+## Invariants
+
+- **D1** All pointer-drag interactions run through this engine (FR-004). After
+  the port, `grep -rn 'mousedown\|mousemove\|mouseup' src/modes/` returns
+  matches only in the engine and the central `events.js` binding.
+- **D2** Drag state has exactly one authoritative owner — the engine's
+  `dragState` — and exactly one read-only projection for listeners
+  (`state.drag`, see data-model.md §2).
+- **D3** A mode subscribes by supplying a target resolver and lifecycle
+  callbacks. It never writes drag fields into `state` (AS-3.3).
+- **D4** At most one drag is active across all modes at any time.
+- **D5** Thresholds, cursor changes and completion semantics are preserved
+  exactly as they are today, per drag kind (AS-3.1).
+
+## Surface
+
+```js
+new BaseDragHandler(instance, {
+  /**
+   * Decide whether this mousedown starts a drag, and of what kind.
+   * Return null to decline (the event falls through to click handling).
+   * @param {DataCoordinates} position
+   * @param {MouseEvent} event
+   * @returns {DragTarget|null}
+   */
+  resolveTarget(position, event),
+
+  /** Called once, after the threshold is crossed. */
+  onDragStart(target, position),
+
+  /** Called per move, already frame-throttled by the dispatcher. */
+  onDragMove(target, position, delta),
+
+  /** Called on mouseup inside the surface. */
+  onDragEnd(target, position),
+
+  /** Called on mouseleave / Escape / mouseup outside — must restore prior state. */
+  onDragCancel(target),
+
+  /** Optional per-kind cursor; defaults to the mode's cursor. */
+  cursorFor(kind),
+})
+```
+
+### Drag kinds
+
+| Kind | Today's machine | Target | Notes |
+|---|---|---|---|
+| `move` | `BaseDragHandler` (analysis markers), Harmonics set drag | existing feature | already here |
+| `create` | Harmonics creation drag | new feature, id minted on start | resolver returns `id` of the provisionally-created set |
+| `place` | Doppler placement drag | doppler marker being placed | `tempFirst`/`previewEnd` stay on `state.doppler` |
+| `pan` | `PanMode` drag, `_wheelPan` | none (`id`/`type` null) | viewport pan; only meaningful at zoom > 1 |
+
+`pan` is the kind that most stretches the engine: it has no feature target and
+its `onDragMove` writes viewport state rather than feature state. The engine
+accommodates this by treating `DragTarget.id`/`.type` as nullable (D2 in
+data-model.md's validation rules) — it does not special-case the mode.
+
+### Middle-button pan
+
+The `_wheelPan` machine differs from `PanMode`'s only in its trigger
+(`event.button === 1`, with `preventDefault` to suppress browser autoscroll) and
+in being active in *every* mode. It becomes a `pan`-kind drag resolved centrally
+in the engine's mousedown path, ahead of the mode's resolver, so mode resolvers
+never see button-1 events.
+
+## Port order and gate
+
+Per the spec's assumption, one machine per PR, newest and least-covered last:
+
+1. Harmonics creation (`create`)
+2. Doppler placement (`place`)
+3. PanMode drag (`pan`)
+4. Middle-button wheel-pan (`pan`, central)
+
+Gate for each: the corresponding Playwright spec passes **unchanged** before and
+after the port (AS-3.1, Independent Test). Gate for the final PR: `state.drag`
+is the only broadcast drag record; `types.js` and the data/state guide updated in
+the same PR (AS-3.2, FR-010); the four in-repo test readers migrated
+(data-model.md §2).

--- a/specs/166-consolidation/contracts/notifications.md
+++ b/specs/166-consolidation/contracts/notifications.md
@@ -1,0 +1,84 @@
+# Contract — State notification dispatcher
+
+**Module**: `src/core/state.js`
+**Replaces**: 41 direct `notifyStateListeners` references across 12 files.
+
+## Invariants
+
+- **N1** Exactly one dispatch choke-point. `notifyStateListeners` is no longer
+  exported to modes; an ESLint `no-restricted-imports` rule fails `yarn lint` if
+  a mode imports it (FR-005, AS-4.4).
+- **N2** At most one deep clone per dispatch, and none at all when
+  `listeners.length === 0` (FR-005). The constitution's "state MUST be
+  deep-copied before passing to listeners" is preserved — the copy moves, it
+  does not disappear.
+- **N3** One settled gesture ⇒ one notification (AS-4.1).
+- **N4** High-frequency paths never notify more often than animation-frame
+  cadence (FR-006, AS-4.2).
+- **N5** No listener ever observes intermediate, half-updated state (SC-004).
+- **N6** No notification is lost on teardown — `flushDispatch` runs
+  synchronously on destroy.
+
+## Surface
+
+```js
+/**
+ * Request a notification. Coalesces; safe to call from anywhere in src/.
+ * @param {GramFrame} instance
+ * @param {DispatchOptions} [options]
+ */
+export function dispatch(instance, options)
+
+/**
+ * Deliver any pending notification synchronously. Teardown/destroy only.
+ * @param {GramFrame} instance
+ */
+export function flushDispatch(instance)
+```
+
+### Coalescing tiers
+
+| Tier | Trigger | Callers |
+|---|---|---|
+| microtask (default) | `queueMicrotask` | mode switch, marker add/delete, colour/symbol change, config parse, rate change, storage load |
+| frame (`{frame: true}`) | `requestAnimationFrame` | mousemove readouts, wheel zoom/pan (`viewport.js:setZoom`), drag-move frames |
+
+**Priority rule**: a pending frame-tier dispatch is *upgraded* to microtask tier
+by any subsequent default-tier dispatch, never downgraded. A mode switch during
+a drag is therefore never delayed to the next frame.
+
+## Observable timing change
+
+This is the only listener-visible behaviour change in the phase. The
+compatibility bar (spec Assumptions) is **same-frame final-state equivalence**:
+after the frame settles, the state a listener has seen is identical to today's.
+
+Concretely, `GramFramePage.getState()` reads the debug page's state display,
+which is written by a state listener. Once dispatch is asynchronous, any spec
+that performs an action and immediately reads that display is racing the
+dispatcher. This is why Story 1 (state-based waits) is a hard prerequisite for
+Story 4 — see plan.md §Sequencing.
+
+DOM rendering is **not** batched. Cursor overlays, LED readouts, markers table
+and harmonics panel continue to update synchronously within their handlers.
+Only *listener notification* is coalesced.
+
+## Storage listener gate (AS-4.3)
+
+The annotation-save listener registered at `src/main.js:447` currently
+re-serializes on every notification, including pure cursor moves. It gains an
+early return keyed on an annotation-relevance signature (marker count,
+harmonic-set count, doppler marker identity, and a mutation counter bumped by
+the annotation-mutating paths). Cursor moves, mode switches and zoom changes no
+longer trigger a save.
+
+## Verification
+
+| Assertion | How |
+|---|---|
+| AS-4.1 — one mode switch ⇒ exactly 1 notification | Playwright spec with a counting listener registered via the public API |
+| AS-4.2 — 60-event mousemove/wheel burst ⇒ count bounded by elapsed frames, not events | same spec; assert `count <= frames + 1` and final state matches the unbatched value |
+| AS-4.3 — save only on annotation-relevant change | spy on `saveAnnotations` via storage writes; move the cursor 20× ⇒ zero writes |
+| AS-4.4 — no bypass | `yarn lint` fails on a mode importing `notifyStateListeners` |
+| N2 — single clone, skipped with no listeners | Vitest unit test on the dispatcher with a clone counter |
+| N6 / HMR | existing HMR listener-preservation coverage plus an explicit destroy-flush assertion |

--- a/specs/166-consolidation/data-model.md
+++ b/specs/166-consolidation/data-model.md
@@ -1,0 +1,159 @@
+# Phase 1 Data Model — Spec 166 Consolidation
+
+This feature adds no persisted data and does not touch the storage schema. It
+changes one thing observable to state listeners: **drag bookkeeping collapses
+from three mirrored places into one read-only projection** (FR-004, FR-010,
+research.md §R4). Everything else here is internal structure.
+
+## 1. Drag state — before
+
+Three parallel records, all written by hand by the modes, all broadcast:
+
+| Location | Contributed by | Fields |
+|---|---|---|
+| `state.analysis` | `AnalysisMode` (`types.js:80-83`) | `isDragging`, `draggedMarkerId`, `dragStartPosition` |
+| `state.dragState` | `HarmonicsMode` initial state (`HarmonicsMode.js:1031`, `types.js:126-133`) | `isDragging`, `dragStartPosition`, `draggedHarmonicSetId`, `originalSpacing`, `originalAnchorTime`, `clickedHarmonicNumber`, `isCreatingNewHarmonicSet` |
+| `state.doppler` | `DopplerMode` (`types.js:18-22`) | `isDragging`, `draggedMarker`, `isPlacingMarkers`, `isPreviewDrag`, `previewEnd`, `tempFirst` |
+
+Authoritative truth already lives in `BaseDragHandler.dragState`
+(`BaseDragHandler.js:51-57`): `{ isDragging, draggedTargetId, draggedTargetType,
+dragStartPosition, originalData }`. The three records above are copies kept in
+sync by hand — the double bookkeeping GF-17 records. `PanMode` keeps a fourth,
+private, un-broadcast flag (`PanMode.js:17`), and `events.js` keeps a fifth on
+`instance._wheelPan`.
+
+## 2. Drag state — after
+
+A single projection, written only by the dispatcher path from the active
+handler, never by a mode:
+
+```js
+/**
+ * Read-only projection of the active drag, derived from the owning
+ * BaseDragHandler. Modes MUST NOT write this; it is rebuilt on each dispatch.
+ * @typedef {Object} DragProjection
+ * @property {boolean} active           - Whether a drag is in progress
+ * @property {DragKind|null} kind       - What kind of drag
+ * @property {ModeType|null} mode       - Mode that owns the drag
+ * @property {string|null} targetId     - Id of the dragged feature, if any
+ * @property {string|null} targetType   - 'marker' | 'harmonicSet' | 'dopplerMarker' | null
+ * @property {DataCoordinates|null} startPosition - Where the drag began, in data coordinates
+ */
+
+/**
+ * @typedef {'move'|'create'|'place'|'pan'} DragKind
+ */
+```
+
+`state.drag` is present at all times with `active: false` and null fields when
+idle, so listeners never have to null-check the container.
+
+### Field mapping
+
+| Old | New |
+|---|---|
+| `state.analysis.isDragging` | `state.drag.active && state.drag.mode === 'analysis'` |
+| `state.analysis.draggedMarkerId` | `state.drag.targetId` (when `targetType === 'marker'`) |
+| `state.analysis.dragStartPosition` | `state.drag.startPosition` |
+| `state.dragState.isDragging` | `state.drag.active && state.drag.kind === 'move'` |
+| `state.dragState.isCreatingNewHarmonicSet` | `state.drag.active && state.drag.kind === 'create'` |
+| `state.dragState.draggedHarmonicSetId` | `state.drag.targetId` |
+| `state.dragState.dragStartPosition` | `state.drag.startPosition` |
+| `state.dragState.originalSpacing` / `.originalAnchorTime` / `.clickedHarmonicNumber` | Handler-internal (`dragState.originalData`); **not** broadcast |
+| `state.doppler.isDragging` | `state.drag.active && state.drag.mode === 'doppler'` |
+| `state.doppler.draggedMarker` | `state.drag.targetId` |
+| `state.doppler.isPlacingMarkers` / `.isPreviewDrag` | `state.drag.kind === 'place'` |
+| `PanMode.isDragging` (private) | `state.drag.kind === 'pan'` |
+| `instance._wheelPan` (private) | `state.drag.kind === 'pan'` |
+
+`state.doppler.tempFirst` and `.previewEnd` are **not** drag bookkeeping — they
+are placement geometry the renderer needs. They stay on `state.doppler`.
+
+### Validation rules
+
+- `active === false` ⟹ every other field is `null`.
+- `active === true` ⟹ `kind` and `mode` are non-null.
+- `kind === 'pan'` ⟹ `targetId` and `targetType` are `null` (a pan drags the
+  viewport, not a feature).
+- At most one drag is active across all modes at any time — enforced by the
+  single owning handler, and asserted by `state-hygiene.spec.js`.
+
+### State transitions
+
+```
+idle ──mousedown on hit target──> active(kind, target)
+  ▲                                      │
+  │                                      ├─ mousemove ──> active (position updates, frame-throttled dispatch)
+  │                                      │
+  └── mouseup / mouseleave / Escape ─────┘
+```
+
+The threshold and cursor semantics of each transition are unchanged from the
+machine being ported (AS-3.1); only the owner changes.
+
+### Consumers to migrate (in PR 7)
+
+All in-repo readers are tests — there are no `src/`-external, `debug.html` or
+`sample/` readers (research.md §R4):
+
+- `tests/doppler-mode.spec.js:674,702` — `state.doppler.isDragging`
+- `tests/mode-integration.spec.js:320` — `state.harmonics?.dragState?.isDragging`
+- `tests/mode-integration.spec.js:321` — `state.doppler?.isDragging`
+- `tests/state-hygiene.spec.js:63` — the key list containing `'dragState'`
+
+`types.js` loses `DragState`'s broadcast role (it stays as the handler-internal
+type) and gains `DragProjection` + `DragKind`. `AnalysisState`, `DopplerState`
+and the `dragState` slot in the harmonics initial state lose the mirrored
+fields. The data/state documentation is updated in the same PR (FR-010).
+
+## 3. Non-state structures introduced
+
+These are internal shapes, not part of the broadcast state.
+
+### `DragTarget` (BaseDragHandler)
+
+Lets one engine serve move, create, place and pan drags. Returned by a mode's
+target resolver on mousedown; `null` means "not a drag".
+
+```js
+/**
+ * @typedef {Object} DragTarget
+ * @property {DragKind} kind
+ * @property {string|null} id          - Feature id for move/place; null for create/pan
+ * @property {string|null} type        - Feature type; null for pan
+ * @property {any} originalData        - Snapshot the mode needs to compute deltas
+ */
+```
+
+### `TableSpec` (DiffingTable)
+
+```js
+/**
+ * @typedef {Object} TableSpec
+ * @property {string[]} columns                 - Header labels, in order
+ * @property {(row: any, index: number) => string} rowKey  - Stable identity for diffing
+ * @property {(row: any, index: number) => (string|Node)[]} cells - Cell content per column
+ * @property {(key: string) => void} [onSelect] - Row click
+ * @property {(key: string) => void} [onDelete] - Delete-button click
+ * @property {(key: string) => boolean} [isSelected]
+ * @property {number} [maxHeightPx]             - Fixed-height scroll wrapper
+ */
+```
+
+### `DispatchOptions` (state dispatcher)
+
+```js
+/**
+ * @typedef {Object} DispatchOptions
+ * @property {boolean} [frame] - Coalesce at animation-frame cadence instead of
+ *                               microtask cadence. For mousemove/wheel/drag paths.
+ */
+```
+
+## 4. What does not change
+
+- The persisted annotation schema — no version bump, no migration.
+- `Config`, `ImageDetails` (including `renderWidth`/`renderHeight`),
+  `AnalysisMarker`, `HarmonicSet`, `CursorPosition`, `zoom`, `margins`,
+  `selection`.
+- Storage keys, TTL semantics, and trainer/student context detection.

--- a/specs/166-consolidation/plan.md
+++ b/specs/166-consolidation/plan.md
@@ -1,0 +1,171 @@
+# Implementation Plan: Phase 2 — Consolidating the Interest-Accruing Seams
+
+**Branch**: `166-consolidation` | **Date**: 2026-07-31 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/166-consolidation/spec.md`
+
+## Summary
+
+Five consolidations of duplicated machinery, each landing behind a
+behaviour-pinning test written **before** the duplicates are deleted:
+
+1. **Deterministic tests** — replace the 244 `waitForTimeout` calls with
+   state-based waits (page object and helpers first, then the four heaviest
+   specs), restore arrow-key movement coverage, drop CI `retries` to 0.
+2. **One coordinate pipeline** — collapse four parallel implementations onto a
+   single canonical module, pinned first by Vitest equivalence tests recorded
+   against all four live paths.
+3. **One drag engine** — port the five hand-rolled drag machines onto
+   `BaseDragHandler`, and replace the three drag-state mirrors with one
+   read-only projection.
+4. **Batched notifications** — route all 41 `notifyStateListeners` call sites
+   through a single dispatcher with microtask batching and frame-cadence
+   throttling for pointer/wheel paths; clone once per dispatch, only when
+   listeners exist.
+5. **One diffing table** — extract the row-diffing engine shared by the
+   markers table and the harmonics panel.
+
+The ordering is load-bearing, not cosmetic. Story 1 is a hard prerequisite for
+Stories 2–4: their entire safety argument is "the suite still passes", and
+Story 4 in particular changes *when* the debug page's state display updates —
+which is how `GramFramePage.getState()` reads state in every existing spec.
+
+## Technical Context
+
+**Language/Version**: JavaScript ES2020+, JSDoc-typed, no TypeScript compilation
+**Primary Dependencies**: None at runtime (zero runtime deps); Vite 5 for build
+**Storage**: Unchanged — Web Storage (`localStorage` trainer / `sessionStorage` student)
+**Testing**: Playwright 1.54 (e2e, `yarn test`); Vitest 4 (pure-JS unit lane, `yarn test:unit`)
+**Target Platform**: Modern evergreen browsers; WebKit smoke lane
+**Project Type**: Single-project browser component (library, global + module export)
+**Performance Goals**: Notifications bounded by animation-frame cadence under
+continuous mousemove/wheel/drag input; at most one deep state clone per dispatch
+**Constraints**: No behaviour change visible to end users; no new runtime
+dependencies; net-negative lines of code across the phase; hygiene baselines
+monotonically lowered (`circularDependencies` 11, `unusedExportModules` 5,
+`waitForTimeoutOccurrences` 244 today)
+**Scale/Scope**: ~14 source modules touched; 4 coordinate implementations → 1;
+5 drag machines → 1; 41 notify sites → 1 dispatcher; 2 table engines → 1;
+~24 spec files affected by the wait migration
+
+No NEEDS CLARIFICATION items remain — the one open question the spec deferred to
+plan stage (whether to keep the deprecated drag-state mirror fields for a
+release) is resolved in [research.md](./research.md) §R4.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+| Principle | Status | Notes |
+|---|---|---|
+| **I. SVG-First Rendering** | ⚠️ Tension — resolved | Principle I names `src/utils/coordinates.js` as *the* coordinate system. The spec's stated consolidation target is `coordinateTransformations.js`. Resolved by consolidating **into `src/utils/coordinates.js`** (constitutionally-named path) while adopting the *implementation* from `coordinateTransformations.js`, which is the more complete one. No constitutional amendment needed. See research.md §R1. Nothing moves to Canvas or absolutely-positioned DOM; SVG stays DOM-queryable. |
+| **II. Test-First (NON-NEGOTIABLE)** | ✅ Pass | FR-001 is strictly stronger than the principle: every consolidation lands behind a passing pin-test first. The constitution's "unit tests alone cannot catch coordinate regressions" is respected — the Vitest equivalence grid is the *pin*, and the Playwright arrow-key spec plus the full suite are the *gate*. `yarn typecheck` and `yarn test` gate every PR in the phase. |
+| **III. Modular Mode Architecture** | ✅ Pass, strengthened | Story 3 removes per-mode drag machinery in favour of the shared `BaseDragHandler`, so a new mode gains drag without touching existing modes (FR-004, AS-3.3). No new mode-to-mode dependencies; `ModeFactory` stays the single entry point. |
+| **IV. Declarative HTML Configuration** | ✅ Pass | Untouched. No change to `gram-config` parsing or auto-discovery. |
+| **Technical Constraints** | ⚠️ Tension — justified | "State MUST be deep-copied before passing to listeners" is preserved (the clone still happens; it happens *once per dispatch* rather than once per call site, and is skipped when no listener is registered — an unobservable optimisation). HMR listener preservation is explicitly re-tested after the dispatcher change. |
+| **Quality Gates** | ✅ Pass | `yarn typecheck`, `yarn test`, `yarn build` gate every PR; `yarn hygiene` and `yarn test:unit` additionally run. |
+
+**Gate result: PASS.** One naming tension (Principle I vs. the spec's assumed
+target module) is resolved in favour of the constitution. No violation requires
+justification in Complexity Tracking.
+
+**Post-Phase-1 re-check**: still PASS. The Phase 1 design introduces three new
+modules (`coordinates.js` absorbing the canonical transforms, a drag-target
+abstraction inside the existing `BaseDragHandler`, and `DiffingTable.js`) and
+deletes four; the net module count falls and no principle is weakened.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/166-consolidation/
+├── plan.md              # This file
+├── research.md          # Phase 0 — decisions R1..R7
+├── data-model.md        # Phase 1 — state-shape changes (drag projection)
+├── quickstart.md        # Phase 1 — how to run/verify each story
+├── contracts/
+│   ├── coordinates.md   # Canonical coordinate module contract
+│   ├── drag-engine.md   # BaseDragHandler contract
+│   ├── notifications.md # Dispatcher / batching contract
+│   └── diffing-table.md # Shared table component contract
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── core/
+│   ├── state.js                 # + single dispatch choke-point (Story 4)
+│   ├── events.js                # − inline screenToDataWithZoom (Story 2)
+│   │                            # − _wheelPan machine (Story 3)
+│   ├── keyboardControl.js       # − private dataToSVG/svgToData (Story 2)
+│   ├── viewport.js              # notify → dispatcher (Story 4)
+│   └── storage.js               # save gated on annotation-relevant change (Story 4)
+├── utils/
+│   ├── coordinates.js           # CANONICAL coordinate module (Story 2)
+│   └── coordinateTransformations.js   # DELETED, implementation absorbed
+├── modes/
+│   ├── shared/BaseDragHandler.js      # + create/pan drag kinds (Story 3)
+│   ├── pan/PanMode.js                 # − hand-rolled drag
+│   ├── harmonics/HarmonicsMode.js     # − creation drag machine
+│   ├── doppler/DopplerMode.js         # − placement drag machine
+│   └── analysis/AnalysisMode.js       # − markers-table engine (Story 5)
+├── components/
+│   ├── DiffingTable.js          # NEW shared row-diffing table (Story 5)
+│   └── HarmonicPanel.js         # − its copy of the table engine
+└── types.js                     # drag mirrors → one projection (Story 3)
+
+tests/
+├── helpers/
+│   ├── gram-frame-page.js       # state-based waits (Story 1)
+│   ├── interaction-helpers.js   # 15 waitForTimeout → 0
+│   └── mode-helpers.js          # 7 waitForTimeout → 0
+├── unit/
+│   ├── coordinate-equivalence.test.js   # NEW pin grid (Story 2)
+│   └── notification-batching.test.js    # NEW (Story 4)
+├── keyboard-movement.spec.js    # NEW, replaces the two .disabled specs
+└── keyboard-focus*.spec.js.disabled     # DELETED
+```
+
+**Structure Decision**: Single-project layout, unchanged. This feature adds no
+directories; it moves code between existing ones and deletes more than it adds
+(SC-006).
+
+## Sequencing & PR Breakdown
+
+Each row is one PR with its own green gate. FR-001 means the pin-test row always
+precedes the deletion row it protects.
+
+| # | Story | Content | Gate |
+|---|---|---|---|
+| 1 | S1 | Page object + `interaction-helpers` + `mode-helpers` → state-based waits (22 sites) | Suite 5× green, retries 0 locally |
+| 2 | S1 | Four heaviest specs (reformat 43, storage 30, pin-toggle 19, pin-sampling 16) | ratchet lowered to ≤ 136 |
+| 3 | S1 | Remaining specs to ≤ 20 justified residue; `retries: 0` in CI; delete `.disabled` specs; new `keyboard-movement.spec.js` asserting data-coordinate deltas | SC-001, SC-005, FR-008 |
+| 4 | S2 | Vitest equivalence grid against **all four live paths** (no source change) | Grid green ⇒ pin is faithful (AS-2.1) |
+| 5 | S2 | Canonical `coordinates.js`; delete the three duplicates; rewire callers | Grid + keyboard spec + full suite; baselines lowered |
+| 6 | S3 | `BaseDragHandler` gains create/pan drag kinds; port Harmonics creation + Doppler placement | Existing mode specs unchanged |
+| 7 | S3 | Port PanMode drag and the `_wheelPan` machine; collapse drag mirrors to one projection; update `types.js` + data guide | FR-004, FR-010 |
+| 8 | S4 | Single dispatcher + microtask batching; unexport direct notify from modes | Counting-listener spec: one mode switch → one notify |
+| 9 | S4 | Frame-cadence throttling on mousemove/wheel/drag; storage listener gated on annotation-relevant change | SC-004 |
+| 10 | S5 | Extract `DiffingTable.js`; adopt in markers table and harmonics panel | Existing table specs unchanged |
+
+**Hard dependency**: PRs 8–9 must not land before PR 3. `GramFramePage.getState()`
+reads the debug page's state display, which is written by a state listener — the
+moment notification becomes asynchronous, every `waitForTimeout`-based read of
+that display becomes a race. Story 1 is what makes Story 4 safe to attempt.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| The coordinate pin grid reveals the four paths already diverge | Spec's own escape hatch: majority behaviour wins, divergence is triaged as a bug in its own issue before PR 5 proceeds (AS-2.1) |
+| Throttling breaks specs that read state immediately after an action | Sequencing (PR 3 before PR 8); dispatcher exposes a synchronous flush used at teardown; DOM rendering stays synchronous — only *listener notification* is batched |
+| Removing drag mirrors breaks in-repo readers | Four known readers, all in `tests/` (`doppler-mode.spec.js` ×2, `mode-integration.spec.js` ×2, `state-hygiene.spec.js` key list) — migrated in PR 7 |
+| Madge cycle count rises when modules merge | `yarn hygiene` fails on any rise; AS-2.3 requires it not increase |
+
+## Complexity Tracking
+
+> No Constitution Check violations require justification. The single tension
+> (Principle I's named coordinate module vs. the spec's assumed target) is
+> resolved by adopting the constitution's path name, not by an exception.

--- a/specs/166-consolidation/quickstart.md
+++ b/specs/166-consolidation/quickstart.md
@@ -1,0 +1,177 @@
+# Quickstart — Spec 166 Consolidation
+
+How to run, verify and gate each story. Every command is run from the repo root.
+
+## Gates (every PR in this phase)
+
+```bash
+yarn typecheck   # zero errors — constitution Quality Gate 1
+yarn test        # full Playwright suite — Quality Gate 2
+yarn build       # clean production build — Quality Gate 3
+yarn lint        # ESLint, incl. the dispatcher no-bypass rule from Story 4
+yarn hygiene     # debt ratchets; fails on any regression
+yarn test:unit   # Vitest lane (pin tests live here)
+```
+
+`yarn hygiene` reads `hygiene-baseline.json`. Today's baselines:
+
+```json
+{ "circularDependencies": 11, "unusedExportModules": 5, "waitForTimeoutOccurrences": 244 }
+```
+
+FR-011: these only ever go **down**. When a PR lowers a count, lower the
+baseline in the same PR.
+
+---
+
+## Story 1 — Deterministic tests
+
+**Measure the current residue**
+
+```bash
+grep -ro waitForTimeout tests/ | wc -l          # 244 today
+grep -rc waitForTimeout tests/ | grep -v ':0' | sort -t: -k2 -rn | head
+```
+
+**The replacement patterns**
+
+```js
+// ❌ before
+await page.waitForTimeout(200)
+const state = await gramFramePage.getState()
+
+// ✅ after — poll the broadcast state
+await expect.poll(async () => (await gramFramePage.getState()).analysis.markers.length).toBe(2)
+
+// ✅ after — wait on a DOM condition
+await expect(page.locator('.gram-frame-markers-table tbody tr')).toHaveCount(2)
+```
+
+**Prove determinism (SC-001)**
+
+```bash
+for i in 1 2 3 4 5; do npx playwright test --retries=0 || break; done
+```
+
+Five consecutive green runs. Then set `retries: 0` in `playwright.config.ts:15`
+(currently `process.env.CI ? 2 : 0`).
+
+**New keyboard coverage**
+
+```bash
+rm tests/keyboard-focus.spec.js.disabled tests/keyboard-focus-simple.spec.js.disabled
+npx playwright test tests/keyboard-movement.spec.js
+```
+
+The new spec must assert *data-coordinate deltas* per keypress (AS-1.2), at
+zoom 1.0 and at a zoomed level — not element visibility.
+
+---
+
+## Story 2 — One coordinate pipeline
+
+**Step 1: write the pin, run it against the four live paths — no source change yet**
+
+```bash
+yarn test:unit tests/unit/coordinate-equivalence.test.js
+```
+
+Green here means the pin is faithful (AS-2.1). Red means the four paths already
+diverge: stop, triage the divergence as its own bug, do not proceed to deletion.
+
+**Step 2: consolidate, then re-run everything**
+
+```bash
+yarn test:unit && npx playwright test tests/keyboard-movement.spec.js && yarn test
+yarn hygiene    # cycles must not increase (AS-2.3)
+git diff --stat tests/   # SC-002: should show zero spec diffs
+```
+
+**Confirm the deletions**
+
+```bash
+test ! -f src/utils/coordinateTransformations.js
+grep -rn 'renderWidth' src/ | grep -v 'utils/coordinates.js'   # expect no transform maths outside the canonical module
+```
+
+---
+
+## Story 3 — One drag engine
+
+Port one machine per PR (harmonics create → doppler place → PanMode → wheel-pan).
+Each PR's gate is the corresponding spec passing **unchanged**:
+
+```bash
+npx playwright test tests/harmonics-mode.spec.js
+npx playwright test tests/doppler-mode.spec.js
+npx playwright test tests/pan-mode.spec.js tests/mouse-wheel-navigation.spec.js
+```
+
+**Confirm the single owner (FR-004)**
+
+```bash
+grep -rn 'isDragging' src/ | grep -v 'shared/BaseDragHandler.js'   # expect only reads of state.drag
+grep -rn '_wheelPan' src/                                          # expect nothing
+grep -rn 'state.dragState' src/                                    # expect nothing
+```
+
+Migrate the four in-repo readers listed in data-model.md §2, and update
+`types.js` plus the data/state guide in the same PR (FR-010).
+
+---
+
+## Story 4 — Batched notifications
+
+> Do not start before Story 1 is merged. `GramFramePage.getState()` reads the
+> debug page's state display, which a state listener writes — asynchronous
+> dispatch makes every `waitForTimeout`-based read of it racy.
+
+**Counting-listener check**
+
+```js
+await page.evaluate(() => {
+  window.__notifyCount = 0
+  window.GramFrame.addStateListener(() => { window.__notifyCount++ })
+})
+// ... perform one mode switch ...
+expect(await page.evaluate(() => window.__notifyCount)).toBe(1)   // AS-4.1
+```
+
+**Burst check (AS-4.2)** — drive 60 mousemove/wheel events, then assert the
+count is bounded by elapsed frames rather than event count, and that the final
+state equals the pre-change value.
+
+**Storage gate (AS-4.3)** — move the cursor 20× with no annotation change and
+assert zero storage writes.
+
+**No-bypass check (AS-4.4)**
+
+```bash
+yarn lint   # fails if any module under src/modes/ imports notifyStateListeners
+```
+
+---
+
+## Story 5 — One diffing table
+
+```bash
+npx playwright test tests/analysis-mode.spec.js tests/harmonics-mode.spec.js \
+                    tests/reformat-markers-harmonics.spec.js
+```
+
+Existing specs must pass **unchanged** (AS-5.1). Demonstrate AS-5.2 by making
+one mechanism change (selected-row styling) in `DiffingTable.js` and observing
+it in both tables.
+
+---
+
+## Phase exit criteria
+
+| Criterion | Check |
+|---|---|
+| SC-001 | 5 consecutive green full runs, `retries: 0`, locally and in CI |
+| SC-002 | Consolidation PR deletes three coordinate implementations with zero spec diffs |
+| SC-003 | Mouse, keyboard and wheel agree at every tested zoom/expand combination |
+| SC-004 | One gesture ⇒ one notification; frame-bounded under continuous input |
+| SC-005 | `grep -ro waitForTimeout tests/ \| wc -l` ≤ 20, each justified inline |
+| SC-006 | `git diff --shortstat main...HEAD` net-negative across the phase |

--- a/specs/166-consolidation/quickstart.md
+++ b/specs/166-consolidation/quickstart.md
@@ -104,7 +104,7 @@ Each PR's gate is the corresponding spec passing **unchanged**:
 ```bash
 npx playwright test tests/harmonics-mode.spec.js
 npx playwright test tests/doppler-mode.spec.js
-npx playwright test tests/pan-mode.spec.js tests/mouse-wheel-navigation.spec.js
+npx playwright test tests/pan-zoom.spec.js   # covers PanMode drag AND wheel-pan (feature 160)
 ```
 
 **Confirm the single owner (FR-004)**

--- a/specs/166-consolidation/research.md
+++ b/specs/166-consolidation/research.md
@@ -1,0 +1,220 @@
+# Phase 0 Research — Spec 166 Consolidation
+
+All decisions below were taken against the live code on branch
+`claude/speckit-plan-166-vnulhx` (2026-07-31), not against the register's
+recorded line numbers. Counts were re-measured; where they differ from the
+spec's prose the measured value is used and the difference noted.
+
+## Measured baseline (2026-07-31)
+
+| Metric | Spec says | Measured | Source |
+|---|---|---|---|
+| `waitForTimeout` in `tests/` | 249 | **244** | `grep -ro waitForTimeout tests/ \| wc -l`, matches `hygiene-baseline.json` |
+| `notifyStateListeners` references in `src/` | ~29 sites | **41 references** across 12 files (call sites + imports) | `grep -rn notifyStateListeners src/` |
+| Coordinate implementations | 4 | **4** — `utils/coordinates.js` (75 L), `utils/coordinateTransformations.js` (122 L), private pair in `keyboardControl.js:308-360`, inline `screenToDataWithZoom` in `events.js:27-86` | read directly |
+| Drag machines | 5 | **5** — `BaseDragHandler`, `PanMode.isDragging`, Harmonics creation, Doppler placement, `instance._wheelPan` in `events.js` | `grep -rn isDragging src/` |
+| CI retries | 2 | **2** (`playwright.config.ts:15`) | read directly |
+| Disabled keyboard specs | 2 | **2** (`keyboard-focus.spec.js.disabled`, `keyboard-focus-simple.spec.js.disabled`) | `ls tests/*.disabled` |
+
+The 249→244 difference is immaterial: spec 165's dead-code sweep removed a few
+between the register's re-verification and today. FR-007's target (≤ 20) and
+SC-005 are unaffected.
+
+---
+
+## R1 — Which module becomes the canonical coordinate pipeline?
+
+**Decision**: `src/utils/coordinates.js` is the canonical module. It absorbs the
+implementations currently in `coordinateTransformations.js`, which is then
+deleted. The private functions in `keyboardControl.js` and the inline
+`screenToDataWithZoom` in `events.js` are deleted and their callers rewired.
+
+**Rationale**: Constitution Principle I states coordinate transforms "MUST flow
+through the established coordinate system in `src/utils/coordinates.js`". The
+spec assumed `coordinateTransformations.js` as the target because it is the more
+complete implementation — which is true of the *code*, not the *path*. Taking
+the better implementation into the constitutionally-named file satisfies both:
+no amendment, no exception, and the diff is a move rather than a rename storm.
+`coordinates.js` is also the name every reader will look for.
+
+**Alternatives considered**:
+- *Keep `coordinateTransformations.js`, amend the constitution* — a MINOR bump to
+  rename a file is a poor trade, and leaves two plausible names in the history.
+- *New third module, delete both* — churns every import for no gain; `coordinates.js`
+  already holds `screenToSVGCoordinates` and `imageToDataCoordinates`, which the
+  canonical API needs verbatim.
+
+**What the canonical module must be aware of** (FR-003): zoom, expand, render
+size (`imageDetails.renderWidth/renderHeight`), and axes margins. The current
+divergence is precisely here — `keyboardControl.js`'s private pair positions
+against `margins.left + normalizedX * renderWidth`, ignoring the image element's
+live `x`/`width` attributes, and compensates externally by dividing the keypress
+increment by the zoom level. The other three read the element attributes. The
+canonical module reads the element attributes; the external compensation in
+`keyboardControl.js` is removed in the same PR.
+
+---
+
+## R2 — How is coordinate equivalence pinned before deletion?
+
+**Decision**: a Vitest table-driven grid in `tests/unit/coordinate-equivalence.test.js`
+that imports **all four live implementations** and asserts they agree, run and
+green *before* any consolidation commit (AS-2.1).
+
+Grid dimensions:
+
+| Axis | Values |
+|---|---|
+| zoom level | 1.0, 1.5, 2.0, 4.0 |
+| expand | off, on (render size ≠ natural size) |
+| render size | natural; 2× natural; non-uniform (w≠h scaling) |
+| margins | default (left 60, bottom 50); zero; asymmetric |
+| rate | 1, 2 |
+| sample points | image corners, centre, and off-image points either side of each edge |
+
+Assertions: `screen→data` and `data→SVG` round-trips agree within `1e-9`
+relative tolerance, and out-of-bounds handling agrees (`null` vs. clamped —
+today `events.js` returns `null` outside bounds while `svgToDataCoordinates`
+clamps; the grid records this as a *documented* difference in the bounds
+predicate, not in the transform, and the canonical API keeps them as two
+separate functions so neither caller changes semantics).
+
+**Rationale**: the pure-JS lane can host this because the transforms take
+plain objects plus an element-like `{getAttribute}` stub — no browser needed.
+Vitest gives a fast, deterministic grid that a Playwright spec could not
+practically enumerate. Constitution II's "unit tests alone cannot catch
+coordinate regressions" still holds: the grid is the *pin*, and the Playwright
+arrow-key spec plus the full suite remain the merge gate.
+
+**Alternatives considered**: recording golden outputs from a running browser and
+replaying — more faithful but far slower to author and brittle to font/DPI; the
+Playwright arrow-key spec (R3) covers the real-browser dimension instead.
+
+---
+
+## R3 — What replaces the two disabled keyboard specs?
+
+**Decision**: delete both `.disabled` files; add `tests/keyboard-movement.spec.js`
+asserting **data-coordinate deltas**, not visibility.
+
+Per FR-008 / AS-1.2, for a selected marker at a known data position, an arrow
+keypress must change `state.analysis.markers[i].freq`/`.time` by the expected
+increment, checked at zoom 1.0 and at a zoomed level (where the increment is
+divided by zoom so the *rendered* movement stays constant). Same for a selected
+harmonic set's spacing/anchor. This is exactly the assertion whose absence
+GF-26ᴺ records, and it is the coverage that protects R1's rewiring of
+`keyboardControl.js`.
+
+**Rationale**: the disabled specs tested FocusManager isolation, which
+`focus-simple.spec.js` and `tab-navigation.spec.js` already cover actively.
+Restoring them would re-add duplicate coverage while leaving the real gap open.
+
+---
+
+## R4 — Drag-state mirrors: remove, or deprecate for one release?
+
+**Decision**: **remove** them. Replace `state.analysis.isDragging`,
+`state.harmonics.dragState.*`, and `state.doppler.isDragging` with a single
+read-only projection `state.drag` (shape in [data-model.md](./data-model.md)).
+No deprecation window.
+
+**Rationale**: the spec left this open pending evidence of a downstream reader.
+The evidence is now in: every reader in the repository is a test —
+`tests/doppler-mode.spec.js:674,702`, `tests/mode-integration.spec.js:320,321`,
+and `tests/state-hygiene.spec.js:63`'s key list. `debug.html` and `sample/`
+reference none of them. A deprecation shim would mean keeping the double
+bookkeeping GF-17 is about, for one release, to serve zero known consumers —
+i.e. paying the finding's cost to avoid a hypothesis. FR-004's "at most one
+read-only projection" is also literally unsatisfiable while three mirrors exist.
+
+**Escape hatch preserved**: if a downstream training system is identified before
+PR 7 lands, `state.drag` is already a projection — repopulating the three legacy
+paths from it is a ten-line, single-site addition, versus the multi-site
+bookkeeping being removed.
+
+---
+
+## R5 — Batching strategy for the notification dispatcher
+
+**Decision**: two-tier. A single `dispatch(instance)` choke-point in
+`src/core/state.js`:
+
+1. **Default tier — microtask batching.** Repeated `dispatch()` calls within one
+   task coalesce into a single notification via `queueMicrotask`, delivered with
+   the settled state. This alone satisfies AS-4.1 (mode switch fires ≥2 notifies
+   today: `keyboardControl.js` + `main.js`).
+2. **High-frequency tier — frame cadence.** `dispatch(instance, {frame: true})`
+   from mousemove, wheel and drag-move paths coalesces via
+   `requestAnimationFrame`, satisfying FR-006 and AS-4.2.
+
+A pending frame-tier dispatch is upgraded — never downgraded — by a subsequent
+default-tier dispatch, so a mode switch during a drag is never delayed to the
+next frame. Cloning happens once inside `dispatch`, and is skipped entirely when
+`listeners.length === 0` (FR-005). A synchronous `flushDispatch(instance)` is
+exported for teardown/destroy so no notification is lost on unmount.
+
+**Rationale**: microtasks preserve today's "state is readable on the test's next
+await" property for the vast majority of specs, which is what makes tier 1
+low-risk; only the genuinely high-frequency paths take the observable frame
+delay, and those are the ones the spec's compatibility bar (same-frame final
+state) was written for.
+
+**Alternatives considered**:
+- *rAF for everything* — simpler, but makes every existing `getState()` read
+  frame-racy, multiplying Story 1's migration cost for no benefit on paths that
+  fire once per gesture.
+- *Synchronous dedupe by dirty-flag, no async* — cannot batch across the two
+  notify sites of a mode switch, which happen in separate functions.
+
+**Enforcement of FR-005/AS-4.4**: `notifyStateListeners` stops being exported to
+modes; the ESLint config gains a `no-restricted-imports` rule so a mode importing
+it fails `yarn lint` rather than being caught in review.
+
+---
+
+## R6 — Storage listener re-serialization
+
+**Decision**: gate `saveAnnotations` on an annotation-relevance check inside the
+listener registered at `src/main.js:447` — compare a cheap signature (marker
+count + harmonic-set count + doppler marker identity + last-mutation counter)
+and return early when unchanged (AS-4.3).
+
+**Rationale**: the listener currently re-serializes annotations on *every*
+notification, including pure cursor moves; combined with the per-notch wheel
+notify added by feature 160 this is the compounding cost GF-07 records. A
+mutation counter bumped by the annotation-mutating paths is more robust than
+deep comparison and costs one integer.
+
+---
+
+## R7 — Shared table engine boundary
+
+**Decision**: extract `src/components/DiffingTable.js` exposing a
+`createDiffingTable(container, spec)` factory plus an `update(rows)` method. The
+component owns: fixed-height scroll wrapper, header construction,
+update-in-place, rebuild-from-index, trailing-row removal, click-to-select, and
+delete-button event propagation. It does **not** own: column definitions, cell
+formatting, selection semantics, or delete behaviour — those arrive via `spec`.
+
+**Rationale**: the two implementations (`AnalysisMode.js:577-717` and
+`HarmonicPanel.js:62-232`) already agree on the mechanism and differ only in
+columns and callbacks; the post-audit scroll wrapper was duplicated verbatim
+(`AnalysisMode.js:373-377` / `HarmonicPanel.js:32-36`), which is the concrete
+evidence that the mechanism is the shared part. Keeping formatting out of the
+component avoids a config object that reimplements a template language.
+
+**Alternatives considered**: a base class with overridable hooks — heavier for
+two consumers and pulls `AnalysisMode` into an inheritance chain it does not
+otherwise need.
+
+---
+
+## Open items carried to `/speckit.tasks`
+
+None blocking. Two items are decisions for the implementer within an agreed
+envelope:
+
+- The exact `waitForTimeout` residue (≤ 20) and which sites keep a justification
+  comment — determined per spec as the migration proceeds (AS-1.3).
+- Whether `harmonicSampling` and other already-pure helpers gain unit coverage
+  opportunistically alongside the new Vitest files — welcome, not required.

--- a/specs/166-consolidation/tasks.md
+++ b/specs/166-consolidation/tasks.md
@@ -1,0 +1,320 @@
+# Tasks: Phase 2 — Consolidating the Interest-Accruing Seams
+
+**Input**: Design documents from `/specs/166-consolidation/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/](./contracts/), [quickstart.md](./quickstart.md)
+
+**Tests**: REQUIRED, and non-negotiable here. FR-001 — "Every consolidation MUST
+land behind a behaviour-pinning test written and passing BEFORE the duplicate
+paths are removed" — plus constitution Principle II. Test tasks are not optional
+decoration in this feature; in US1 they *are* the deliverable.
+
+**Organization**: Grouped by user story. Each story is independently
+implementable and testable, with one exception recorded explicitly below.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1–US5, mapping to the spec's user stories
+
+## Path Conventions
+
+Single project: `src/`, `tests/` at repository root (per plan.md Structure Decision).
+
+## ⚠️ Story ordering is load-bearing
+
+Unlike a typical spec-kit feature, these stories are **not** freely parallelisable:
+
+| Constraint | Reason |
+|---|---|
+| **US1 → US4 is a hard dependency** | `GramFramePage.getState()` reads the debug page's state display, written by a state listener. Once dispatch is asynchronous, every `waitForTimeout`-based read of that display is a race. US4 must not start before T023. |
+| **US1 → US2 strongly recommended** | US2's safety argument is "the full suite still passes". T017 (arrow-key spec) is the specific coverage protecting US2's rewire of `keyboardControl.js`. |
+| US3, US5 | Independent of each other and of US2/US4 once US1 lands. |
+
+US1 is therefore both the MVP *and* the gate.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Nothing to scaffold — the project, the Vitest lane (spec 164) and
+the ratchets already exist. These tasks establish the measurement baseline every
+later task is checked against.
+
+- [ ] T001 Record the phase-start baseline in `specs/166-consolidation/baseline.md`: output of `grep -ro waitForTimeout tests/ | wc -l` (expect 244), `yarn hygiene`, and `git rev-parse HEAD` — the reference point for SC-005 and SC-006
+- [ ] T002 [P] Verify the gate commands all pass on a clean tree before any change: `yarn typecheck && yarn lint && yarn test:unit && yarn hygiene && yarn build`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The shared test vocabulary US1 spends 200+ call sites using. Writing
+these first is what stops the wait migration becoming 200 ad-hoc `expect.poll`
+snippets.
+
+**⚠️ CRITICAL**: T003–T004 block all of US1.
+
+- [ ] T003 Add state-wait helpers to `tests/helpers/gram-frame-page.js`: `waitForState(predicate, opts)` (polls `getState()`), `waitForMarkerCount(n)`, `waitForHarmonicSetCount(n)`, `waitForMode(mode)`, `waitForZoomLevel(level)` — each built on `expect.poll` with the config timeout, no fixed sleeps
+- [ ] T004 [P] Add DOM-condition helpers to `tests/helpers/gram-frame-page.js`: `waitForTableRowCount(table, n)` and `waitForSelectedRow(table, key)` using `expect(locator).toHaveCount()` / `toHaveClass()`
+
+**Checkpoint**: Helpers exist and are unit-exercised by at least one migrated call site.
+
+---
+
+## Phase 3: User Story 1 — Deterministic tests & restored keyboard coverage (Priority: P1) 🎯 MVP
+
+**Goal**: The suite gives the same answer twice. 244 `waitForTimeout` → ≤ 20
+justified, CI `retries: 0`, and arrow-key movement covered by assertions on data
+coordinates rather than visibility.
+
+**Independent Test**: Run the full suite 5× with `--retries=0`; zero flakes. The
+new keyboard spec fails if arrow-key movement breaks.
+
+### Migration — helpers first (used everywhere)
+
+- [ ] T005 [US1] Replace all 15 `waitForTimeout` calls in `tests/helpers/interaction-helpers.js` with the T003/T004 helpers
+- [ ] T006 [US1] Replace all 7 `waitForTimeout` calls in `tests/helpers/mode-helpers.js` with the T003/T004 helpers
+- [ ] T007 [US1] Replace the 3 `waitForTimeout` calls in `tests/helpers/gram-frame-page.js` (lines ~337, ~481, ~493 per GF-27) with state-based waits
+- [ ] T008 [US1] Run the full suite 3× and lower `waitForTimeoutOccurrences` in `hygiene-baseline.json` to the measured count (FR-011)
+
+### Migration — the four heaviest specs
+
+- [ ] T009 [P] [US1] Replace all 43 `waitForTimeout` calls in `tests/reformat-markers-harmonics.spec.js`
+- [ ] T010 [P] [US1] Replace all 30 `waitForTimeout` calls in `tests/storage.spec.js`
+- [ ] T011 [P] [US1] Replace all 19 `waitForTimeout` calls in `tests/harmonic-pin-toggle.spec.js`
+- [ ] T012 [P] [US1] Replace all 16 `waitForTimeout` calls in `tests/harmonic-pin-sampling.spec.js`
+- [ ] T013 [US1] Lower `waitForTimeoutOccurrences` in `hygiene-baseline.json` to the measured count after T009–T012 (expect ≈ 111)
+
+### Migration — the remaining specs, down to the justified residue
+
+- [ ] T014 [P] [US1] Replace `waitForTimeout` in the mid-weight specs: `tests/doppler-mode.spec.js` (11), `tests/keyboard-simple.spec.js` (9), `tests/harmonic-labels.spec.js` (9), `tests/harmonic-hotspot.spec.js` (9), `tests/analysis-mode.spec.js` (9), `tests/harmonic-symbols.spec.js` (8)
+- [ ] T015 [P] [US1] Replace `waitForTimeout` in the light specs: `tests/harmonic-pin-height.spec.js` (6), `tests/focus-interaction.spec.js` (6), `tests/basic-functionality.spec.js` (6), `tests/harmonic-label-halo.spec.js` (5), `tests/harmonics-mode.spec.js` (4), `tests/image-scaling.spec.js` (3), `tests/focus-simple.spec.js` (3), `tests/table-scroll.spec.js` (2), `tests/tab-navigation.spec.js` (2), `tests/expand-image.spec.js` (2), `tests/advanced-interactions.spec.js` (2), `tests/mode-integration.spec.js` (1)
+- [ ] T016 [US1] Add an inline justification comment above each surviving `waitForTimeout` explaining why no state or DOM condition expresses the wait; confirm the total is ≤ 20 and lower `hygiene-baseline.json` to it (FR-007, SC-005, AS-1.3)
+
+### Restored keyboard coverage
+
+- [ ] T017 [US1] Create `tests/keyboard-movement.spec.js` asserting arrow-key **data-coordinate deltas**: select a marker at a known position, press each arrow key, assert `state.analysis.markers[i].freq`/`.time` changed by the expected increment; repeat for a selected harmonic set's spacing and anchor time; run each at zoom 1.0 and at a zoomed level where the rendered movement must stay constant (FR-008, AS-1.2)
+- [ ] T018 [US1] Delete `tests/keyboard-focus.spec.js.disabled` and `tests/keyboard-focus-simple.spec.js.disabled` — their FocusManager coverage is already active in `tests/focus-simple.spec.js` and `tests/tab-navigation.spec.js` (research.md §R3); lower the ratchet by the 14 occurrences they contained
+
+### Determinism gate
+
+- [ ] T019 [US1] Run `for i in 1 2 3 4 5; do npx playwright test --retries=0 || break; done` — five consecutive green runs required (AS-1.1, SC-001)
+- [ ] T020 [US1] Triage any flake T019 exposes: identify the racing condition and replace the wait; do not paper over it by restoring a timeout
+- [ ] T021 [US1] Set `retries: 0` unconditionally in `playwright.config.ts:15` (currently `process.env.CI ? 2 : 0`) (FR-007, AS-1.4)
+- [ ] T022 [P] [US1] Opportunistic POM adoption in the ~6–8 small specs that duplicate selectors instead of using `GramFramePage` (GF-28ᴿ) — scope-limited, skip any spec where the change is not mechanical
+- [ ] T023 [US1] Confirm CI is green with `retries: 0` on a pushed branch — **this is the gate that unblocks US4**
+
+**Checkpoint**: Suite is deterministic. US2 and US4 may now proceed.
+
+---
+
+## Phase 4: User Story 2 — One coordinate pipeline (Priority: P1)
+
+**Goal**: One module owns every screen/SVG/image/data conversion, and it is
+zoom-, expand-, render-size- and margin-aware so no caller compensates externally.
+
+**Independent Test**: The Vitest equivalence grid passes against the canonical
+module for every (zoom, expand, render-size, margin) case.
+
+### Pin FIRST — no source changes in this group (FR-001, AS-2.1)
+
+- [ ] T024 [US2] Create `tests/unit/coordinate-equivalence.test.js` importing **all four live implementations** — `src/utils/coordinates.js`, `src/utils/coordinateTransformations.js`, and test-only re-exports of the private functions in `src/core/keyboardControl.js` and the inline `screenToDataWithZoom` in `src/core/events.js` — with a `{getAttribute}` stub standing in for the SVG image element
+- [ ] T025 [US2] Implement the grid from research.md §R2 in `tests/unit/coordinate-equivalence.test.js`: zoom ∈ {1, 1.5, 2, 4} × expand ∈ {off, on} × render size ∈ {natural, 2×, non-uniform} × margins ∈ {default, zero, asymmetric} × rate ∈ {1, 2}, sampling image corners, centre, and points just outside each edge
+- [ ] T026 [US2] Assert equivalences E1–E6 from `contracts/coordinates.md` at 1e-9 relative tolerance, with E3 narrowed to zoom 1 / expand off and replaced elsewhere by the rendered-pixels-per-keypress equivalence
+- [ ] T027 [US2] Run `yarn test:unit` — **if any cell fails, STOP**: the pin is not faithful. Raise the divergence as its own issue, triage it, and do not begin T028 until the grid is green (spec Assumptions, AS-2.1)
+
+### Consolidate — only after T027 is green
+
+- [ ] T028 [US2] Move the zoom-aware implementations from `src/utils/coordinateTransformations.js` into `src/utils/coordinates.js` under the surface in `contracts/coordinates.md`: `screenToSVG`, `svgToImage`, `imageToData`, `dataToSVG`, `screenToData`, `getImageBounds`, `isWithinImage` — canonical path per constitution Principle I (research.md §R1)
+- [ ] T029 [US2] Delete `src/utils/coordinateTransformations.js` and rewire its importers to `src/utils/coordinates.js`
+- [ ] T030 [US2] Delete the private `dataToSVGCoordinates` and `svgToDataCoordinates` from `src/core/keyboardControl.js` (lines ~308–360) and route `moveSelectedMarker`/`moveSelectedHarmonicSet` through the canonical module
+- [ ] T031 [US2] Remove the external zoom compensation in `src/core/keyboardControl.js` (the `increment / zoomLevel` division) now that the canonical module is zoom-aware (FR-003, I2)
+- [ ] T032 [US2] Delete the inline `screenToDataWithZoom` from `src/core/events.js` (lines ~27–86) and call `screenToData` + `isWithinImage` instead, preserving the current out-of-bounds `null` semantics at the call site
+- [ ] T033 [US2] Repoint `tests/unit/coordinate-equivalence.test.js` at the canonical module alone, keeping the grid as the regression suite; remove the test-only re-exports added in T024
+- [ ] T034 [US2] Verify no transform maths survives outside the canonical module: `grep -rn 'renderWidth' src/ | grep -v 'utils/coordinates.js'` returns no positioning arithmetic (FR-002)
+- [ ] T035 [US2] Run `yarn test:unit && npx playwright test tests/keyboard-movement.spec.js && yarn test`; confirm `git diff --stat tests/` shows zero spec diffs from this group (SC-002, AS-2.2)
+- [ ] T036 [US2] Run `yarn hygiene`: madge cycle count must not increase (AS-2.3); lower `circularDependencies` and `unusedExportModules` baselines where the deletions allow (FR-011)
+- [ ] T037 [US2] Add a Playwright assertion that mouse, keyboard, wheel-zoom and expand report identical data coordinates for the same physical point across zoom/expand combinations (AS-2.4, SC-003)
+
+**Checkpoint**: One coordinate module. Three implementations deleted.
+
+---
+
+## Phase 5: User Story 3 — One drag engine (Priority: P2)
+
+**Goal**: Five drag machines become one, and drag state has a single owner with
+one read-only projection.
+
+**Independent Test**: Each of the five interactions has a Playwright spec passing
+before and after the port; `grep` shows one `isDragging` owner in `src/`.
+
+### Engine extension
+
+- [ ] T038 [US3] Extend `src/modes/shared/BaseDragHandler.js` with the four drag kinds and the `resolveTarget` callback from `contracts/drag-engine.md`; make `DragTarget.id`/`.type` nullable so pan drags need no feature target
+- [ ] T039 [P] [US3] Add `DragKind`, `DragTarget` and `DragProjection` typedefs to `src/types.js` per data-model.md §2–3
+
+### Port one machine per PR — newest and least-covered last
+
+- [ ] T040 [US3] Port the Harmonics creation drag (`src/modes/harmonics/HarmonicsMode.js:202-210,255-261,551-599`) to a `create`-kind drag; gate on `tests/harmonics-mode.spec.js` passing **unchanged**
+- [ ] T041 [US3] Port the Doppler placement drag (`src/modes/doppler/DopplerMode.js:256-260,288-310,322-354`) to a `place`-kind drag, leaving `tempFirst`/`previewEnd` on `state.doppler` as renderer geometry; gate on `tests/doppler-mode.spec.js` passing unchanged
+- [ ] T042 [US3] Port the PanMode drag (`src/modes/pan/PanMode.js:17-21,57-134`) to a `pan`-kind drag; gate on `tests/pan-zoom.spec.js` passing unchanged
+- [ ] T043 [US3] Port the middle-button wheel-pan (`instance._wheelPan` in `src/core/events.js:115-120,208-217,264-280,300-304,323-326`) to a centrally-resolved `pan`-kind drag ahead of mode resolvers, preserving `preventDefault` autoscroll suppression; gate on `tests/pan-zoom.spec.js` (US3 of feature 160) passing unchanged
+
+### Collapse the mirrors (FR-004, AS-3.2)
+
+- [ ] T044 [US3] Add the `state.drag` read-only projection, rebuilt from the owning handler on each dispatch, always present with `active: false` when idle (data-model.md §2)
+- [ ] T045 [US3] Remove `isDragging`/`draggedMarkerId`/`dragStartPosition` from `state.analysis`, the whole `state.dragState` slot, and `isDragging`/`draggedMarker`/`isPlacingMarkers`/`isPreviewDrag` from `state.doppler`; update `AnalysisState`, `DopplerState` and `DragState` in `src/types.js` (FR-010)
+- [ ] T046 [P] [US3] Migrate the four in-repo readers to `state.drag`: `tests/doppler-mode.spec.js:674,702`, `tests/mode-integration.spec.js:320,321`, and the `'dragState'` entry in `tests/state-hygiene.spec.js:63`
+- [ ] T047 [US3] Update the data/state documentation in `docs/` to describe `state.drag` and record the removed mirror fields, in the same PR as T045 (FR-010)
+- [ ] T048 [US3] Verify the single owner: `grep -rn 'isDragging' src/ | grep -v shared/BaseDragHandler.js` shows only reads of `state.drag`; `grep -rn '_wheelPan\|state.dragState' src/` returns nothing
+- [ ] T049 [US3] Add a `state-hygiene.spec.js` assertion that at most one drag is active across all modes at any time (data-model.md §2 validation rules)
+
+**Checkpoint**: One drag engine, one drag record.
+
+---
+
+## Phase 6: User Story 4 — Batched, throttled notifications (Priority: P2)
+
+**Goal**: One gesture, one notification. One clone per dispatch, and none when no
+listener is registered.
+
+**⚠️ BLOCKED until T023.** Asynchronous dispatch makes every
+`waitForTimeout`-based read of the debug state display racy.
+
+**Independent Test**: A counting listener sees exactly one notification per mode
+switch, and a frame-bounded count under a 60-event burst.
+
+### Pin FIRST (FR-001)
+
+- [ ] T050 [US4] Create `tests/unit/notification-batching.test.js` pinning today's behaviour: clone count per notification, and the fact that a mode switch currently fires ≥ 2
+- [ ] T051 [P] [US4] Add a Playwright counting-listener spec to `tests/state-listener.spec.js` recording today's notification counts for a mode switch, a 60-event mousemove burst and a wheel burst — the "before" side of the compatibility comparison
+
+### Dispatcher
+
+- [ ] T052 [US4] Implement `dispatch(instance, options)` and `flushDispatch(instance)` in `src/core/state.js` per `contracts/notifications.md`: microtask coalescing by default, `{frame: true}` for animation-frame cadence, frame-tier upgraded (never downgraded) by a default-tier dispatch
+- [ ] T053 [US4] Move the single deep clone inside `dispatch` and skip it entirely when `listeners.length === 0` (FR-005, N2)
+- [ ] T054 [US4] Convert the default-tier call sites to `dispatch(instance)`: `src/main.js` (5), `src/core/keyboardControl.js` (7), `src/components/table.js` (2), `src/components/SymbolPicker.js` (2), `src/components/ExpandToggle.js` (2), `src/api/GramFrameAPI.js` (2)
+- [ ] T055 [US4] Convert the high-frequency call sites to `dispatch(instance, {frame: true})`: `src/core/events.js` (3, incl. mousemove), `src/core/viewport.js` (2, incl. the per-notch `setZoom`), and the drag-move paths in `src/modes/doppler/DopplerMode.js` (7), `src/modes/harmonics/HarmonicsMode.js` (4), `src/modes/analysis/AnalysisMode.js` (4) (FR-006)
+- [ ] T056 [US4] Stop exporting `notifyStateListeners` to modes and add an ESLint `no-restricted-imports` rule in `eslint.config.js` failing any `src/modes/**` import of it (FR-005, AS-4.4)
+- [ ] T057 [US4] Call `flushDispatch` on instance destroy/teardown so no notification is lost on unmount (N6)
+
+### Storage listener gate
+
+- [ ] T058 [US4] Gate the annotation-save listener at `src/main.js:447` on an annotation-relevance signature (marker count, harmonic-set count, doppler marker identity, mutation counter), returning early when unchanged (AS-4.3, research.md §R6)
+- [ ] T059 [US4] Add a mutation counter bumped by the annotation-mutating paths in `src/core/state.js` and the modes
+
+### Verify
+
+- [ ] T060 [US4] Extend `tests/state-listener.spec.js`: one mode switch → exactly 1 notification (AS-4.1)
+- [ ] T061 [US4] Assert a 60-event mousemove/wheel burst yields a count bounded by elapsed frames, and that the settled state matches the T051 "before" value (AS-4.2, SC-004)
+- [ ] T062 [US4] Assert 20 cursor moves with no annotation change produce zero storage writes (AS-4.3)
+- [ ] T063 [US4] Verify HMR listener preservation still holds after the dispatcher change (constitution Technical Constraints)
+- [ ] T064 [US4] Run the full suite 5× with `retries: 0` — the batching change must not reintroduce flakes (SC-001)
+
+**Checkpoint**: One dispatcher, batched and frame-bounded.
+
+---
+
+## Phase 7: User Story 5 — One diffing-table component (Priority: P3)
+
+**Goal**: One row-diffing engine serves both the markers table and the harmonics panel.
+
+**Independent Test**: Existing markers-table and harmonics-panel specs pass unchanged.
+
+- [ ] T065 [US5] Create `src/components/DiffingTable.js` exporting `createDiffingTable(container, spec)` per `contracts/diffing-table.md`, owning the scroll wrapper, header construction, update-in-place, rebuild-from-index, trailing-row removal, click-to-select and delete-button propagation
+- [ ] T066 [P] [US5] Add the `TableSpec` typedef to `src/types.js` (data-model.md §3)
+- [ ] T067 [US5] Adopt `DiffingTable` in the markers table, deleting the engine at `src/modes/analysis/AnalysisMode.js:577-717` and the scroll wrapper at `:373-377`; keep rendered DOM structure and class names identical (T2)
+- [ ] T068 [US5] Adopt `DiffingTable` in the harmonics panel, deleting the engine at `src/components/HarmonicPanel.js:62-232` and the scroll wrapper at `:32-36`
+- [ ] T069 [US5] Verify `tests/analysis-mode.spec.js`, `tests/harmonics-mode.spec.js`, `tests/reformat-markers-harmonics.spec.js` and `tests/table-scroll.spec.js` pass **unchanged** across add, update, remove, select and delete in both tables (AS-5.1)
+- [ ] T070 [US5] Demonstrate AS-5.2: make one mechanism change (selected-row styling) in `src/components/DiffingTable.js` alone and confirm it appears in both tables
+
+**Checkpoint**: One table engine.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+- [ ] T071 Lower every `hygiene-baseline.json` count to its final measured value and confirm none was raised at any point in the phase (FR-011)
+- [ ] T072 [P] Update `CLAUDE.md`'s File Structure list: remove `src/utils/coordinateTransformations.js`, add `src/components/DiffingTable.js` — the project instructions require this list to stay in step with `src/`
+- [ ] T073 [P] Update `docs/` architecture notes to describe the single coordinate module, the single drag engine and the dispatcher
+- [ ] T074 Mark GF-01ᴿ, GF-07, GF-08, GF-17, GF-18, GF-20, GF-26ᴺ, GF-27 and GF-28ᴿ as resolved in `docs/analysis/Findings-Register.md`, citing the PRs
+- [ ] T075 Verify SC-006: `git diff --shortstat main...HEAD` is net-negative in lines across the phase
+- [ ] T076 Run the full `quickstart.md` validation — every phase exit criterion SC-001 through SC-006
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies
+- **Foundational (Phase 2)**: after Setup — blocks US1 only
+- **US1 (Phase 3)**: after Foundational — **gates US2 and US4**
+- **US2 (Phase 4)**: after T023 (strongly recommended; T017 is its protective coverage)
+- **US3 (Phase 5)**: after Foundational; independent of US2/US4/US5
+- **US4 (Phase 6)**: **hard-blocked on T023**
+- **US5 (Phase 7)**: after Foundational; independent of all others
+- **Polish (Phase 8)**: after all desired stories
+
+### Within-story ordering
+
+- Pin tests before deletions, always (T024–T027 before T028; T050–T051 before T052)
+- Engine extension before ports (T038 before T040–T043)
+- All ports before mirror collapse (T043 before T044)
+- Component before adoption (T065 before T067–T068)
+
+### Parallel Opportunities
+
+- T009–T012 — four independent spec files, no shared state
+- T014, T015 — disjoint spec-file sets
+- T039, T046, T066, T072, T073 — independent files
+- **Across stories**: once T023 lands, US3 and US5 can run alongside US2 by different developers; US4 should not overlap US2 (both touch `events.js` and the mode files heavily)
+
+---
+
+## Parallel Example: User Story 1, heaviest specs
+
+```bash
+# After T005–T008, launch the four heavy-spec migrations together:
+Task: "Replace all 43 waitForTimeout calls in tests/reformat-markers-harmonics.spec.js"
+Task: "Replace all 30 waitForTimeout calls in tests/storage.spec.js"
+Task: "Replace all 19 waitForTimeout calls in tests/harmonic-pin-toggle.spec.js"
+Task: "Replace all 16 waitForTimeout calls in tests/harmonic-pin-sampling.spec.js"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP: User Story 1 only
+
+1. Phase 1 Setup → Phase 2 Foundational → Phase 3 US1
+2. **STOP and VALIDATE**: five consecutive green runs at `retries: 0`
+3. US1 has standalone value even if the phase ends here — a deterministic suite
+   and restored keyboard coverage are the deliverable, not scaffolding
+
+### Incremental delivery
+
+1. US1 → deterministic suite (MVP, and the gate)
+2. US2 → one coordinate pipeline (the fastest-accruing finding)
+3. US3 → one drag engine
+4. US4 → batched notifications (only after US1 is merged)
+5. US5 → one diffing table
+
+### If the phase must be cut short
+
+Ship US1 + US2. Those two carry SC-001, SC-002, SC-003 and SC-005, and they
+close the finding the re-verification caught actively worsening (feature-156/160
+support copy-pasted into all four coordinate pipelines). US3–US5 are real debt
+but are not compounding at the same rate.
+
+---
+
+## Notes
+
+- Every task's exit is `yarn typecheck && yarn test && yarn build` green — the
+  constitution's Quality Gates, no exceptions
+- FR-001 is a hard rule, not a preference: if a pin test cannot be written for a
+  deletion, the deletion does not happen
+- T027 has a genuine STOP condition. A red grid means the four implementations
+  already disagree; that is a bug to triage, not an obstacle to route around
+- Commit after each task or logical group; one PR per plan.md sequencing row


### PR DESCRIPTION
Planning artifacts for `specs/166-consolidation` (`/speckit.plan`). **No source changes** — this PR only adds documents under `specs/166-consolidation/` plus the routine `CLAUDE.md` context refresh.

## What's here

| File | Contents |
|---|---|
| `plan.md` | Technical context, Constitution Check, 10-PR sequencing, risk table |
| `research.md` | Decisions R1–R7, with baselines re-measured against the live code |
| `data-model.md` | Drag-state mirrors → one read-only `state.drag` projection |
| `contracts/coordinates.md` | Canonical coordinate module surface + the equivalence grid |
| `contracts/drag-engine.md` | `BaseDragHandler` extended to four drag kinds |
| `contracts/notifications.md` | Single dispatcher, two-tier coalescing |
| `contracts/diffing-table.md` | Shared row-diffing table boundary |
| `quickstart.md` | Per-story commands and phase exit criteria |

## Two open questions the spec deferred to plan stage — both now resolved

**1. Which module becomes the canonical coordinate pipeline?**
The spec assumed `coordinateTransformations.js`. Constitution Principle I names `src/utils/coordinates.js` as *the* coordinate system. Resolved by consolidating **into `src/utils/coordinates.js`** while adopting the implementation from `coordinateTransformations.js` (the more complete one). Both satisfied; no constitutional amendment needed.

**2. Keep the deprecated drag-state mirror fields for one release?**
**No — remove them.** Every reader in the repository is a test (`doppler-mode.spec.js:674,702`, `mode-integration.spec.js:320,321`, `state-hygiene.spec.js:63`); `debug.html` and `sample/` reference none. A deprecation shim would mean keeping the exact double bookkeeping GF-17 is about, for one release, to serve zero known consumers. FR-004's "at most one read-only projection" is also unsatisfiable while three mirrors exist. The escape hatch is cheap if a downstream reader surfaces before the port lands.

## Sequencing is load-bearing

Story 1 (deterministic tests) is a **hard prerequisite** for Story 4 (batched notifications), not just a nice ordering. `GramFramePage.getState()` reads the debug page's state display, which a state listener writes — the moment notification becomes asynchronous, every `waitForTimeout`-based read of that display becomes a race. The plan gates PRs 8–9 behind PR 3 for this reason.

## Baselines re-measured against the live code

`waitForTimeout` in `tests/` is **244**, not the 249 the spec quotes (spec 165's sweep landed in between) — this matches `hygiene-baseline.json`, and does not affect FR-007's ≤ 20 target. Other counts confirmed as stated: 4 coordinate implementations, 5 drag machines, 2 disabled keyboard specs, CI `retries: 2`.

## Verification

Documentation only, so the code gates are unaffected; `.specify/scripts/bash/update-agent-context.sh claude` ran clean and its `CLAUDE.md` edit is included.

---
_Generated by [Claude Code](https://claude.ai/code/session_012mH39ETSiZxFnr5siy75aw)_