### PR TITLE
docs(167): implementation plan for Phase 3 structural refactor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,8 +219,10 @@ There is no visual/screenshot regression testing — see
 - Browser Web Storage — additive `symbol` field on markers; `cross` (symbol-less) default; no schema bump (161-reformat-markers-harmonics)
 - JavaScript ES2020+, JSDoc-typed, no TypeScript compilation + None at runtime (zero runtime deps); Vite 5 for build (166-consolidation)
 - Unchanged — Web Storage (`localStorage` trainer / `sessionStorage` student) (166-consolidation)
+- Unchanged — Web Storage (`localStorage` trainer / `sessionStorage` student). No persisted-shape change in this phase. (167-structural-refactor)
 
 ## Recent Changes
+- 167-structural-refactor: Planned Phase 3 — strict type gate burn-down (540 errors), state⇄modes decoupling, table.js split, capability seams, shrunk instance surface
 - 166-consolidation: Planned Phase 2 consolidation — one coordinate pipeline, one drag engine, batched notifications, one diffing table, deterministic tests
 - 165-quick-fixes: Truthful published state and loud failures, dead-code sweep, docs corrected against the code
 - 161-reformat-markers-harmonics: Added a `cross` (symbol-less) default style and in-place restyling of selected markers/harmonic sets (colour + symbol)

--- a/specs/167-structural-refactor/baseline.md
+++ b/specs/167-structural-refactor/baseline.md
@@ -1,0 +1,289 @@
+# Baseline Measurements — Phase 3
+
+Every number below was measured at commit `7115a8a` (post-Phase-2 `main`,
+PR #223 merged), not carried over from the audit. Commands are given so each
+can be re-run and disputed.
+
+The register's figures were taken at `edfc549`, before Phase 2 landed. Where
+the two disagree, **the measurement here is authoritative** and the difference
+is explained.
+
+---
+
+## 1. Strict-flag error counts (Story 1)
+
+Measured by writing a probe tsconfig **at the repo root** (this matters — a
+tsconfig outside the repo cannot resolve `node_modules/@types`, which silently
+adds ~46 phantom errors) and counting `error TS` lines.
+
+```bash
+node -e "
+const fs=require('fs');const c=JSON.parse(fs.readFileSync('tsconfig.json','utf8'));
+for (const f of process.argv.slice(1)) c.compilerOptions[f]=true;
+fs.writeFileSync('tsconfig.probe.json',JSON.stringify(c,null,2));
+" noImplicitAny strictNullChecks strictPropertyInitialization
+npx tsc --noEmit -p tsconfig.probe.json 2>&1 | grep -c "error TS"
+rm tsconfig.probe.json
+```
+
+| Configuration | Errors |
+|---|---|
+| Current `tsconfig.json` (all three off) | **0** |
+| `+ noImplicitAny` | **143** |
+| `+ strictNullChecks` | **401** |
+| `+ strictNullChecks + strictPropertyInitialization` | **401** |
+| `+ noImplicitAny + strictNullChecks` | **540** |
+| **All three (the Story 1 ceiling)** | **540** |
+
+Two results drive the plan:
+
+1. **`strictPropertyInitialization` adds zero errors** once `strictNullChecks`
+   is on, and *cannot be enabled without it* — TypeScript rejects the
+   combination with `TS5052: Option 'strictPropertyInitialization' cannot be
+   specified without specifying option 'strictNullChecks'`. It is therefore not
+   an independent burn-down. See research §R1.
+2. `noImplicitAny` and `strictNullChecks` are near-independent: 143 + 401 = 544
+   against a combined 540, so only 4 errors are double-reported. Enabling
+   `noImplicitAny` first leaves 397 for `strictNullChecks` rather than 401 —
+   a small argument for that order, reinforced by §R2.
+
+### Distribution by file (all three flags on, 540 total)
+
+| File | Errors | | File | Errors |
+|---|---|---|---|---|
+| `src/main.js` | 70 | | `src/utils/tolerance.js` | 15 |
+| `src/components/table.js` | 65 | | `src/core/events.js` | 15 |
+| `src/modes/harmonics/HarmonicsMode.js` | 51 | | `src/components/HarmonicPanel.js` | 11 |
+| `src/modes/doppler/DopplerMode.js` | 47 | | `src/modes/pan/PanMode.js` | 8 |
+| `src/core/keyboardControl.js` | 46 | | `src/components/SymbolPicker.js` | 7 |
+| `src/modes/analysis/AnalysisMode.js` | 45 | | `src/components/ColorPicker.js` | 7 |
+| `src/core/viewport.js` | 28 | | `src/core/initialization/ModeInitialization.js` | 6 |
+| `src/core/state.js` | 21 | | `src/core/FocusManager.js` | 6 |
+| `src/components/ExpandToggle.js` | 21 | | `src/components/ModeButtons.js` | 6 |
+| `src/core/initialization/UISetup.js` | 20 | | `src/modes/BaseMode.js` | 5 |
+| `src/core/FeatureRenderer.js` | 16 | | `src/core/configuration.js` | 5 |
+
+Remaining 9 files carry ≤ 4 each: `GramFrameAPI.js` (4),
+`BaseDragHandler.js` (3), `EventBindings.js` (2), `PinToggle.js` (2),
+`MainUI.js` (2), `LEDDisplay.js` (2), `utils/doppler.js` (1),
+`utils/calculations.js` (1), `storage.js` (1), `DOMSetup.js` (1).
+
+### Distribution by error code
+
+| Code | Count | Meaning |
+|---|---|---|
+| `TS18048` | 134 | `'X' is possibly 'undefined'` |
+| `TS2532` | 129 | Object is possibly 'undefined' |
+| `TS2339` | 54 | Property does not exist on type |
+| `TS7008` | 46 | Member implicitly has an `any` type |
+| `TS2345` | 46 | Argument type not assignable |
+| `TS18049` | 36 | `'X' is possibly 'null' or 'undefined'` |
+| `TS2783` | 20 | Property specified more than once, will be overwritten |
+| `TS2722` | 17 | Cannot invoke a possibly-undefined object |
+| `TS2533` | 15 | Object is possibly 'null' or 'undefined' |
+| `TS7006` | 14 | Parameter implicitly has an `any` type |
+| `TS7053` / `TS7005` | 7 / 6 | Implicit `any` from index access / variable |
+
+The shape is what GF-32 predicted: 314 of 540 (58%) are nullability errors on
+DOM and state access. `TS7008` is a single concentrated fix — the 46 untyped
+class-field declarations in `main.js:80-165`.
+
+`TS2783` (20) is a genuine latent bug class rather than a typing nuisance:
+`src/core/state.js:38-39` sets `version` and `timestamp` and then spreads
+`buildModeInitialState()` over them. Worth a look during PR 4, which touches
+that exact composition.
+
+---
+
+## 2. Circular dependencies (Stories 2 & 3)
+
+`yarn hygiene` — baseline **11**, current **11**.
+
+| # | Cycle | Dissolved by |
+|---|---|---|
+| 1 | `ExpandToggle.js > table.js` | Story 3 (PR 7) |
+| 2 | `state.js > AnalysisMode.js` | Story 2 (PR 4) |
+| 3 | `state.js > DopplerMode.js > UIComponents.js > ColorPicker.js > SymbolPicker.js` | Story 2 |
+| 4 | `state.js > DopplerMode.js > UIComponents.js > ColorPicker.js > keyboardControl.js` | Story 2 |
+| 5 | `state.js > DopplerMode.js` | Story 2 |
+| 6 | `table.js > state.js > HarmonicsMode.js` | Story 2 |
+| 7 | `state.js > HarmonicsMode.js` | Story 2 |
+| 8 | `table.js > state.js > HarmonicsMode.js > ManualHarmonicModal.js` | Story 2 |
+| 9 | `ExpandToggle.js > table.js > state.js > PanMode.js > viewport.js` | Story 2 |
+| 10 | `table.js > state.js > PanMode.js > viewport.js` | Story 2 |
+| 11 | `state.js > PanMode.js > viewport.js` | Story 2 |
+
+All 11 close through `state.js` importing a mode class, `table.js` importing
+`dispatch` from `state.js`, or `ExpandToggle` ⇄ `table.js`. Cutting the four
+mode imports out of `state.js` (PR 4) removes cycles 2–11; cycle 1 goes with
+the Story 3 split (PR 7). **SC-002's target of ≤ 1 is comfortably reachable;
+the realistic landing point is 0.**
+
+The remaining edges into `state.js` are all one-directional imports of
+`dispatch` — from `table.js`, `ExpandToggle.js`, `SymbolPicker.js` and the
+three feature modes. None of them is a cycle once `state.js` stops importing
+back.
+
+---
+
+## 3. `table.js` responsibilities (Story 3)
+
+713 lines. Line ranges as measured:
+
+| Lines | Responsibility | Destination |
+|---|---|---|
+| 22–34 | `getRenderDimensions` | `components/spectrogramImage.js` |
+| 35–139 | `createComponentStructure` (private) | `components/table.js` (stays) |
+| 140–205 | `setupSpectrogramImage` | `components/spectrogramImage.js` |
+| 206–265 | `updateSVGLayout` | `components/svgLayout.js` |
+| 266–325 | `applyZoomTransform` | `core/viewport.js` |
+| 326–358 | `renderAxes` | `rendering/axes.js` |
+| 359–411 | `calculateVisibleDataRange` | `core/viewport.js` |
+| 412–687 | 8 private axis helpers | `rendering/axes.js` |
+| 688–713 | `replaceConfigTable`, `setupComponentTable` | `components/table.js` (stays) |
+
+Projected sizes: `axes.js` ≈ 310, `table.js` ≈ 135, `spectrogramImage.js` ≈ 90,
+`svgLayout.js` ≈ 60, `viewport.js` 192 → ≈ 305. All under the SC-004 line.
+
+Current importers of `table.js` (all rewired by PR 8):
+
+| Importer | Imports | New source |
+|---|---|---|
+| `ExpandToggle.js` | `updateSVGLayout`, `renderAxes` | `svgLayout.js`, `axes.js` |
+| `ManualHarmonicModal.js` | `calculateVisibleDataRange` | `core/viewport.js` |
+| `HarmonicsMode.js` | `calculateVisibleDataRange`, `getRenderDimensions` | `core/viewport.js`, `spectrogramImage.js` |
+| `core/viewport.js` | `applyZoomTransform`, `updateSVGLayout`, `renderAxes` | in-module, `svgLayout.js`, `axes.js` |
+| `UISetup.js` | `setupSpectrogramImage` | `spectrogramImage.js` |
+| `DOMSetup.js` | `setupComponentTable` | `table.js` (unchanged) |
+
+After the split only `DOMSetup.js` imports `table.js` — which is what a
+scaffold module should look like.
+
+---
+
+## 4. `BaseMode` hook audit (Story 4)
+
+20 members. "Overrides" counts mode files declaring the method; "callers"
+counts call sites outside `BaseMode.js`.
+
+| Hook | Overrides | Callers | Verdict |
+|---|---|---|---|
+| `renderCursor` | **0** | 1 | **DELETE** — sole caller `FeatureRenderer.js:88` always hits the base no-op |
+| `getStateSnapshot` | **0** | **0** | **DELETE** — dead |
+| `activate` | 1 | 2 | Keep — lifecycle |
+| `deactivate` | 2 | 1 | Keep — lifecycle |
+| `handleMouseMove` | 5 | 6 | Keep |
+| `handleMouseDown` | 4 | 1 | Keep |
+| `handleMouseUp` | 4 | 1 | Keep |
+| `handleMouseLeave` | 2 | 1 | Keep |
+| `renderPersistentFeatures` | 3 | 3 | Keep → becomes a **capability** |
+| `updateLEDs` | 3 | 1 | Keep |
+| `getGuidanceText` | 4 | 3 | Keep |
+| `getCommandButtons` | 1 | 2 | Keep |
+| `isEnabled` | 1 | 5 | Keep |
+| `resetState` | 4 | 1 | Keep |
+| `cleanup` | 4 | 2 | Keep |
+| `createUI` | 3 | 2 | Keep |
+| `destroyUI` | 2 | 2 | Keep |
+| `static getInitialState` | 4 | 4 | Keep → the **registration seam** (Story 2) |
+| `getViewport` | 0 | 17 | Keep — concrete base helper, not a hook |
+| `updateCursorStyle` | 2 | 3 | Keep — concrete base helper |
+
+GF-10's claim is confirmed exactly: `renderCursor` and `getStateSnapshot` are
+the two with zero overrides. `getViewport` and `updateCursorStyle` also have
+zero overrides but are *concrete helpers* with 17 and 3 callers — they stay,
+and the pruned `BaseMode` documents the distinction.
+
+---
+
+## 5. Named-mode reach-ins (Story 4)
+
+| Site | Reach-in | Capability replacing it |
+|---|---|---|
+| `FeatureRenderer.js:32-44` | `instance.modes.analysis / .harmonics / .doppler` + three `hasXFeatures()` predicates | `PersistentFeatureProvider` |
+| `MainUI.js:211,217` | `/** @type {any} */ (instance.modes['analysis'])`, `…['harmonics']` | `PanelOwner` |
+| `PanMode.js:219,225` | `this.instance._zoomOut()`, `_zoomIn()` | `core/viewport.js` seam (FR-007) |
+| `viewport.js:162` | `instance.modes.pan && instance.modes.pan.isEnabled()` | see research §R6 |
+| `types.js:431-434` | `_setZoom`, `_zoomIn`, `_zoomOut`, `_zoomReset` optional members | removed with PR 12 |
+
+---
+
+## 6. Instance surface (Story 5)
+
+```bash
+grep -rn "instance\.state" src --include=*.js | wc -l   # 243
+grep -rln "instance\.state" src --include=*.js | wc -l  # 22
+```
+
+| Quantity | Register (at `edfc549`) | Measured now | Δ |
+|---|---|---|---|
+| `instance.state` reach-ins | 371 | **243** | −128 (−34%) |
+| Files containing them | 21 | **22** | +1 |
+| Class field declarations in `main.js` | ~54 | **56** | +2 |
+| Class methods on `GramFrame` | — | 16 | — |
+| `this.state` inside `main.js` | — | 24 | — |
+
+Phase 2 removed 128 reach-ins as a by-product of the coordinate and drag
+consolidations. The 371 figure in the spec is stale; see research §R7 for how
+SC-005 is interpreted against the current number.
+
+The 56 fields group naturally into four cohesive sets, which is what Story 5
+exploits:
+
+| Group | Fields | Count |
+|---|---|---|
+| `ui` (DOM handles) | `container`, `readoutPanel`, `modeCell`, `mainCell`, `modeLED`, `rateLED`, `colorPicker`, `svg`, `cursorGroup`, `axesGroup`, `imageClipRect`, `cursorClipRect`, `leftColumn`, `middleColumn`, `rightColumn`, `modeColumn`, `guidanceColumn`, `controlsColumn`, `unifiedLayoutContainer`, `timeLED`, `freqLED`, `speedLED`, `markersContainer`, `harmonicsContainer`, `spectrogramImage`, `expandToggleButton`, `modesContainer`, `modeButtons`, `commandButtons`, `guidancePanel` | 30 |
+| `interaction` | `setSelection`, `clearSelection`, `updateSelectionVisuals`, `applyColorToSelectedFeature`, `applySymbolToSelectedFeature`, `applyPinToSelectedFeature`, `applyLargeSymbolsToSelectedFeature`, `syncStyleControls`, `_symbolControl`, `_pinControl`, `_largeSymbolsControl`, `_registeredListeners`, `_wheelPanHandler`, `_wheelPanLast` | 14 |
+| `viewport` | `resizeObserver`, `_boundHandleResize` | 2 |
+| `persistence` | `_storageInstanceIndex`, `_isTrainerContext` | 2 |
+| Core (stay on the instance) | `state`, `configTable`, `stateListeners`, `instanceId`, `modes`, `currentMode`, `featureRenderer`, `_unsupportedBrowser` | 8 |
+
+30 + 14 + 2 + 2 + 8 = 56. Grouping the first four sets behind four sub-objects
+takes the constructor's own field count from 56 to 12 — comfortably past
+SC-005's ≥ 40% reduction (target ≤ 33).
+
+---
+
+## 7. Public API surface (Story 5 / FR-010)
+
+Documented methods on the object returned by `createGramFrameAPI`:
+
+| Method | Current coverage |
+|---|---|
+| `init()` | indirect (auto-init on every page) |
+| `detectAndReplaceConfigTables(container)` | `auto-detection.spec.js:88` — `typeof` only |
+| `addStateListener(callback)` | `auto-detection.spec.js:96` — `typeof` only |
+| `removeStateListener(callback)` | none |
+| `getExpandState()` | via `__test__` hooks only |
+| `setExpandState(expanded)` | via `__test__` hooks only |
+
+Private (`_`-prefixed, not in scope for FR-010): `_getInstances`,
+`_restoreConfigTable`, `_addErrorIndicator`, `_instances`.
+Debug-only, attached solely when `window.GRAMFRAME_DEBUG` is set:
+`__test__flushDispatches`, `__test__getInstances`, `__test__getInstance`.
+
+---
+
+## 8. Other ratchets at phase start
+
+| Ratchet | Baseline | Story 3 effect |
+|---|---|---|
+| `circularDependencies` | 11 | → 0 expected |
+| `unusedExportModules` | 5 | unchanged (`index.js`, `browserCompatibility.js`, `storage.js`, `harmonicSampling.js`, `version.js`) |
+| `waitForTimeoutOccurrences` | 1 | unchanged |
+
+## 9. Modules over the SC-004 ~350-line guideline
+
+| Module | Lines | Addressed by this phase? |
+|---|---|---|
+| `modes/harmonics/HarmonicsMode.js` | 1016 | No — documented exception |
+| `components/table.js` | 713 | **Yes** — Story 3 → ~135 |
+| `main.js` | 677 | **Yes** — Story 5 |
+| `modes/doppler/DopplerMode.js` | 657 | No — documented exception |
+| `types.js` | 617 | Exempt (declarations) |
+| `modes/analysis/AnalysisMode.js` | 612 | No — documented exception |
+| `core/keyboardControl.js` | 561 | No — documented exception |
+| `api/GramFrameAPI.js` | 413 | No — documented exception |
+| `core/events.js` | 395 | No — documented exception |
+
+Total `src/`: 10,965 lines across 44 modules.

--- a/specs/167-structural-refactor/contracts/axes.md
+++ b/specs/167-structural-refactor/contracts/axes.md
@@ -1,0 +1,89 @@
+# Contract — `src/rendering/axes.js`
+
+**Story 3 · FR-004 · SC-004 · ADR-018**
+
+The axis engine, extracted from `components/table.js` into the `rendering/`
+family beside `cursors.js` and `symbols.js` — where CLAUDE.md has documented it
+living for some time, and where GF-38 recorded it as a phantom module.
+
+## Public interface
+
+```js
+/**
+ * Render both axes into the instance's axes group.
+ *
+ * Clears the group and redraws the time (vertical) and frequency (horizontal)
+ * axes for the currently visible data range. Safe to call repeatedly; the sole
+ * entry point into the axis engine.
+ * @param {GramFrame} instance - GramFrame instance
+ */
+export function renderAxes(instance)
+```
+
+One export. Everything else in the module is private.
+
+## Private helpers (moved verbatim from `table.js:412-687`)
+
+| Helper | Role |
+|---|---|
+| `renderTimeAxis` | Vertical axis: ticks, labels, line |
+| `renderFrequencyAxis` | Horizontal axis: ticks, labels, line |
+| `calculateAxisTicks` | Nice-number tick selection for a range and pixel span |
+| `formatFrequencyLabels` | Frequency label formatting |
+| `renderAxisLine` | Draws one axis line |
+| `renderAxisTicks` | Draws a tick set |
+| `renderAxisLabels` | Draws a label set |
+
+Time labels use `utils/timeFormatter.js` (`formatTime`), as today.
+
+Projected size ≈ 310 lines — under the SC-004 guideline.
+
+## Dependencies
+
+| Imports | From |
+|---|---|
+| `formatTime` | `utils/timeFormatter.js` |
+| visible-range math | `core/viewport.js` (`calculateVisibleDataRange`, moved there in PR 8) |
+
+`rendering/axes.js` must **not** import `components/table.js` — the point of the
+split. It must not import `core/state.js`: rendering draws, it does not
+dispatch.
+
+## Consumers after the split
+
+| Consumer | Was | Now |
+|---|---|---|
+| `core/viewport.js` (`updateAxes`) | `table.js` | `rendering/axes.js` |
+| `components/ExpandToggle.js` | `table.js` | `rendering/axes.js` (+ `svgLayout.js`) |
+
+`ExpandToggle` importing `axes.js` and `svgLayout.js` instead of `table.js` is
+what dissolves madge cycle #1 (`ExpandToggle.js > table.js`).
+
+## Sibling modules created by the same split
+
+| Module | Exports | ≈ lines |
+|---|---|---|
+| `components/spectrogramImage.js` | `setupSpectrogramImage`, `getRenderDimensions` | 90 |
+| `components/svgLayout.js` | `updateSVGLayout` | 60 |
+| `core/viewport.js` (absorbs) | `applyZoomTransform`, `calculateVisibleDataRange` | 192 → 305 |
+| `components/table.js` (remains) | `setupComponentTable`, and private `createComponentStructure` / `replaceConfigTable` | 135 |
+
+After the split, `components/table.js` is imported by exactly one module —
+`core/initialization/DOMSetup.js` — which is what a scaffold should look like.
+
+## Move discipline
+
+PRs 6–8 are **pure moves**. The diff is relocation plus import rewiring; `git
+diff -M` should show the rename. Any behaviour change is a separate PR. AS-3.1
+requires zero behavioural diff, enforced by the existing suite passing unchanged
+and by reviewing each PR as a move.
+
+## Verification
+
+| Assertion | Where |
+|---|---|
+| Zero behavioural diff | full suite unchanged (AS-3.1) |
+| Axes live in `rendering/` with a documented interface | this file; ADR-018 (AS-3.2) |
+| ExpandToggle ⇄ table cycle gone, no new cycle | `yarn hygiene`, baseline lowered (AS-3.3) |
+| Zoom math has one home shared by wheel, keyboard and API | `tests/pan-zoom.spec.js` unchanged (AS-3.4, FR-007) |
+| CLAUDE.md's `src/rendering/axes.js` claim is finally true | file exists; GF-38 partially closed |

--- a/specs/167-structural-refactor/contracts/capabilities.md
+++ b/specs/167-structural-refactor/contracts/capabilities.md
@@ -1,0 +1,141 @@
+# Contract — Mode capability interfaces
+
+**Story 4 · FR-005 · FR-006 · FR-007 · ADR-017**
+
+Cross-module collaborators discover what a mode can do by asking the mode, not
+by naming it.
+
+Capabilities are **duck-typed**: a mode opts in by implementing the methods.
+There is no roster to keep in sync, no registration call, and no inheritance —
+which matters in a JSDoc-typed codebase with no compilation step, where a
+declared `capabilities` array would be a second source of truth that can drift
+from the methods it describes.
+
+Lives in `src/modes/capabilities.js`: the typedefs and their predicates
+together.
+
+---
+
+## `PersistentFeatureProvider`
+
+A mode that owns features surviving a mode switch.
+
+| Member | Signature | Contract |
+|---|---|---|
+| `hasPersistentFeatures` | `() => boolean` | `true` iff at least one such feature currently exists. Reads this mode's own state slice. |
+| `renderPersistentFeatures` | `() => void` | Draws them into `instance.cursorGroup`. Called only when `hasPersistentFeatures()` returns `true`. Must be safe to call repeatedly. |
+
+```js
+export function isPersistentFeatureProvider(mode) {
+  return typeof mode?.hasPersistentFeatures === 'function'
+      && typeof mode?.renderPersistentFeatures === 'function'
+}
+```
+
+**Implementors**: Analysis, Harmonics, Doppler. **Not** Pan.
+
+**`FeatureRenderer` after the change**:
+
+```js
+renderAllPersistentFeatures() {
+  if (!this.instance.cursorGroup) return
+  this.instance.cursorGroup.innerHTML = ''
+  Object.values(this.instance.modes)
+    .filter(isPersistentFeatureProvider)
+    .filter(mode => mode.hasPersistentFeatures())
+    .forEach(mode => mode.renderPersistentFeatures())
+}
+```
+
+`hasAnalysisFeatures()`, `hasHarmonicFeatures()` and `hasDopplerFeatures()` are
+deleted from `FeatureRenderer` and reimplemented as `hasPersistentFeatures()` on
+the mode that owns the state each reads. That removes eight `instance.state`
+reach-ins from `FeatureRenderer`, counting toward Story 5's ratchet.
+
+---
+
+## `PanelOwner`
+
+A mode that owns a persistent panel in the unified layout.
+
+| Member | Signature | Contract |
+|---|---|---|
+| `refreshPanel` | `() => void` | Re-renders the panel from current state. Idempotent; safe when the panel is empty or its container is absent. |
+
+```js
+export function isPanelOwner(mode) {
+  return typeof mode?.refreshPanel === 'function'
+}
+```
+
+**Implementors**: Analysis (today's `updateMarkersTable`), Harmonics (today's
+`updateHarmonicPanel`).
+
+**`MainUI.updatePersistentPanels` after the change**:
+
+```js
+Object.values(instance.modes).filter(isPanelOwner).forEach(mode => mode.refreshPanel())
+```
+
+replacing `MainUI.js:211,217`, which today reads:
+
+```js
+const analysisMode = /** @type {any} */ (instance.modes['analysis'])
+const harmonicsMode = /** @type {any} */ (instance.modes['harmonics'])
+```
+
+Both `any` casts go. No mode-name string remains in `MainUI.js`.
+
+---
+
+## `ZoomConsumer` — a consumption rule, not an implemented interface
+
+There is nothing for a mode to implement. The rule is that **every** zoom caller
+goes through `core/viewport.js`:
+
+| Caller | Today | After |
+|---|---|---|
+| Wheel | `viewport.js` | unchanged |
+| Keyboard | `viewport.js` | unchanged |
+| Public API | `main.js._zoomIn` → `viewport.js` | direct, or a documented forwarder |
+| PanMode command buttons | `this.instance._zoomOut()` / `_zoomIn()` (`PanMode.js:219,225`) | `zoomOut(this.instance)` / `zoomIn(this.instance)` imported from `core/viewport.js` |
+
+`types.js:431-434`'s `_setZoom` / `_zoomIn` / `_zoomOut` / `_zoomReset` optional
+members are removed. Whether `main.js` keeps thin forwarders for the public API
+is decided in PR 12, when the full call graph is visible; either way
+`core/viewport.js` is the single home for zoom math (FR-007, AS-4.3).
+
+---
+
+## Documented exception
+
+`viewport.js:162` reads `instance.modes.pan` to decide whether to leave pan mode
+when zoom returns to 1×:
+
+```js
+if (instance.state.mode === 'pan' && instance.modes.pan && !instance.modes.pan.isEnabled() && …)
+```
+
+This is pan-specific policy, not cross-cutting coordination. A fourth capability
+for one call site would be worse than the reach-in. It is recorded here as an
+exception to FR-006 rather than disguised (research §R6).
+
+---
+
+## Rules
+
+1. No module outside `modes/` names a mode by string or index to obtain
+   behaviour — one exception, above.
+2. No `any` cast is used to reach a mode method.
+3. A capability with zero implementors is deleted, not kept for symmetry.
+4. Every capability must be exercised by the fifth-mode spike (SC-003) before it
+   counts as real.
+
+## Verification
+
+| Assertion | Where |
+|---|---|
+| `FeatureRenderer` and `MainUI` contain no mode-name string and no `any` cast to a mode | grep in PR 11; `yarn lint` |
+| A fifth mode with persistent features is rendered with no edit to `FeatureRenderer` or `MainUI` | `tests/mode-registration.spec.js` + spike PR (AS-4.2, SC-003) |
+| Zoom via PanMode buttons, keyboard, wheel and API all produce identical state | `tests/pan-zoom.spec.js` (existing, unchanged — that is the point) |
+| Deleted `BaseMode` hooks have no callers | grep in PR 10; `tsc` under Story 1's flags |

--- a/specs/167-structural-refactor/contracts/mode-registration.md
+++ b/specs/167-structural-refactor/contracts/mode-registration.md
@@ -1,0 +1,89 @@
+# Contract — Mode state registration seam
+
+**Story 2 · FR-002 · SC-003 · ADR-014**
+
+How a mode contributes its slice of initial state without `core/state.js`
+knowing the mode exists.
+
+## Producer — `ModeFactory`
+
+```js
+/**
+ * Compose the initial-state slices contributed by every registered mode.
+ *
+ * The single place that knows the mode roster for state purposes, mirroring
+ * `createMode`'s role for instantiation. `core/state.js` receives the result
+ * rather than importing the mode classes itself — which is what breaks the
+ * state ⇄ modes cycle (GF-03).
+ * @returns {Partial<GramFrameState>} Merged mode slices
+ */
+static getModeInitialStates() {
+  return Object.assign({},
+    AnalysisMode.getInitialState(),
+    HarmonicsMode.getInitialState(),
+    DopplerMode.getInitialState(),
+    PanMode.getInitialState()
+  )
+}
+```
+
+`ModeFactory` already imports all four classes for `createMode`. No new imports.
+
+## Consumer — `core/state.js`
+
+```js
+/**
+ * Create a deep copy of the initial state for a new instance.
+ * @param {Partial<GramFrameState>} [modeStates={}] - Mode slices from
+ *   ModeFactory.getModeInitialStates(). Defaults to none so the module can be
+ *   loaded and exercised without any mode being imported (AS-2.2).
+ * @returns {GramFrameState}
+ */
+export function createInitialState(modeStates = {}) { … }
+```
+
+`core/state.js` has **no** `import … from '../modes/…'` after this change.
+
+## Call site — `main.js`
+
+```js
+this.state = createInitialState(ModeFactory.getModeInitialStates())
+```
+
+## Key-collision rule
+
+Mode slices are spread **first**; core keys are written **after**, so a mode
+cannot overwrite `version`, `timestamp`, `mode`, `zoom`, `drag` or any other
+core key. This fixes the 20 `TS2783` errors that currently report `version` and
+`timestamp` being set and then spread over (`state.js:38-39`).
+
+A mode slice whose key collides with a core key is a bug in the mode. PR 4 adds
+a development-time assertion listing any collision rather than silently
+resolving it.
+
+## Merge order
+
+Fixed and explicit: **analysis, harmonics, doppler, pan**. Order is observable
+only through collisions, which the rule above forbids — but it is pinned anyway
+by a frozen-snapshot unit test written before PR 4 changes anything.
+
+## Adding a fifth mode
+
+| File | Change |
+|---|---|
+| `src/modes/<name>/<Name>Mode.js` | new — extends `BaseMode`, implements `static getInitialState()` |
+| `src/modes/ModeFactory.js` | one `case` in `createMode`, one entry in `getModeInitialStates`, one entry in `getAvailableModes` |
+
+Nothing else. Specifically **not** `core/state.js`, **not**
+`components/MainUI.js`, **not** `core/FeatureRenderer.js` — that is SC-003, and
+the spike PR in the sequencing table is its evidence.
+
+## Verification
+
+| Assertion | Where |
+|---|---|
+| No madge cycle contains both `core/state.js` and a `modes/` file | `yarn hygiene`, baseline lowered 11 → ~1 (AS-2.1) |
+| A mode module loads in the Vitest lane without importing `state.js` | `tests/unit/mode-registration.test.js` (AS-2.2) |
+| `createInitialState()` with no argument returns a valid core state | same file |
+| Composed state matches the frozen snapshot | same file, written **before** PR 4 |
+| A fifth mode's initial state appears without editing `state.js` | `tests/mode-registration.spec.js` + the spike PR (AS-2.2, SC-003) |

--- a/specs/167-structural-refactor/contracts/strict-ratchet.md
+++ b/specs/167-structural-refactor/contracts/strict-ratchet.md
@@ -1,0 +1,103 @@
+# Contract — Strict type ceiling
+
+**Story 1 · FR-001 · SC-001**
+
+A temporary, committed overlay tsconfig plus one hygiene ratchet, both deleted
+when the count reaches zero.
+
+## `tsconfig.strict.json` (repo root, temporary)
+
+```json
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true
+  }
+}
+```
+
+**Why the repo root and not a temp directory**: a tsconfig outside the
+repository cannot resolve `node_modules/@types`, which silently adds ~46
+phantom errors. The ceiling would then be unreachable. This file must sit
+beside `tsconfig.json`.
+
+**Why all three flags in one overlay** rather than three files:
+`strictPropertyInitialization` cannot be set without `strictNullChecks`
+(`TS5052`), and a single overlay measured under the end-state configuration is
+monotone by construction — no mid-phase re-baselining. See research §R1/§R3.
+
+## Ratchet entry
+
+```json
+{
+  "strictTypeErrors": 540
+}
+```
+
+in `hygiene-baseline.json`, enforced by `scripts/hygiene.js`.
+
+## `scripts/hygiene.js` behaviour
+
+| Condition | Behaviour |
+|---|---|
+| count > baseline | **fail**, print the new errors, exit non-zero |
+| count < baseline | pass, print the standard "lower the baseline in this PR" reminder |
+| count == baseline | pass |
+| output contains `TS5052` / `TS6046` / `TS5023` | **fail loudly** — a config error, not a type error. The overlay is malformed and the count is meaningless. Mirrors the existing madge `moduleCount < 10` guard. |
+| `tsconfig.strict.json` absent | skip the ratchet silently — this is how the check disappears after PR 14 |
+
+The detail output prints the per-flag sub-counts (`noImplicitAny` 143,
+`strictNullChecks` 401) and the top offending files, so the burn-down's shape
+stays visible without either sub-count becoming a gate.
+
+The counting rule is the one already used elsewhere in the script: lines
+matching `error TS`.
+
+## Lifecycle
+
+| Step | State |
+|---|---|
+| PR 1 | Overlay + ratchet added at 540. No source change. CI proves a deliberate +1 fails. |
+| PRs 2–13 | Each PR that touches a strict-unclean file lowers the count and the baseline **in the same PR** (AS-1.2). |
+| PR 14 | Count is 0 → the three flags move into `tsconfig.json`; `tsconfig.strict.json` and the `strictTypeErrors` entry are deleted; ADR-007 annotated (AS-1.3, AS-1.4). |
+
+## End state (SC-001)
+
+```json
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "allowJs": true,
+    "noEmit": true,
+    "strict": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  }
+}
+```
+
+No `noImplicitAny: false`, no `strictNullChecks: false`, no
+`strictPropertyInitialization: false`. `yarn typecheck` passes.
+
+## Independent test (spec US1)
+
+With the flags on, adding an unguarded `document.querySelector('x').classList`
+to any `src/` file fails `yarn typecheck`. Before the phase, it does not.
+
+## What a burn-down PR may contain
+
+Permitted: `@type` annotations, definite-assignment annotations at sites where
+construction is legitimately deferred (documented per site, per the spec's
+Assumptions), null guards that preserve the current runtime path, non-null
+assertions where the invariant is genuinely established.
+
+Not permitted: `// @ts-expect-error`, `// @ts-ignore`, `any` casts introduced to
+silence an error, or a guard that changes behaviour. A site where the honest fix
+*is* a behaviour change is split into its own PR with a test, and its error is
+left standing until then (research §R2).

--- a/specs/167-structural-refactor/data-model.md
+++ b/specs/167-structural-refactor/data-model.md
@@ -1,0 +1,221 @@
+# Phase 1 Data Model — Structural Refactor
+
+**No persisted-state change.** Nothing in this phase alters the shape of a
+stored annotation, the storage schema version, or the broadcast
+`GramFrameState`. Saved work from before the phase loads unchanged after it, and
+no migration is written. `specs/155-browser-storage`'s schema stands.
+
+What follows is the *structural* model: the entities the refactor introduces or
+reshapes, and the invariants each must hold.
+
+---
+
+## 1. `ModeInitialStates` — the registration seam (Story 2)
+
+The composed object handed to `createInitialState()`, replacing the four mode
+imports inside `state.js`.
+
+| Field | Type | Source |
+|---|---|---|
+| `analysis` | `AnalysisState` | `AnalysisMode.getInitialState()` |
+| `harmonics` | `HarmonicsState` | `HarmonicsMode.getInitialState()` |
+| `doppler` | `DopplerState` | `DopplerMode.getInitialState()` |
+| *(pan contributes no slice today)* | — | `PanMode.getInitialState()` returns `{}` |
+
+**Producer**: `ModeFactory.getModeInitialStates()` — the only module importing
+all four mode classes.
+**Consumer**: `createInitialState(modeStates)` in `core/state.js`.
+
+**Invariants**
+
+1. `createInitialState()` called with no argument returns a valid core state
+   with no mode slices. This is what lets a unit test build state without
+   loading a mode (AS-2.2).
+2. Merge order is fixed and explicit: analysis, harmonics, doppler, pan. A
+   frozen-snapshot unit test pins the composed shape before PR 4 changes
+   anything.
+3. A mode slice must not collide with a core key. Today `TS2783` reports
+   `version` and `timestamp` being set and then spread over — the composition
+   must set core keys **after** the spread, or reject colliding keys outright.
+   PR 4 owns this fix.
+4. Adding a fifth mode adds one line to `getModeInitialStates()` and touches no
+   other file (SC-003, AS-2.2).
+
+**State shape**: unchanged. The same keys appear in the same places; only the
+module that assembles them moves.
+
+---
+
+## 2. Listener registries (Story 2)
+
+Two arrays with genuinely different lifetimes, each with exactly one write path.
+
+| Registry | Lives in | Holds | Lifetime |
+|---|---|---|---|
+| `globalStateListeners` | `core/state.js` (module scope) | listeners added via `GramFrame.addStateListener()` | survives instance destruction; cleared only by `clearGlobalStateListeners()` (HMR, tests) |
+| `instance.stateListeners` | per instance | listeners scoped to one instance | dies with the instance |
+
+**Change**: instances stop *copying* the global list into their own at
+construction (`EventBindings.js:46`), and `removeStateListener` stops splicing
+every instance's copy (`GramFrameAPI.js:283-289`).
+
+**Invariants**
+
+1. A given callback appears in **at most one** registry. Delivery walks the
+   union and de-duplicates, so a callback in both is delivered once.
+2. `addStateListener(cb)` writes to `globalStateListeners` only; the immediate
+   call-with-current-state per live instance is preserved (observable API
+   behaviour, asserted by `state-listener.spec.js`).
+3. `removeStateListener(cb)` removes from `globalStateListeners` only, and
+   returns `true` iff something was removed.
+4. After add-then-remove, no instance holds a reference to `cb` — no leak, no
+   duplicate delivery (AS-2.3).
+5. HMR re-registration (`main.js:663-666`) preserves global listeners across a
+   hot reload (Technical Constraints; AS-2.3 names it).
+
+---
+
+## 3. Mode capabilities (Story 4)
+
+Duck-typed interfaces in `src/modes/capabilities.js`. A mode opts in by
+implementing the methods; there is no registration list and no inheritance.
+
+### `PersistentFeatureProvider`
+
+| Member | Signature | Contract |
+|---|---|---|
+| `hasPersistentFeatures` | `() => boolean` | `true` iff this mode owns at least one feature that must survive a mode switch |
+| `renderPersistentFeatures` | `() => void` | Draws them into `instance.cursorGroup`; called only when `hasPersistentFeatures()` is `true` |
+
+Implemented by: Analysis, Harmonics, Doppler. Not Pan.
+Predicate: `isPersistentFeatureProvider(mode)`.
+
+The three `hasXFeatures()` predicates currently on `FeatureRenderer` move onto
+the modes whose state they read — deleting eight `instance.state` reach-ins from
+`FeatureRenderer` toward Story 5's ratchet.
+
+### `PanelOwner`
+
+| Member | Signature | Contract |
+|---|---|---|
+| `refreshPanel` | `() => void` | Re-renders this mode's persistent panel (markers table / harmonics panel) from current state; idempotent, safe to call when the panel is empty |
+
+Implemented by: Analysis (`updateMarkersTable`), Harmonics (`updateHarmonicPanel`).
+Predicate: `isPanelOwner(mode)`.
+
+### `ZoomConsumer`
+
+Not an implemented interface — a *consumption* rule. Every zoom caller (wheel,
+keyboard, PanMode's command buttons, the public API) goes through
+`core/viewport.js`. No caller reaches for `instance._zoomIn` and friends
+(FR-007).
+
+**Invariants**
+
+1. No module outside `modes/` names a mode by string or index to obtain
+   behaviour (FR-006). One documented exception: `viewport.js:162`'s
+   pan-specific policy check (research §R6).
+2. No `any` cast is used to reach a mode method.
+3. A fifth mode implementing `PersistentFeatureProvider` is rendered by
+   `FeatureRenderer` with no edit to `FeatureRenderer` (AS-4.2, SC-003).
+4. A capability with zero implementors is deleted, not kept "for symmetry".
+
+---
+
+## 4. `BaseMode` after pruning (Story 4)
+
+| Category | Members |
+|---|---|
+| **Lifecycle hooks** (kept) | `activate`, `deactivate`, `resetState`, `cleanup`, `createUI`, `destroyUI` |
+| **Event hooks** (kept) | `handleMouseMove`, `handleMouseDown`, `handleMouseUp`, `handleMouseLeave` |
+| **Presentation hooks** (kept) | `updateLEDs`, `getGuidanceText`, `getCommandButtons`, `isEnabled` |
+| **Registration** (kept) | `static getInitialState` |
+| **Concrete helpers** (kept, not hooks) | `getViewport` (17 callers), `updateCursorStyle` (3 callers) |
+| **Capability methods** (kept, moved out of the base contract) | `renderPersistentFeatures` — now a capability, not a hook every mode inherits as a no-op |
+| **Deleted** | `renderCursor` (0 overrides, 1 caller that always hits the no-op), `getStateSnapshot` (0 overrides, 0 callers) |
+
+20 members → 18, of which 2 are concrete helpers and 1 moves to a capability.
+
+**Invariants**
+
+1. Every remaining hook has ≥ 1 real override or a documented lifecycle
+   contract explaining why the base implementation is the whole contract
+   (FR-005, AS-4.1).
+2. Deleted hooks have zero callers after PR 10 — verified by grep in the PR, and
+   by `tsc` once Story 1's flags are on.
+3. `FeatureRenderer.renderCurrentModeCursor()` — whose only job was calling the
+   deleted `renderCursor` — is removed with it, along with its call sites.
+
+---
+
+## 5. Instance sub-objects (Story 5)
+
+56 flat fields become 12, with 44 grouped behind four cohesive sub-objects. Full
+field lists in [baseline.md](./baseline.md) §6.
+
+| Sub-object | Fields | Contents |
+|---|---|---|
+| `instance.ui` | 30 | Every DOM element handle: containers, columns, LEDs, SVG groups, clip rects, the image, the toggles |
+| `instance.interaction` | 14 | Selection functions, restyle functions, control handles, registered listeners, wheel-pan transients |
+| `instance.viewport` | 2 | `resizeObserver`, `_boundHandleResize` |
+| `instance.persistence` | 2 | `_storageInstanceIndex`, `_isTrainerContext` |
+| *(ungrouped)* | 8 | `state`, `configTable`, `stateListeners`, `instanceId`, `modes`, `currentMode`, `featureRenderer`, `_unsupportedBrowser` |
+
+**Invariants**
+
+1. The grouping is a *move*, not a redesign: no field changes meaning, type, or
+   lifetime. `tsc` under Story 1's flags catches every missed reach-in.
+2. Sub-objects are created in the constructor before any initialization step
+   runs, so no step sees a partially-formed instance.
+3. `instance.state` remains ungrouped and directly accessible — it is the
+   broadcast state and the constitution names it. Story 5 reduces the *number
+   of reach-ins*, not the accessibility of the field.
+4. Ratchets `instanceStateReachIns` (243 → ≤ 185) and `instanceFields`
+   (56 → ≤ 33) fall monotonically (FR-008, AS-5.1).
+
+---
+
+## 6. Initialization steps (Story 5)
+
+Today: ten calls in a fixed order, each mutating the instance
+(`main.js:203-212`), with `DOMSetup.js:100-106` nulling fields another step
+re-creates.
+
+After: each step declares what it needs as parameters and returns what it built.
+
+| Step | Needs | Returns |
+|---|---|---|
+| `initializeDOMProperties` | `configTable` | `{ ui: {…} }` seed |
+| `setupSpectrogramComponents` | `ui.container` | `{ svg, cursorGroup, axesGroup, clipRects }` |
+| `createUnifiedLayoutStructure` | `ui.container` | column handles |
+| `setupPersistentContainers` | column handles | `{ markersContainer, harmonicsContainer }` |
+| `setupSpectrogramIfAvailable` | `configTable`, `ui.svg` | `{ spectrogramImage }` or nothing |
+| `initializeModeInfrastructure` | `state`, instance | `{ modes, featureRenderer }` |
+| `setupModeUI` | `modes`, column handles | `{ modesContainer, modeButtons }` |
+| `updateModeUIWithCommands` | `modes`, `currentMode` | `{ commandButtons, guidancePanel }` |
+| `setupAllEventListeners` | `ui`, `modes` | `{ registeredListeners }` |
+| `setupStateListeners` | instance | — |
+
+**Invariants**
+
+1. **FR-009**: no step relies on a field another step nulls and re-creates. The
+   `DOMSetup.js:100-106` double-nulling is removed.
+2. **AS-5.2**: reordering two steps produces a compile-time error (a required
+   parameter is missing) or an immediate explicit throw — never a silent
+   `undefined` surfacing later at runtime.
+3. The public construction contract is unchanged: `new GramFrame(configTable)`
+   yields a fully initialized instance, and the legacy-browser early return
+   (`main.js:196-201`) still short-circuits before any DOM work.
+
+---
+
+## 7. Type definitions removed (`types.js`)
+
+| Removed | Story | Reason |
+|---|---|---|
+| `_setZoom`, `_zoomIn`, `_zoomOut`, `_zoomReset` optional members (`types.js:431-434`) | 4 | Zoom flows through `core/viewport.js`; no caller reaches for the underscore members (FR-007) |
+| `getStateSnapshot` on the mode interface | 4 | Deleted hook |
+| `renderCursor` on the mode interface | 4 | Deleted hook |
+
+**Added**: the three capability typedefs, in `modes/capabilities.js` rather than
+`types.js`, so the interface lives beside its predicate.

--- a/specs/167-structural-refactor/plan.md
+++ b/specs/167-structural-refactor/plan.md
@@ -1,0 +1,250 @@
+# Implementation Plan: Phase 3 — Structural Refactor & Strict Type Gate
+
+**Branch**: `167-structural-refactor` | **Date**: 2026-07-31 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/167-structural-refactor/spec.md`
+
+## Summary
+
+Five structural changes, each landing as a sequence of small PRs that keep the
+suite green and ratchet a measured number monotonically down:
+
+1. **Strict type gate restored** — `noImplicitAny` then `strictNullChecks`
+   (+ `strictPropertyInitialization`, which rides along for free) burned down
+   from a measured **540** errors to zero behind a committed overlay tsconfig
+   and a CI-enforced ceiling, then folded into `tsconfig.json` permanently.
+2. **State ⇄ modes decoupled** — `core/state.js` stops importing the four mode
+   classes; mode initial-state slices arrive through the factory registration
+   seam. 10 of the 11 madge cycles dissolve. The global/per-instance listener
+   double-registry collapses to one.
+3. **`table.js` split** — 713 lines and six responsibilities become a
+   135-line scaffold plus `rendering/axes.js`, `components/spectrogramImage.js`,
+   `components/svgLayout.js`, and zoom/visible-range math merged into
+   `core/viewport.js`. The 11th cycle (ExpandToggle ⇄ table) dissolves.
+4. **Narrow mode contract, capability seams** — `BaseMode` sheds the hooks with
+   zero overrides; `FeatureRenderer`, `MainUI` and `PanMode` stop reaching into
+   named modes, `any`-casts and underscore-prefixed instance internals.
+5. **Shrunk instance surface & explicit initialization** — 56 constructor
+   fields and 243 `instance.state` reach-ins ratcheted down behind cohesive
+   sub-objects; the 10-call order-sensitive constructor becomes explicit; the
+   public API gains behavioural Playwright coverage.
+
+The ordering is load-bearing. Story 1's ceiling is established **first** and
+burns down continuously in the background, so every module moved by Stories
+2–5 is re-checked under real strictness as it moves. Story 2 precedes Story 4
+because capability interfaces are declared at the registration seam Story 2
+creates. Story 3 is independent. Story 5 is last because it is the only story
+whose ratchet target depends on all the others having landed.
+
+## Technical Context
+
+**Language/Version**: JavaScript ES2020+, JSDoc-typed, no TypeScript compilation
+**Primary Dependencies**: None at runtime (zero runtime deps); Vite 5 for build
+**Storage**: Unchanged — Web Storage (`localStorage` trainer / `sessionStorage` student). No persisted-shape change in this phase.
+**Testing**: Playwright 1.54 (e2e, `yarn test`); Vitest 4 (pure-JS unit lane, `yarn test:unit`); `yarn hygiene` ratchets; `yarn lint`
+**Target Platform**: Modern evergreen browsers; WebKit smoke lane
+**Project Type**: Single-project browser component (library, global + module export)
+**Performance Goals**: Unchanged from Phase 2 — no new work on hot paths; the phase must not regress the frame-bounded notification cadence
+**Constraints**: No behaviour change visible to end users; no new runtime dependencies; every PR keeps `yarn typecheck`/`yarn test`/`yarn build` green and raises no hygiene baseline; no long-lived integration branch
+**Scale/Scope**: 540 strict errors across 32 files; 11 madge cycles → ≤1; `table.js` 713 lines → 5 modules; 20 `BaseMode` hooks → ~14; 56 instance fields; 243 `instance.state` reach-ins across 22 files
+
+**No NEEDS CLARIFICATION items remain.** Three questions the spec left implicit
+are resolved in [research.md](./research.md): the per-flag ceiling mechanism
+(§R1, where a TypeScript constraint forces a change to the spec's stated
+approach), the mode-registration seam shape (§R3), and the re-baselining of
+Story 5's counters against post-Phase-2 reality (§R7).
+
+### Measurements taken for this plan
+
+All figures below are measured at `7115a8a` (post-Phase-2 `main`), not carried
+over from the audit. Full detail in [baseline.md](./baseline.md).
+
+| Quantity | Spec/audit says | Measured now | Used as |
+|---|---|---|---|
+| Strict-flag errors (all three on) | not stated | **540** | Story 1 ceiling |
+| — `noImplicitAny` alone | not stated | 143 | sub-count |
+| — `strictNullChecks` alone | not stated | 401 | sub-count |
+| — `strictPropertyInitialization` | "a flag to burn down" | **0 additional** | rides with `strictNullChecks` |
+| madge cycles | 11 | **11** | Stories 2–3 |
+| `table.js` lines | 716 | **713** | Story 3 |
+| `BaseMode` hooks with zero overrides | `renderCursor`, `getStateSnapshot` | **confirmed both** | Story 4 |
+| `instance.state` reach-ins | 371 / 21 files | **243 / 22 files** | Story 5 (re-baselined) |
+| Constructor fields | ~54 | **56** | Story 5 |
+
+Two of these change the plan materially and are called out here rather than
+buried: `strictPropertyInitialization` is **not** an independent burn-down
+(§R1), and the `instance.state` count is **243, not 371** — Phase 2's drag and
+coordinate consolidation already removed 128 reach-ins (§R7).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+| Principle | Status | Notes |
+|---|---|---|
+| **I. SVG-First Rendering** | ✅ Pass | Nothing moves to Canvas or absolutely-positioned DOM. Story 3 moves the axes engine into `rendering/axes.js` — still SVG, still DOM-queryable, and it puts the axis code beside `cursors.js`/`symbols.js` where the principle's rendering family already lives. Principle I names `src/utils/coordinates.js` as the coordinate system; Story 3 does not touch it (Phase 2 already consolidated there), and the zoom/visible-range math merged into `core/viewport.js` consumes it rather than duplicating it. |
+| **II. Test-First (NON-NEGOTIABLE)** | ✅ Pass, strengthened | Story 5 adds the behavioural Playwright coverage of the public API that GF-30's residual calls for (FR-010), reducing `__test__`-hook reliance. Stories 2–4 are move-and-rewire refactors whose gate is the existing suite passing unchanged — the constitution's "tests must pass before merging" is the phase's core safety argument (FR-011). |
+| **III. Modular Mode Architecture** | ✅ Pass, materially strengthened | This is the principle the phase most directly serves. "Adding a new mode MUST NOT require modifications to existing modes" is today violated in spirit by `state.js` importing all four modes and by `FeatureRenderer`/`MainUI` naming them; SC-003 makes the fifth-mode test explicit. `ModeFactory` remains and *gains* responsibility as the single registration point (FR-002). Cross-mode concerns stay in `FeatureRenderer` — it just stops naming the modes it coordinates (FR-006). |
+| **IV. Declarative HTML Configuration** | ✅ Pass | Untouched. `setupComponentTable`/`replaceConfigTable` keep the `table.js` name through the Story 3 split precisely so the `gram-config` contract stays where readers expect it. |
+| **Technical Constraints** | ⚠️ Tension — resolved | "State management: Centralized in `src/core/state.js` with listener pattern" — Story 2 keeps state centralized there and keeps the listener pattern; what moves out is the *import of mode classes*, so `state.js` composes slices handed to it instead of reaching for them. The deep-copy-before-listeners contract is unchanged (Phase 2's dispatcher owns it). HMR listener preservation is re-tested after the listener-registry unification (AS-2.3 names it explicitly). |
+| **Quality Gates** | ✅ Pass, strengthened | `yarn typecheck`, `yarn test`, `yarn build` gate every PR, plus `yarn hygiene`, `yarn lint`, `yarn test:unit`. Story 1 makes gate 1 mean what it claims: today `yarn typecheck` passes with three strict flags off. |
+
+**Gate result: PASS.** One tension (Technical Constraints' "centralized in
+`state.js`") is resolved by preserving centralization and removing only the
+inverted dependency — no constitutional amendment needed, no entry required in
+Complexity Tracking.
+
+**Post-Phase-1 re-check: still PASS.** The Phase 1 design adds four modules
+(`rendering/axes.js`, `components/spectrogramImage.js`,
+`components/svgLayout.js`, `modes/capabilities.js`) and one committed config
+overlay (`tsconfig.strict.json`, deleted at the end of Story 1); it deletes no
+principle-bearing code. Module count rises by four while the largest module
+falls from 713 to ~310 lines — the trade SC-004 asks for.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/167-structural-refactor/
+├── plan.md              # This file
+├── baseline.md          # Measured starting numbers (all ratchet sources)
+├── research.md          # Phase 0 — decisions R1..R9
+├── data-model.md        # Phase 1 — structural entities; no persisted-shape change
+├── quickstart.md        # Phase 1 — how to run/verify each story
+├── contracts/
+│   ├── strict-ratchet.md      # tsconfig.strict.json + hygiene ceiling contract
+│   ├── mode-registration.md   # How a mode contributes initial state
+│   ├── capabilities.md        # Capability interfaces modes opt into
+│   └── axes.md                # rendering/axes.js public interface
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── core/
+│   ├── state.js                 # − imports of the 4 mode classes (Story 2)
+│   │                            # − globalStateListeners copy-out (Story 2)
+│   ├── viewport.js              # + applyZoomTransform, calculateVisibleDataRange
+│   │                            #   from table.js — one zoom seam (Story 3, FR-007)
+│   ├── FeatureRenderer.js       # named modes → capability iteration (Story 4)
+│   └── initialization/
+│       ├── DOMSetup.js          # steps return what they built (Story 5)
+│       ├── UISetup.js           #   "
+│       ├── EventBindings.js     # − global-listener copy loop (Story 2)
+│       └── ModeInitialization.js#   "
+├── modes/
+│   ├── BaseMode.js              # − renderCursor, − getStateSnapshot (Story 4)
+│   ├── ModeFactory.js           # + getModeInitialStates(), + capability roster
+│   ├── capabilities.js          # NEW — capability predicates & typedefs
+│   └── pan/PanMode.js           # instance._zoomIn/_zoomOut → viewport seam
+├── components/
+│   ├── table.js                 # scaffold + config-table replacement ONLY (~135)
+│   ├── spectrogramImage.js      # NEW — setupSpectrogramImage, getRenderDimensions
+│   ├── svgLayout.js             # NEW — updateSVGLayout
+│   ├── MainUI.js                # − 2 any-casts to named modes (Story 4)
+│   └── ExpandToggle.js          # imports layout/axes, not table.js — cycle gone
+├── rendering/
+│   └── axes.js                  # NEW — renderAxes + 8 private helpers (~310)
+├── main.js                      # 56 fields → cohesive sub-objects (Story 5)
+└── types.js                     # − _zoomIn/_zoomOut/_setZoom/_zoomReset typedefs
+
+tests/
+├── public-api.spec.js           # NEW — behavioural coverage (Story 5, FR-010)
+├── mode-registration.spec.js    # NEW — fifth-mode spike evidence (SC-003)
+└── unit/
+    └── mode-registration.test.js# NEW — mode loads without importing state.js
+
+tsconfig.strict.json             # NEW, TEMPORARY — deleted when Story 1 hits 0
+hygiene-baseline.json            # + strictTypeErrors, instanceStateReachIns,
+                                 #   instanceFields
+scripts/hygiene.js               # + three new ratchets
+```
+
+**Structure Decision**: Single-project layout, unchanged. The phase adds one
+directory member (`src/modes/capabilities.js`) and populates the long-claimed
+`src/rendering/axes.js` that CLAUDE.md has documented and GF-38 flagged as
+phantom. No new top-level directories.
+
+## Sequencing & PR Breakdown
+
+Each row is one PR with its own green gate. Story 1's rows interleave with the
+others in wall-clock time — the ceiling is established in PR 1 and every
+subsequent PR lowers it as a side effect of touching strict-unclean files.
+
+| # | Story | Content | Gate |
+|---|---|---|---|
+| 1 | S1 | `tsconfig.strict.json` overlay + `strictTypeErrors: 540` ratchet in `hygiene.js`; no source change | `yarn hygiene` reports 540/540; CI fails a deliberate +1 |
+| 2 | S1 | `noImplicitAny` burn-down: the 46 `TS7008` member declarations in `main.js` + `TS7006`/`TS7053` params | Ceiling lowered in the same PR (AS-1.2) |
+| 3 | S1 | `strictNullChecks` burn-down, tranche A: `core/` (`state.js` 21, `viewport.js` 28, `events.js` 15, `FeatureRenderer.js` 16, `UISetup.js` 20, `FocusManager.js` 6) | Ceiling lowered |
+| 4 | S2 | `ModeFactory.getModeInitialStates()`; `createInitialState(modeStates)` takes slices; `state.js` drops the four mode imports | madge: no cycle contains `state.js` + a `modes/` file; baseline lowered 11 → ~1 (AS-2.1) |
+| 5 | S2 | Listener registry unification: instances stop copying `globalStateListeners`; delivery walks one union; HMR re-registration re-tested | AS-2.3 — add-then-remove touches one registry, no duplicate delivery |
+| 6 | S3 | Extract `rendering/axes.js` (renderAxes + 8 helpers) — pure move | Suite unchanged; reviewed as a move (AS-3.1, AS-3.2) |
+| 7 | S3 | Extract `spectrogramImage.js` + `svgLayout.js`; `ExpandToggle` rewired | ExpandToggle⇄table cycle gone, no new cycle (AS-3.3) |
+| 8 | S3 | Merge `applyZoomTransform` + `calculateVisibleDataRange` into `core/viewport.js`; `table.js` is scaffold-only | One zoom home for wheel/keyboard/API (AS-3.4, FR-007) |
+| 9 | S1 | `strictNullChecks` burn-down, tranche B: `components/` + the now-split `table.js` family (65 errors, re-attributed across PRs 6–8) | Ceiling lowered |
+| 10 | S4 | Delete `renderCursor` and `getStateSnapshot` from `BaseMode`; audit every remaining hook against §R6's table | AS-4.1 — no deleted hook has a caller |
+| 11 | S4 | `modes/capabilities.js`; `FeatureRenderer` iterates by capability; `MainUI`'s two `any`-casts removed | AS-4.2 — no mode-name string, no `any` cast |
+| 12 | S4 | PanMode uses the `core/viewport.js` seam; `_zoomIn/_zoomOut/_zoomReset/_setZoom` typedefs removed from `types.js` | AS-4.3, FR-007 |
+| 13 | S1 | `strictNullChecks` burn-down, tranche C: `modes/` (143 errors across the four modes + `BaseMode` + `BaseDragHandler`) | Ceiling lowered |
+| 14 | S1 | Final burn-down; flip all three flags in `tsconfig.json`; delete `tsconfig.strict.json` and the ratchet entry; annotate ADR-007 | **SC-001** — `strict: true`, zero disables, `yarn typecheck` green |
+| 15 | S5 | `instanceStateReachIns: 243` + `instanceFields: 56` ratchets; no source change | Ratchets live before the refactor that moves them (AS-5.1) |
+| 16 | S5 | Group DOM handles into `instance.ui`; accessors; reach-ins ratcheted down | Ratchet lowered; suite green |
+| 17 | S5 | Group `viewport` / `interaction` / `persistence` fields; explicit initialization — each step returns what it built, double-nulling removed | AS-5.2 — reordering two steps errors explicitly, not silently |
+| 18 | S5 | `tests/public-api.spec.js`: behavioural assertions for `addStateListener`, `removeStateListener`, `detectAndReplaceConfigTables`, `init`, `getExpandState`, `setExpandState` | **SC-006** — every documented method has a non-`typeof` assertion |
+| 19 | S3/S4 | Fifth-mode spike as SC-003 evidence + the three ADRs (§R9) | SC-003 — spike touches only `modes/` + factory registration |
+
+**Hard dependencies**
+
+- PR 1 before PRs 2–3, 9, 13, 14 (the ceiling must exist before it can fall).
+- PR 4 before PRs 10–12: capability interfaces are declared at the registration
+  seam PR 4 creates, and the fifth-mode test (SC-003) is meaningless while
+  `state.js` still imports the mode roster.
+- PRs 6–8 in that order: `table.js`'s remaining importers are rewired
+  incrementally, so the scaffold is the last thing to shrink.
+- PR 15 before PRs 16–17 (same reason as PR 1).
+- PR 14 should land **after** PRs 6–8 and 10–12 where practical, so moved code
+  is written strict-clean once rather than fixed twice. It is sequenced last in
+  Story 1 for exactly this reason.
+
+## Scope observations
+
+Two items in the spec's Success Criteria are not fully reachable from the
+spec's own stories. Both are surfaced here rather than silently reinterpreted;
+neither blocks the phase.
+
+- **SC-004** ("no source module exceeds ~350 lines except by documented
+  exception") — Story 3 fixes `table.js`, and Story 5 shrinks `main.js`. That
+  leaves seven modules over 350 lines that no story in this spec touches:
+  `HarmonicsMode.js` (1016), `DopplerMode.js` (657), `types.js` (617),
+  `AnalysisMode.js` (612), `keyboardControl.js` (561), `GramFrameAPI.js` (413),
+  `events.js` (395). The spec itself calls SC-004 "a review heuristic, not a
+  hard gate" (Assumptions), so the plan treats it as: **table.js and main.js
+  are brought under the line; the remaining seven are recorded as documented
+  exceptions** in the hygiene baseline file, with the three mode files noted as
+  candidates for a later phase. `types.js` is a declaration file and is
+  exempted on its face.
+- **SC-005** ("reduce `instance.state` reach-ins ≥ 50% from the 371 baseline")
+  — the 371 figure predates Phase 2; the count today is 243. §R7 resolves this
+  in favour of the spec's *endpoint* (≤ 185) rather than its *percentage*,
+  which would demand a further 50% cut from an already-halved number.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| A 540-error burn-down stalls half-done and the overlay lives forever | The ceiling is a ratchet, not a deadline: it can only fall, so a stalled burn-down is visible and harmless. PR 14 is gated on zero, and PRs 6–13 lower the count as a side effect of code they already touch. |
+| Strict fixes silently change runtime behaviour (a `?.` where a throw was intended) | Every burn-down PR is reviewed against the rule in §R2: null-guards preserve existing behaviour, and any site where the correct fix is a *behaviour* change is split into its own PR with a test. |
+| Removing the mode imports from `state.js` breaks initial-state composition order | `createInitialState` keeps its merge order (analysis, harmonics, doppler, pan) explicitly in `ModeFactory`; a unit test in the Vitest lane pins the composed shape against a frozen snapshot before PR 4 changes anything. |
+| Listener-registry unification drops HMR-preserved listeners | AS-2.3 names HMR explicitly; `main.js:663-666` is the one HMR re-registration site and gets a dedicated assertion in `tests/state-listener.spec.js`. |
+| The `table.js` split changes behaviour under the guise of a move | PRs 6–8 are reviewed as pure moves (AS-3.1): the diff must be import-rewiring plus relocation, with `git diff -M` showing the rename. Any behaviour change is a separate PR. |
+| Capability interfaces become a second, weaker naming scheme | §R6 fixes the roster at three capabilities and requires each to be exercised by the fifth-mode spike (SC-003) before it is considered real. |
+| Grouping instance fields breaks the `__test__` hooks and the debug page | Story 5's PRs land after Story 1's typing work on `main.js`, so `tsc` catches every renamed reach-in; the debug page is in the suite. |
+
+## Complexity Tracking
+
+> No Constitution Check violations require justification. The single tension
+> (Technical Constraints' "state centralized in `src/core/state.js`") is
+> resolved by keeping state centralized there and removing only the inverted
+> import direction — an exception is not needed.

--- a/specs/167-structural-refactor/quickstart.md
+++ b/specs/167-structural-refactor/quickstart.md
@@ -1,0 +1,201 @@
+# Quickstart — Phase 3 verification
+
+How to run and verify each story. Every PR in the phase must pass the standing
+gate before anything story-specific is checked.
+
+## Standing gate (every PR, FR-011)
+
+```bash
+yarn typecheck     # zero errors
+yarn test          # full Playwright suite green
+yarn build         # clean production build
+yarn hygiene       # no baseline raised
+yarn lint
+yarn test:unit
+```
+
+No PR in this phase may raise a hygiene baseline. When a PR lowers a count,
+lower the baseline in `hygiene-baseline.json` **in the same PR**.
+
+---
+
+## Story 1 — Strict type gate
+
+### Establish the ceiling (PR 1)
+
+```bash
+yarn hygiene
+# ✔ Strict type errors (tsconfig.strict.json): 540 (baseline 540)
+```
+
+Prove the ratchet bites — introduce a deliberate regression and confirm it fails:
+
+```bash
+# add `const x = document.querySelector('.nope'); x.classList.add('a')` to any src/ file
+yarn hygiene       # must exit non-zero, printing the new error
+git checkout -- .
+```
+
+### Measure any flag combination by hand
+
+```bash
+node -e "
+const fs=require('fs');const c=JSON.parse(fs.readFileSync('tsconfig.json','utf8'));
+for (const f of process.argv.slice(1)) c.compilerOptions[f]=true;
+fs.writeFileSync('tsconfig.probe.json',JSON.stringify(c,null,2));
+" noImplicitAny strictNullChecks strictPropertyInitialization
+npx tsc --noEmit -p tsconfig.probe.json 2>&1 | grep -c "error TS"   # 540
+rm tsconfig.probe.json
+```
+
+The probe tsconfig **must be written to the repo root**. From anywhere else it
+cannot resolve `node_modules/@types` and reports ~46 phantom errors.
+
+`strictPropertyInitialization` on its own returns `TS5052` — it requires
+`strictNullChecks`. That is a config error, not two type errors.
+
+### Track the burn-down
+
+```bash
+# errors by file
+npx tsc --noEmit -p tsconfig.strict.json 2>&1 | grep "error TS" | sed 's/(.*//' | sort | uniq -c | sort -rn
+# errors by code
+npx tsc --noEmit -p tsconfig.strict.json 2>&1 | grep -o "error TS[0-9]*" | sort | uniq -c | sort -rn
+```
+
+### Final acceptance (PR 14, SC-001)
+
+```bash
+grep -E "strictNullChecks|noImplicitAny|strictPropertyInitialization" tsconfig.json   # no matches
+ls tsconfig.strict.json                                                               # not found
+yarn typecheck                                                                        # passes
+```
+
+**Independent test** (spec US1): add `document.querySelector('.nope').classList`
+to any `src/` file — `yarn typecheck` must now fail. Before the phase it passed.
+
+---
+
+## Story 2 — State and modes decoupled
+
+```bash
+# no cycle contains both state.js and a modes/ file (AS-2.1)
+node -e "
+import('madge').then(async ({default:m}) => {
+  const g = await m('src/index.js', {fileExtensions:['js']});
+  const bad = g.circular().filter(c =>
+    c.some(f => f.endsWith('core/state.js')) && c.some(f => f.includes('modes/')));
+  console.log('state<->modes cycles:', bad.length);
+  console.log('total cycles:', g.circular().length);
+})"
+# expect: 0 and ≤ 1
+
+# state.js imports no mode
+grep -c "from '../modes/" src/core/state.js     # 0
+```
+
+```bash
+yarn test:unit                    # mode-registration.test.js: mode loads without state.js
+yarn test tests/state-listener.spec.js   # AS-2.3: one registry, no duplicate delivery, HMR
+```
+
+**Fifth-mode check (AS-2.2)**: on the spike branch, a new mode's initial state
+appears in `GramFrame.__test__getInstances()[0].state` with no edit to
+`src/core/state.js`.
+
+---
+
+## Story 3 — `table.js` split
+
+```bash
+wc -l src/components/table.js src/rendering/axes.js \
+      src/components/spectrogramImage.js src/components/svgLayout.js src/core/viewport.js
+# expect ≈ 135 / 310 / 90 / 60 / 305 — all under 350 (SC-004)
+
+# table.js has exactly one importer left
+grep -rn "components/table.js" src --include=*.js    # DOMSetup.js only
+
+# the ExpandToggle cycle is gone (AS-3.3)
+yarn hygiene
+```
+
+Review discipline: PRs 6–8 must read as moves.
+
+```bash
+git diff -M --stat    # renames, not rewrites
+```
+
+Behavioural gate (AS-3.1): the full suite passes **with no spec file edited**.
+A spec that needed changing means the move was not a move.
+
+---
+
+## Story 4 — Narrow mode contract, capability seams
+
+```bash
+# deleted hooks have no callers (AS-4.1)
+grep -rn "renderCursor\|getStateSnapshot" src --include=*.js     # no matches
+
+# no mode-name reach-ins outside modes/ except the documented exception (AS-4.2)
+grep -rn "modes\.\(analysis\|harmonics\|doppler\|pan\)\|modes\['" src --include=*.js
+# expect: viewport.js:162 only (research §R6)
+
+# no any-cast to a mode
+grep -rn "@type {any} */ (instance.modes" src --include=*.js     # no matches
+
+# zoom goes through one seam (AS-4.3, FR-007)
+grep -rn "_zoomIn\|_zoomOut\|_zoomReset\|_setZoom" src --include=*.js
+```
+
+```bash
+yarn test tests/pan-zoom.spec.js   # unchanged spec must still pass
+```
+
+---
+
+## Story 5 — Instance surface & explicit initialization
+
+```bash
+# the two ratcheted counts
+grep -rn "instance\.state" src --include=*.js | wc -l        # 243 → ≤ 185
+awk '/^export class GramFrame/,/^  constructor/' src/main.js \
+  | grep -cP "^  [a-zA-Z_]\w*\s*(;|=)"                       # 56 → ≤ 33
+
+yarn hygiene    # both ratchets, monotonically down (AS-5.1)
+```
+
+**Initialization ordering (AS-5.2)**: swap two calls in the constructor and
+confirm the failure is loud — a `tsc` error for a missing required argument, or
+an immediate explicit throw. A silent `undefined` surfacing later is a fail.
+
+```bash
+yarn test tests/public-api.spec.js    # SC-006
+```
+
+The public-API spec runs against a fixture that does **not** set
+`window.GRAMFRAME_DEBUG`, so it proves the API works without the `__test__`
+hooks — and catches those hooks leaking onto a production page.
+
+---
+
+## Phase acceptance
+
+| Criterion | Check |
+|---|---|
+| **SC-001** | `tsconfig.json` has `strict: true`, zero strict-family disables; `yarn typecheck` passes |
+| **SC-002** | madge cycles ≤ 1; any residue documented in `hygiene-baseline.json` |
+| **SC-003** | Fifth-mode spike touches only `modes/` + factory registration |
+| **SC-004** | `table.js` is scaffold-only; the seven remaining >350-line modules are recorded as documented exceptions (see plan §Scope observations) |
+| **SC-005** | Reach-ins ≤ 185; constructor fields ≤ 33 |
+| **SC-006** | Every documented public API method has a behavioural (not `typeof`) assertion |
+
+---
+
+## Notes
+
+- **Baselines only go down.** If a count rises, the fix is the diff, not the
+  baseline.
+- **Behaviour changes are never bundled into a refactor PR.** Stories 2–4 are
+  move-and-rewire; Story 1's burn-down is annotations and behaviour-preserving
+  guards. Anything else gets its own PR and its own test (research §R2).
+- **No long-lived branch** (FR-011). Each PR lands on `main` green.

--- a/specs/167-structural-refactor/research.md
+++ b/specs/167-structural-refactor/research.md
@@ -1,0 +1,359 @@
+# Phase 0 Research — Structural Refactor & Strict Type Gate
+
+Decisions taken before design, each with the alternatives that were rejected.
+Measurements referenced here live in [baseline.md](./baseline.md).
+
+---
+
+## R1 — `strictPropertyInitialization` is not an independent burn-down
+
+**Decision**: Treat the three flags as **two** burn-downs, not three.
+`noImplicitAny` (143 errors) and `strictNullChecks` (401) are burned down
+separately; `strictPropertyInitialization` is enabled in the same commit as
+`strictNullChecks` and contributes no errors of its own.
+
+**Rationale**: TypeScript refuses the combination the spec assumes.
+Setting `strictPropertyInitialization: true` without `strictNullChecks: true`
+produces `TS5052: Option 'strictPropertyInitialization' cannot be specified
+without specifying option 'strictNullChecks'` — a configuration error, not a
+type error. An early probe that appeared to show "2 errors" for the flag was
+counting exactly those two `TS5052` lines. With `strictNullChecks` on, adding
+`strictPropertyInitialization` changes the count not at all: 401 → 401.
+
+The reason is visible in the code: `main.js` declares its 56 fields bare
+(`container;` with a JSDoc comment above), and a JS class field with no
+initializer and no type annotation is not a property `strictPropertyInitialization`
+can complain about — it is an *implicit any* member, which is
+`noImplicitAny`'s 46 `TS7008` errors. Fixing those with `@type` annotations is
+what would create `strictPropertyInitialization` work, and the spec's own
+Assumptions already permit definite-assignment annotations at those sites.
+
+**Impact on the spec**: AS-1.1 ("for each disabled flag, record the current
+error count under that flag as a ceiling") cannot be satisfied literally for
+the third flag. FR-001's substance — all three enabled at the end, with
+CI-enforced non-increasing ceilings at every intermediate step — is satisfied
+in full by §R3's single-ceiling mechanism.
+
+**Alternatives rejected**:
+- *Three separate ceilings, one per flag* — impossible for the third flag, and
+  for the other two it creates a re-baselining problem: enabling `noImplicitAny`
+  permanently changes the `strictNullChecks` count (401 → 397), so a per-flag
+  ceiling would have to be re-measured mid-phase, and a re-measurement that
+  moves a ratchet is exactly the thing a ratchet exists to prevent.
+- *Enable `strictNullChecks` first, `noImplicitAny` second* — legal, but wastes
+  work: null-checking code whose types are still implicitly `any` produces
+  errors that change once real types arrive. Fixing 143 implicit-any errors
+  first leaves 397 rather than 401 null errors — a small win, and a larger one
+  in avoided rework.
+
+---
+
+## R2 — Burn-down rule: null-guards preserve behaviour; behaviour changes are separate PRs
+
+**Decision**: A strict-fix PR may only add type annotations, null guards that
+preserve the current runtime path, and non-null assertions where the invariant
+is genuinely established. Any site where the honest fix would *change*
+behaviour — a missing early return, a swallowed undefined that should throw —
+is split out into its own PR with a test, and the strict error is left standing
+until then.
+
+**Rationale**: 314 of the 540 errors (58%) are `possibly undefined`/`possibly
+null` on DOM and state access. Each is a fork: the guard that silences the
+compiler (`if (!x) return`) may or may not be what the code should do. Bundling
+those judgements into a 50-file burn-down PR is how a refactor phase ships a
+regression under cover of "type-only changes". Keeping them separable is what
+lets PRs 2, 3, 9 and 13 be reviewed quickly and honestly.
+
+The concrete tell that this matters: `TS2783` (20 errors) reports
+`src/core/state.js:38-39` setting `version` and `timestamp` and then spreading
+`buildModeInitialState()` over them. That is a latent bug — a mode returning a
+`version` key would silently win — and it deserves a fix and a test, not a
+cast.
+
+**Alternatives rejected**:
+- *`// @ts-expect-error` sweep to reach zero fast* — reaches SC-001's letter
+  while destroying its point, and leaves comments that must later be found and
+  removed.
+- *`any`-cast at each error site* — same objection, and it would fight
+  `noImplicitAny` on the way back.
+
+---
+
+## R3 — The ceiling mechanism: one committed overlay tsconfig, one ratchet number
+
+**Decision**: Add `tsconfig.strict.json` at the repo root — a temporary,
+committed file that extends `tsconfig.json` and turns the three flags on — plus
+a `strictTypeErrors: 540` entry in `hygiene-baseline.json` that
+`scripts/hygiene.js` enforces by running `tsc -p tsconfig.strict.json` and
+counting `error TS` lines. Both are deleted in PR 14 when the count reaches
+zero and the flags move into `tsconfig.json` proper.
+
+**Rationale**: It reuses the ratchet machinery spec 164 already built and the
+team already reads. `yarn hygiene` fails on a rise, prints the improvement
+reminder on a fall, and the baseline file already carries the "these only ever
+go down" comment. One number, measured under the end-state configuration, is
+monotone by construction — which is precisely what the per-flag alternative in
+§R1 could not offer.
+
+The per-flag sub-counts (143 / 401) are still printed in the ratchet's detail
+output, so the burn-down's shape stays visible without becoming a gate.
+
+**Two implementation details worth pinning down**:
+
+1. The probe tsconfig **must live at the repo root**. A tsconfig written to a
+   temp directory cannot resolve `node_modules/@types` and silently reports ~46
+   extra errors — an inflated ceiling that would then never be reachable. The
+   hygiene script uses the committed root-level file, so this is structural
+   rather than a caution.
+2. `hygiene.js` must distinguish a *type* error from a *config* error. A
+   `TS5052`/`TS6046` in the output means the overlay is malformed; the script
+   should fail loudly rather than report a count, for the same reason it
+   already errors when madge resolves fewer than 10 modules.
+
+**Alternatives rejected**:
+- *A separate `scripts/strict-ratchet.js`* — a second script with a second
+  baseline file, for one number that the existing script is already shaped to
+  hold.
+- *Per-directory tsconfigs enabling strictness incrementally by folder* — finer
+  control, but it fragments the build config and the phase's file-by-file
+  tranches (PRs 3, 9, 13) already give directory-shaped increments without it.
+- *`typescript-strict-plugin` or a `// @ts-strict` per-file pragma* — a new dev
+  dependency and a second dialect of strictness for a burn-down expected to
+  take one phase.
+
+---
+
+## R4 — Mode registration: the factory composes initial state, `state.js` receives it
+
+**Decision**: `ModeFactory` gains `getModeInitialStates()`, returning the four
+slices in a fixed order. `createInitialState()` takes them as an argument:
+
+```js
+// core/state.js — no mode imports
+export function createInitialState(modeStates = {}) { … }
+
+// modes/ModeFactory.js — already imports all four classes
+static getModeInitialStates() {
+  return Object.assign({},
+    AnalysisMode.getInitialState(),
+    HarmonicsMode.getInitialState(),
+    DopplerMode.getInitialState(),
+    PanMode.getInitialState())
+}
+
+// main.js — composes at the call site
+this.state = createInitialState(ModeFactory.getModeInitialStates())
+```
+
+**Rationale**: It is the smallest cut that severs 10 of the 11 cycles.
+`ModeFactory` already imports all four mode classes and is already the
+constitution's "single entry point for mode instantiation" — extending it to be
+the single entry point for mode *state* is the same idea, and requires no new
+module. `state.js` keeps its role as the centralized state module (Technical
+Constraints) and simply stops reaching downward for the roster.
+
+The static-method shape (`static getInitialState()`) is untouched, so no mode
+file changes in PR 4 — the whole cycle-cutting PR is three files.
+
+`createInitialState()` keeping a default `{}` argument means the Vitest lane can
+import `state.js` and build a core state without loading any mode — which is
+AS-2.2's independent test, expressible as a unit test rather than an
+integration one.
+
+**Alternatives rejected**:
+- *Side-effect registration* (`registerMode(AnalysisMode)` at module load) —
+  makes the composed state depend on import order, which is exactly the
+  load-order fragility GF-03 is about.
+- *A new `modes/registry.js`* — a fifth module doing what `ModeFactory` already
+  exists to do, and it would need the same four imports.
+- *Modes push their slice during construction* — initial state must exist
+  before the first mode is constructed (the modes read `instance.state`), so
+  this inverts a real dependency.
+
+---
+
+## R5 — One listener registry: instances stop copying the global list
+
+**Decision**: `globalStateListeners` remains the storage for API-registered
+listeners. Instances stop copying it into `instance.stateListeners` at
+construction (`EventBindings.js:46`) and stop splicing it on removal
+(`GramFrameAPI.js:283-289`). Delivery in `deliverToListeners` walks the union of
+`instance.stateListeners` (per-instance listeners only) and the global list,
+de-duplicated. `addStateListener` writes to one place; `removeStateListener`
+removes from one place.
+
+**Rationale**: GF-06 is a *copying* bug, not a two-lists bug — the same callback
+lives in N+1 arrays, so removal must find and splice N+1 times and any missed
+instance leaks a live listener. Removing the copy step leaves two arrays with
+genuinely different lifetimes (global: survives instance destruction; instance:
+does not) and one write path into each. That satisfies AS-2.3's "exactly one
+registry is touched" for any given call, without inventing a subscription
+manager.
+
+The immediate-call-with-current-state behaviour of `addStateListener`
+(`GramFrameAPI.js:237-244`) is preserved — it is observable API behaviour and
+`tests/state-listener.spec.js` asserts it.
+
+**HMR**: `main.js:663-666` reads the global list, recreates instances, then
+clears it. With the copy gone, the recreated instances pick up global listeners
+through delivery rather than through a copy, so the clear-and-reregister dance
+simplifies. AS-2.3 names HMR explicitly, so this gets its own assertion.
+
+**Alternatives rejected**:
+- *Collapse to a single global list, dropping per-instance listeners* — the
+  per-instance list is what makes `flushDispatch(instance)` and Phase 2's
+  no-listener fast path work; and multi-instance pages (Principle IV) need
+  per-instance delivery.
+- *A `Set` instead of arrays* — would give free de-duplication, but delivery
+  order becomes insertion order across two sets and the existing specs assert
+  ordering in places. Not worth coupling to this change.
+
+---
+
+## R6 — Three capability interfaces, duck-typed, exercised by the fifth-mode spike
+
+**Decision**: Add `src/modes/capabilities.js` declaring three capabilities as
+JSDoc typedefs plus a predicate each. A mode opts in by implementing the
+methods; nothing registers, nothing inherits.
+
+| Capability | Methods | Replaces |
+|---|---|---|
+| `PersistentFeatureProvider` | `hasPersistentFeatures(): boolean`, `renderPersistentFeatures(): void` | `FeatureRenderer.js:32-44` naming three modes and owning three `hasXFeatures()` predicates |
+| `PanelOwner` | `refreshPanel(): void` | `MainUI.js:211,217` `any`-casting to `modes['analysis']` / `modes['harmonics']` |
+| `ZoomConsumer` | — (consumes, does not implement) | `PanMode.js:219,225` calling `instance._zoomIn/_zoomOut` |
+
+`FeatureRenderer.renderAllPersistentFeatures()` becomes:
+
+```js
+Object.values(this.instance.modes)
+  .filter(isPersistentFeatureProvider)
+  .filter(mode => mode.hasPersistentFeatures())
+  .forEach(mode => mode.renderPersistentFeatures())
+```
+
+The three `hasXFeatures()` predicates move onto the modes that own the state
+they inspect — which is where they always belonged; `FeatureRenderer` currently
+reads `state.analysis.markers`, `state.harmonics.harmonicSets` and three
+`state.doppler.*` fields directly, so removing them also deletes eight
+`instance.state` reach-ins toward Story 5's ratchet.
+
+**Rationale for duck typing over a class hierarchy or a declared roster**: the
+project is JSDoc-typed JavaScript with no compilation step. A `capabilities`
+array on each mode would be a second thing to keep in sync with the methods it
+describes. `typeof mode.renderPersistentFeatures === 'function'` is checkable at
+runtime, expressible as a JSDoc typedef for `tsc`, and impossible to get out of
+sync with the implementation.
+
+**On `ZoomConsumer`**: there is nothing for a mode to implement — the fix is
+that PanMode imports `zoomIn`/`zoomOut` from `core/viewport.js` like every other
+caller, rather than calling `instance._zoomIn()`. FR-007's "one shared seam" is
+`core/viewport.js`, and `main.js`'s `_zoomIn`/`_zoomOut`/`_zoomReset`/`_setZoom`
+become thin forwarders retained only for the public API's benefit — or are
+removed outright if the API can call viewport directly. That decision is
+deferred to PR 12, where the call graph is visible.
+
+**One reach-in stays**: `viewport.js:162` reads `instance.modes.pan` to decide
+whether to leave pan mode when zoom returns to 1×. That is a genuine
+pan-specific policy, not a cross-cutting concern, and inventing a fourth
+capability for one call site would be worse than the reach-in. It is recorded
+as a documented exception to FR-006 rather than dressed up.
+
+**Alternatives rejected**:
+- *An abstract `PersistentFeatureMode` subclass* — forces single inheritance in
+  a system where Doppler is plausibly both a feature provider and a panel owner.
+- *A capability registry keyed by string* — reintroduces exactly the mode-name
+  strings FR-006 exists to remove.
+
+---
+
+## R7 — Story 5's ratchets are re-baselined to measured reality
+
+**Decision**: Baseline `instanceStateReachIns` at **243** (not the spec's 371)
+and `instanceFields` at **56** (not ~54). Interpret SC-005 by its **endpoints**:
+reach-ins ≤ **185**, constructor fields ≤ **33**.
+
+**Rationale**: The 371 figure was measured at `edfc549`, before Phase 2. The
+coordinate and drag consolidations removed 128 reach-ins as a by-product, so
+the count today is 243 across 22 files. Two readings of SC-005 are available and
+they differ by a lot:
+
+- *"≥ 50% below 371"* → target ≤ 185. A further 24% cut from today. Achievable
+  by the four sub-object groupings, and it delivers the absolute number the
+  spec author wrote down.
+- *"≥ 50% below whatever it is when the story starts"* → target ≤ 121. A 50%
+  cut on top of a 34% cut already taken — a much larger job, and one the spec
+  had no way of scoping since Phase 2 had not landed when it was written.
+
+The first reading is adopted: the spec's number is the commitment, and Phase 2
+having done some of the work early is not a reason to demand more. The same
+logic gives constructor fields 56 → ≤ 33 (the spec's "≥ 40% from ~54" endpoint
+is 32.4; measured against 56 the same percentage gives 33.6 — ≤ 33 satisfies
+both readings).
+
+Baseline.md §6 shows the grouping arithmetic reaches 12 constructor fields, so
+the field target has substantial headroom. The reach-in target is the binding
+one.
+
+**Alternatives rejected**:
+- *Keep 371 as the ratchet baseline* — a ratchet that starts 128 above the
+  current value cannot fail, which makes it decoration.
+- *Silently retarget to ≤ 121* — a harder goal than the spec asked for,
+  adopted without the author's say-so.
+
+---
+
+## R8 — Public API coverage: one spec, behavioural assertions, no new debug hooks
+
+**Decision**: `tests/public-api.spec.js` exercises the six documented methods as
+a consumer would, from a fixture page that does **not** set
+`window.GRAMFRAME_DEBUG`. Each gets at least one assertion about an effect, not
+about a type.
+
+| Method | Behavioural assertion |
+|---|---|
+| `init()` | on a page with two `gram-config` tables, returns 2 instances and both tables are replaced by `.gram-frame-container` |
+| `detectAndReplaceConfigTables(el)` | scoped to a subtree, replaces only tables inside it; a table outside is untouched |
+| `addStateListener(cb)` | `cb` fires immediately with current state, then again after a mode switch, with `state.mode` changed |
+| `removeStateListener(cb)` | after removal, a mode switch produces no further call; returns `true` for a known listener and `false` for an unknown one |
+| `getExpandState()` | reflects the expanded state after `setExpandState(true)` |
+| `setExpandState(true/false)` | the image element's rendered width changes; `getExpandState()` agrees |
+
+**Rationale**: FR-010 and SC-006 are about the API being *tested as an API*.
+Running against a non-debug page is what makes that real — it proves the public
+surface works without the `__test__` hooks, which is precisely GF-30's residual
+finding ("interactions still route through `__test__` hooks and the public API
+surface remains untested"). It also guards the debug-gating itself: if
+`__test__*` ever leaks onto a production page, this spec is where it shows up.
+
+The existing `auto-detection.spec.js:88,96` `typeof` checks stay — they are
+cheap smoke assertions — but they stop being the only coverage.
+
+**Alternatives rejected**:
+- *Extend `auto-detection.spec.js`* — mixes auto-discovery (Principle IV)
+  assertions with API-contract assertions in one file.
+- *Unit-test the API against a jsdom stub* — `setExpandState` measures rendered
+  image geometry; the constitution's "unit tests alone cannot catch rendering
+  regressions" applies directly.
+
+---
+
+## R9 — ADRs: fill the ADR-014 gap, add two, annotate one
+
+**Decision**: three new ADRs and one annotation.
+
+| ADR | Subject | Story |
+|---|---|---|
+| **ADR-014** (fills the numbering gap noted in GF-43) | Mode state registration seam — why `ModeFactory` composes initial state and `state.js` receives it | 2 |
+| **ADR-017** | Mode capability interfaces — duck-typed capabilities over named-mode reach-ins | 4 |
+| **ADR-018** | The `table.js` split — one responsibility per module, and why `rendering/axes.js` is where the axis engine belongs | 3 |
+| **ADR-007** (annotate) | JSDoc/TypeScript integration — record that the strict gate is fully in force, per AS-1.4 | 1 |
+
+**Rationale**: The spec's Assumptions call for exactly this, and GF-43 flags the
+ADR-014 gap as worth reusing. ADR-011 (Feature Renderer cross-mode coordination)
+also needs a note in ADR-017, since GF-40 records that ADR-011's documented
+method names have zero overlap with `FeatureRenderer`'s actual ones — the
+capability refactor rewrites those methods anyway, so ADR-017 is the natural
+place to correct the record.
+
+Each ADR lands in the PR that implements it, not in a documentation sweep at the
+end.

--- a/specs/167-structural-refactor/tasks.md
+++ b/specs/167-structural-refactor/tasks.md
@@ -1,0 +1,352 @@
+# Tasks: Phase 3 — Structural Refactor & Strict Type Gate
+
+**Input**: Design documents from `/specs/167-structural-refactor/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [baseline.md](./baseline.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/](./contracts/), [quickstart.md](./quickstart.md)
+
+**Tests**: REQUIRED but asymmetric. Stories 1–4 are refactors whose gate is **the
+existing suite passing unchanged** — a spec that needed editing means the move
+was not a move. New test tasks appear only where the spec demands new coverage:
+US2's registration unit tests (AS-2.2), US5's public-API spec (FR-010, SC-006),
+and the fifth-mode spike that is SC-003's evidence.
+
+**Organization**: Grouped by user story. Unlike a typical spec-kit feature these
+stories are only partly parallelisable — see the ordering table below.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1–US5, mapping to the spec's user stories
+
+## Path Conventions
+
+Single project: `src/`, `tests/` at repository root (per plan.md Structure Decision).
+
+---
+
+## ⚠️ Story ordering is load-bearing
+
+| Constraint | Reason |
+|---|---|
+| **Phase 2 → US1** | The ceiling must exist before it can fall. T003–T005 block every burn-down task. |
+| **US2 → US4 is a hard dependency** | Capability interfaces are declared at the registration seam US2 creates, and SC-003's fifth-mode test is meaningless while `state.js` still imports the mode roster. T027+ must not start before T017. |
+| **US1 runs continuously alongside US2–US5** | The ceiling is established first and falls as a side effect of every PR that touches a strict-unclean file. T014 (the flag flip) is deliberately sequenced *after* US3 and US4 so moved code is written strict-clean once rather than fixed twice. |
+| **US3 tasks are strictly ordered** | T021 → T022 → T023. `table.js`'s importers are rewired incrementally; the scaffold shrinks last. |
+| **US3 is otherwise independent** | It shares no file with US2 or US4 and can proceed in parallel with them. |
+| US5 | Last. Its ratchet target depends on US4 having removed its eight `FeatureRenderer` reach-ins. |
+
+US1 is the MVP: it is the phase's only High-severity finding, and it is what
+makes `yarn typecheck` mean what the Quality Gates claim.
+
+---
+
+## Standing gate (every task that changes code)
+
+```bash
+yarn typecheck && yarn test && yarn build && yarn hygiene && yarn lint && yarn test:unit
+```
+
+No task may raise a hygiene baseline (FR-011). When a task lowers a count, lower
+the baseline in `hygiene-baseline.json` **in the same commit**.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Nothing to scaffold — the project, the Vitest lane and the ratchet
+machinery all exist. These tasks fix the reference point every later task is
+measured against.
+
+- [ ] T001 Record the phase-start reference in `specs/167-structural-refactor/baseline.md`: append the actual `git rev-parse HEAD` at phase start and confirm each measurement in that file still reproduces (strict count 540, madge 11, reach-ins 243, constructor fields 56)
+- [ ] T002 [P] Verify the standing gate passes on a clean tree before any change: `yarn typecheck && yarn lint && yarn test:unit && yarn hygiene && yarn build`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The three ratchets this phase burns down. Establishing all of them
+up front — rather than at the head of each story — means a story that
+accidentally *raises* another story's number is caught the same day.
+
+**⚠️ CRITICAL**: T003–T005 block all of US1; T006 blocks US5's acceptance.
+
+- [ ] T003 Create `tsconfig.strict.json` at the repo root extending `./tsconfig.json` with `noImplicitAny`, `strictNullChecks` and `strictPropertyInitialization` all `true`, per [contracts/strict-ratchet.md](./contracts/strict-ratchet.md). It must live at the repo root — from anywhere else it cannot resolve `node_modules/@types` and reports ~46 phantom errors
+- [ ] T004 Add the `strictTypeErrors: 540` ratchet to `scripts/hygiene.js` and `hygiene-baseline.json`: run `tsc -p tsconfig.strict.json`, count `error TS` lines, print per-flag sub-counts (143 / 401) and top offending files as detail; skip the ratchet silently when `tsconfig.strict.json` is absent so the check disappears after T014
+- [ ] T005 Add the config-error guard to the `strictTypeErrors` ratchet in `scripts/hygiene.js`: output containing `TS5052`, `TS6046` or `TS5023` means the overlay is malformed and the count is meaningless — fail loudly, mirroring the existing madge `moduleCount < 10` guard
+- [ ] T006 [P] Add `instanceStateReachIns: 243` and `instanceFields: 56` ratchets to `scripts/hygiene.js` and `hygiene-baseline.json`, counting `instance.state` occurrences under `src/` and class-field declarations between `export class GramFrame` and `constructor` in `src/main.js` (commands in [quickstart.md](./quickstart.md))
+- [ ] T007 Verify all four new ratchets in `scripts/hygiene.js` bite: introduce a deliberate `+1` to each in `src/main.js` (an unguarded `querySelector(...).classList`, an extra `instance.state` read, an extra class field), confirm `yarn hygiene` exits non-zero for each, then revert
+
+**Checkpoint**: Four ratchets live and proven to fail on regression. Every story
+below now has a measurable, monotone target.
+
+---
+
+## Phase 3: User Story 1 — Strict type gate, restored per-flag (Priority: P1) 🎯 MVP
+
+**Goal**: All three strict flags enabled in `tsconfig.json`, 540 errors burned to
+zero, with a CI-enforced non-increasing ceiling at every intermediate step.
+
+**Independent Test**: With the flags on, adding `document.querySelector('.nope').classList`
+to any `src/` file fails `yarn typecheck`. Before the phase it passed.
+
+**Burn-down rule (research §R2)**: A task here may add `@type` annotations,
+definite-assignment annotations (documented per site), null guards that preserve
+the current runtime path, and non-null assertions where the invariant is
+genuinely established. It may **not** add `@ts-expect-error`, `@ts-ignore`, or an
+`any` cast to silence an error. Any site where the honest fix would *change*
+behaviour is split into its own task with a test, and its error is left standing.
+
+**Every task in this phase lowers `strictTypeErrors` in `hygiene-baseline.json`
+in the same commit** (AS-1.2).
+
+### noImplicitAny burn-down (143 errors)
+
+- [ ] T008 [US1] Annotate the 46 `TS7008` class-field declarations in `src/main.js` (lines ~80–165) with `@type` JSDoc — the single largest concentrated fix in the phase, and the one that makes the US5 grouping legible
+- [ ] T009 [P] [US1] Fix the 14 `TS7006` implicit-`any` parameters and 7 `TS7053` implicit index accesses across `src/`, adding `@param` types
+- [ ] T010 [US1] Fix the remaining `TS7005` implicit-`any` variables, then enable `noImplicitAny: true` in `tsconfig.json` and remove it from `tsconfig.strict.json` — the one flag that can be flipped independently (AS-1.3)
+
+### strictNullChecks burn-down (401 errors, tranched by directory)
+
+- [ ] T011 [US1] Tranche A — `src/core/`: `state.js` (21), `viewport.js` (28), `events.js` (15), `FeatureRenderer.js` (16), `initialization/UISetup.js` (20), `FocusManager.js` (6), `configuration.js` (5), and the ≤2-error files. Fix the 20 `TS2783` errors at `src/core/state.js:38-39` properly — `version`/`timestamp` are set and then spread over by `buildModeInitialState()`, so a mode returning either key silently wins. This is a latent bug, not a cast site; it is fixed for real in T017
+- [ ] T012 [US1] Tranche B — `src/components/` and the post-split `table.js` family (65 errors, re-attributed across T021–T023): `ExpandToggle.js` (21), `HarmonicPanel.js` (11), `SymbolPicker.js` (7), `ColorPicker.js` (7), `ModeButtons.js` (6), `MainUI.js`, `PinToggle.js`, `LEDDisplay.js`
+- [ ] T013 [US1] Tranche C — `src/modes/` and `src/core/keyboardControl.js`: `HarmonicsMode.js` (51), `DopplerMode.js` (47), `keyboardControl.js` (46), `AnalysisMode.js` (45), `PanMode.js` (8), `BaseMode.js` (5), `shared/BaseDragHandler.js` (3), plus `src/utils/tolerance.js` (15) and `src/main.js`'s remaining null errors
+
+### Close the gate
+
+- [ ] T014 [US1] With the count at zero, enable `strictNullChecks` and `strictPropertyInitialization` in `tsconfig.json`; delete `tsconfig.strict.json`, the `strictTypeErrors` entry from `hygiene-baseline.json`, and the ratchet block from `scripts/hygiene.js`; verify `tsconfig.json` contains no strict-family disable (AS-1.3, SC-001). Sequence this **after** T030 so US3/US4's moved code is written strict-clean once
+- [ ] T015 [P] [US1] Annotate `docs/ADRs/ADR-007-JSDoc-TypeScript-Integration.md` recording that the strict gate is now fully in force, with the burn-down's start and end numbers (AS-1.4)
+
+**Checkpoint**: `yarn typecheck` gates real strictness. SC-001 met.
+
+---
+
+## Phase 4: User Story 2 — State and modes decoupled (Priority: P1)
+
+**Goal**: `core/state.js` imports no mode; mode initial state arrives through the
+factory; listener registration touches one registry.
+
+**Independent Test**: `yarn hygiene` shows no cycle containing both
+`core/state.js` and a `modes/` file; a mode module loads in the Vitest lane
+without importing `state.js`.
+
+### Pin before changing
+
+- [ ] T016 [US2] Write `tests/unit/mode-registration.test.js` **before** any source change: freeze the composed initial state produced by today's `createInitialState()` as a snapshot, so T017's rewiring is provably shape-preserving (plan Risks)
+
+### The registration seam
+
+- [ ] T017 [US2] Add `ModeFactory.getModeInitialStates()` to `src/modes/ModeFactory.js` merging the four `static getInitialState()` slices in fixed order (analysis, harmonics, doppler, pan); change `createInitialState(modeStates = {})` in `src/core/state.js` to receive them; delete the four `import … from '../modes/…'` lines from `state.js`; update the call site in `src/main.js` to `createInitialState(ModeFactory.getModeInitialStates())`. Spread mode slices **first** and write core keys after, fixing the `TS2783` collision — see [contracts/mode-registration.md](./contracts/mode-registration.md)
+- [ ] T018 [US2] Add a development-time collision assertion in `src/modes/ModeFactory.js` that lists any mode slice key colliding with a core state key rather than silently resolving it
+- [ ] T019 [US2] Extend `tests/unit/mode-registration.test.js`: `createInitialState()` with no argument returns a valid core state, and the module imports no mode (AS-2.2)
+- [ ] T020 [US2] Lower `circularDependencies` in `hygiene-baseline.json` from 11 to the measured residue (expected 1 — only `ExpandToggle ⇄ table`, which T022 removes) and verify no cycle contains both `core/state.js` and a `modes/` file (AS-2.1)
+
+### One listener registry
+
+- [ ] T021 [US2] Remove the global-listener copy loop from `setupStateListeners` in `src/core/initialization/EventBindings.js` and the per-instance splice loop from `removeStateListener` in `src/api/GramFrameAPI.js`; change `deliverToListeners` in `src/core/state.js` to walk the de-duplicated union of `instance.stateListeners` and `globalStateListeners`, preserving `addStateListener`'s immediate call-with-current-state — see [data-model.md](./data-model.md) §2
+- [ ] T022 [US2] Add assertions to `tests/state-listener.spec.js`: add-then-remove via the public API touches one registry with no duplicate delivery and no leak, and global listeners survive the HMR re-registration path at `src/main.js:663-666` (AS-2.3)
+
+**Checkpoint**: 10 of 11 cycles gone. A mode can be loaded without `state.js`.
+
+---
+
+## Phase 5: User Story 3 — table.js split into what it actually is (Priority: P2)
+
+**Goal**: 713 lines and six responsibilities become five modules, none over ~350
+lines, with the axes engine in `rendering/` where CLAUDE.md has long claimed it.
+
+**Independent Test**: `yarn hygiene` shows the ExpandToggle⇄table cycle gone and
+no new cycle; the full suite passes with no spec file edited.
+
+**Move discipline**: T023–T025 are **pure moves**. The diff is relocation plus
+import rewiring; `git diff -M` must show renames. Any behaviour change is a
+separate task. AS-3.1 requires zero behavioural diff — a spec that needed editing
+means the move was not a move.
+
+- [ ] T023 [US3] Create `src/rendering/axes.js`: move `renderAxes` (`table.js:326-358`) and the 8 private helpers (`table.js:412-687` — `renderTimeAxis`, `renderFrequencyAxis`, `calculateAxisTicks`, `formatFrequencyLabels`, `renderAxisLine`, `renderAxisTicks`, `renderAxisLabels`) verbatim; export only `renderAxes`; rewire `src/core/viewport.js` and `src/components/ExpandToggle.js` — see [contracts/axes.md](./contracts/axes.md)
+- [ ] T024 [US3] Create `src/components/spectrogramImage.js` (`setupSpectrogramImage` from `table.js:140-205`, `getRenderDimensions` from `table.js:22-34`) and `src/components/svgLayout.js` (`updateSVGLayout` from `table.js:206-265`); rewire `src/core/initialization/UISetup.js`, `src/components/ExpandToggle.js`, `src/modes/harmonics/HarmonicsMode.js` and `src/core/viewport.js`
+- [ ] T025 [US3] Move `applyZoomTransform` (`table.js:266-325`) and `calculateVisibleDataRange` (`table.js:359-411`) into `src/core/viewport.js`, giving zoom math one home for wheel, keyboard, PanMode and API callers (FR-007, AS-3.4); rewire `src/modes/harmonics/HarmonicsMode.js` and `src/modes/harmonics/ManualHarmonicModal.js`
+- [ ] T026 [US3] Verify `src/components/table.js` is scaffold-only (~135 lines: `setupComponentTable`, private `createComponentStructure` and `replaceConfigTable`) and imported by exactly one module, `src/core/initialization/DOMSetup.js`; confirm all five modules are under 350 lines
+- [ ] T027 [US3] Lower `circularDependencies` in `hygiene-baseline.json` to 0 and confirm no new cycle appeared (AS-3.3, SC-002)
+
+**Checkpoint**: SC-002 met at 0. `rendering/axes.js` exists, closing part of GF-38.
+
+---
+
+## Phase 6: User Story 4 — Narrow mode contract, capability seams (Priority: P2)
+
+**Goal**: `BaseMode` contains only hooks with real implementations; no module
+outside `modes/` names a mode to obtain behaviour.
+
+**Independent Test**: `grep` finds no mode-name reach-in outside `modes/` (bar
+one documented exception) and no `any` cast to a mode; adding a fifth mode with
+persistent features requires no edit to `FeatureRenderer` or `MainUI`.
+
+**⚠️ Depends on US2 (T017).**
+
+- [ ] T028 [US4] Delete `renderCursor` (0 overrides) and `getStateSnapshot` (0 overrides, 0 callers) from `src/modes/BaseMode.js`; delete `renderCurrentModeCursor` from `src/core/FeatureRenderer.js` — its only job was calling the deleted `renderCursor` no-op — and its call sites; remove both from the mode interface in `src/types.js`; verify by grep that no caller remains (AS-4.1). Keep `getViewport` and `updateCursorStyle`: zero overrides but 17 and 3 callers, so they are concrete base helpers, and document the distinction in `BaseMode`'s header
+- [ ] T029 [US4] Create `src/modes/capabilities.js` with the `PersistentFeatureProvider` and `PanelOwner` typedefs and their `isPersistentFeatureProvider` / `isPanelOwner` predicates, per [contracts/capabilities.md](./contracts/capabilities.md)
+- [ ] T030 [P] [US4] Move `hasAnalysisFeatures` / `hasHarmonicFeatures` / `hasDopplerFeatures` off `src/core/FeatureRenderer.js` onto the modes that own the state each reads, as `hasPersistentFeatures()` on `AnalysisMode`, `HarmonicsMode` and `DopplerMode`; rewrite `renderAllPersistentFeatures` to filter `Object.values(this.instance.modes)` by capability. This also deletes 8 `instance.state` reach-ins toward US5's ratchet (AS-4.2)
+- [ ] T031 [P] [US4] Add `refreshPanel()` to `AnalysisMode` (wrapping `updateMarkersTable`) and `HarmonicsMode` (wrapping `updateHarmonicPanel`, absorbing the panel-reference resolution currently done from outside at `MainUI.js:219-226`); rewrite `updatePersistentPanels` in `src/components/MainUI.js` to `Object.values(instance.modes).filter(isPanelOwner).forEach(m => m.refreshPanel())`, removing both `/** @type {any} */` casts (AS-4.2)
+- [ ] T032 [US4] Replace `this.instance._zoomOut()` / `_zoomIn()` in `getCommandButtons` at `src/modes/pan/PanMode.js:219,225` with `zoomOut(this.instance)` / `zoomIn(this.instance)` imported from `src/core/viewport.js`; decide whether `main.js`'s `_zoomIn`/`_zoomOut`/`_zoomReset`/`_setZoom` remain as public-API forwarders or are removed, and delete the `_setZoom`/`_zoomIn`/`_zoomOut`/`_zoomReset` typedefs at `src/types.js:431-434` (AS-4.3, FR-007)
+- [ ] T033 [US4] Record the one FR-006 exception in `docs/ADRs/ADR-017-Mode-Capability-Interfaces.md`: `src/core/viewport.js:162` reads `instance.modes.pan` for a pan-specific policy decision (leave pan mode when zoom returns to 1×), which is not cross-cutting coordination and does not warrant a fourth capability (research §R6)
+
+**Checkpoint**: `FeatureRenderer` and `MainUI` are mode-agnostic. Constitution
+Principle III's "adding a mode must not modify existing modes" holds in fact.
+
+---
+
+## Phase 7: User Story 5 — Shrunk instance surface & explicit initialization (Priority: P3)
+
+**Goal**: 56 flat instance fields become 12 behind four cohesive sub-objects;
+initialization dependencies are explicit; the public API is behaviourally tested.
+
+**Independent Test**: `yarn hygiene` shows both instance ratchets below baseline;
+reordering two constructor steps produces a loud failure, not a silent
+`undefined`; `tests/public-api.spec.js` passes against a non-debug page.
+
+**Depends on US4 (T030) for its eight-reach-in head start. Benefits from US1
+(T008) having typed the fields being grouped.**
+
+- [ ] T034 [US5] Group the 30 DOM element handles into `instance.ui` in `src/main.js` (list in [baseline.md](./baseline.md) §6), creating the sub-object in the constructor before any initialization step runs; update every reach-in across `src/` — `tsc` under US1's flags catches misses; lower `instanceFields` in `hygiene-baseline.json`
+- [ ] T035 [US5] Group the remaining 18 fields into `instance.interaction` (14), `instance.viewport` (2) and `instance.persistence` (2) in `src/main.js`; leave `state`, `configTable`, `stateListeners`, `instanceId`, `modes`, `currentMode`, `featureRenderer` and `_unsupportedBrowser` ungrouped; lower `instanceFields` to ≤ 33 (SC-005)
+- [ ] T036 [US5] Make initialization explicit in `src/main.js` and `src/core/initialization/`: each of the ten steps declares what it needs as parameters and returns what it built (table in [data-model.md](./data-model.md) §6); remove the double-nulling at `src/core/initialization/DOMSetup.js:88-95` where `modes`, `currentMode` and `featureRenderer` are nulled and later re-created by `initializeModeInfrastructure` (FR-009)
+- [ ] T037 [US5] Verify AS-5.2 by experiment: swap two initialization calls in the `src/main.js` constructor and confirm the failure is a `tsc` error for a missing required argument or an immediate explicit throw — never a silent `undefined` surfacing later; revert, and record the outcome in the PR description
+- [ ] T038 [US5] Lower `instanceStateReachIns` in `hygiene-baseline.json` to ≤ 185 (SC-005's endpoint, per research §R7 — the spec's "50% of 371", not 50% of today's 243)
+- [ ] T039 [P] [US5] Create `tests/public-api.spec.js` with behavioural (not `typeof`) assertions for `init`, `detectAndReplaceConfigTables`, `addStateListener`, `removeStateListener`, `getExpandState` and `setExpandState`, per research §R8; run it against a fixture page that does **not** set `window.GRAMFRAME_DEBUG`, proving the API works without `__test__` hooks and catching those hooks leaking onto a production page (FR-010, SC-006)
+
+**Checkpoint**: Both instance ratchets met. The public API is tested as an API.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: The evidence, the decision records, and the documentation this
+phase's claims depend on. ADRs land in the PR that implements them where
+practical; these tasks catch what did not.
+
+- [ ] T040 [P] Write `docs/ADRs/ADR-014-Mode-State-Registration-Seam.md` filling the numbering gap GF-43 flags: why `ModeFactory` composes initial state and `core/state.js` receives it (research §R9)
+- [ ] T041 [P] Write `docs/ADRs/ADR-017-Mode-Capability-Interfaces.md`: duck-typed capabilities over named-mode reach-ins, why not a class hierarchy or a string-keyed registry, plus a note correcting ADR-011, whose documented `FeatureRenderer` method names have zero overlap with the real ones (GF-40)
+- [ ] T042 [P] Write `docs/ADRs/ADR-018-Table-Split.md`: one responsibility per module, and why the axis engine belongs in `rendering/` beside `cursors.js` and `symbols.js`
+- [ ] T043 Build the fifth-mode spike as SC-003's evidence: add a throwaway mode under `src/modes/` implementing `static getInitialState()`, `hasPersistentFeatures()` and `renderPersistentFeatures()`, registered only in `src/modes/ModeFactory.js`; add `tests/mode-registration.spec.js` asserting its initial state appears and its features render with **no** edit to `src/core/state.js`, `src/components/MainUI.js` or `src/core/FeatureRenderer.js` (AS-2.2, AS-4.2, SC-003)
+- [ ] T044 [P] Update the File Structure section of `CLAUDE.md` for the four new modules (`rendering/axes.js`, `components/spectrogramImage.js`, `components/svgLayout.js`, `modes/capabilities.js`) and `table.js`'s narrowed role — the list is required to stay in step with `src/`
+- [ ] T045 [P] Record the SC-004 documented exceptions in `hygiene-baseline.json`'s comment block: the seven modules still over ~350 lines that no story in this spec touches (`HarmonicsMode.js` 1016, `DopplerMode.js` 657, `AnalysisMode.js` 612, `keyboardControl.js` 561, `GramFrameAPI.js` 413, `events.js` 395), with `types.js` exempt as declarations, and the three mode files flagged as candidates for a later phase
+- [ ] T046 Add a Phase 3 resolutions section to `docs/analysis/Findings-Register.md` (mirroring §7's format) recording GF-32, GF-03, GF-05, GF-06, GF-09, GF-10, GF-11, GF-13 and GF-30's residual as resolved, each with the test that fails if it returns
+- [ ] T047 Run the full [quickstart.md](./quickstart.md) validation end to end and confirm every success criterion: SC-001 (no strict disables, `yarn typecheck` green), SC-002 (cycles ≤ 1), SC-003 (spike scope), SC-004 (`table.js` scaffold-only, exceptions documented), SC-005 (reach-ins ≤ 185, fields ≤ 33), SC-006 (public API behaviourally covered)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+
+- **Phase 1 (Setup)**: no dependencies
+- **Phase 2 (Foundational)**: depends on Phase 1 — **blocks US1 entirely and US5's acceptance**
+- **US1 (Phase 3)**: starts immediately after Phase 2 and runs continuously; T014 is deliberately last
+- **US2 (Phase 4)**: independent of US1; **blocks US4**
+- **US3 (Phase 5)**: independent of US2 and US4
+- **US4 (Phase 6)**: requires T017 (US2)
+- **US5 (Phase 7)**: requires T030 (US4) for its ratchet head start; benefits from T008 (US1)
+- **Phase 8 (Polish)**: T040 after US2, T041 after US4, T042 after US3, T043 after both US2 and US4, T047 after everything
+
+### Critical path
+
+```text
+T001-T002 → T003-T007 → T016 → T017 → T028 → T029 → T030 → T034 → T035 → T036 → T038 → T043 → T047
+                      ↘ T008 … T013 ─────────────────────────────────→ T014 ↗
+                      ↘ T023 → T024 → T025 → T026 → T027 ─────────────────↗
+```
+
+### Within US1
+
+Tranches are independent of each other and may be reordered, but `noImplicitAny`
+(T008–T010) should precede `strictNullChecks` (T011–T013): fixing 143 implicit-any
+errors first leaves 397 null errors rather than 401, and avoids null-checking code
+whose types are still implicitly `any` (research §R1).
+
+### Within US3
+
+Strictly ordered T023 → T024 → T025 → T026 → T027. No parallelism — every task
+rewires importers of the same shrinking module.
+
+### Parallel opportunities
+
+- T002 alongside T001; T006 alongside T003–T005
+- **US2, US3 and US1's tranches can proceed concurrently** — they share no file
+  once T011's `core/` tranche is done (T011 touches `viewport.js`, which T025
+  also touches; sequence those two)
+- T030 and T031 (different files, both after T029)
+- T039 alongside T034–T038 (new file, no source dependency)
+- T040, T041, T042, T044, T045 all [P] once their stories land
+
+---
+
+## Parallel Example: User Story 4
+
+```bash
+# After T029 creates the capability predicates, these two are independent:
+Task: "T030 — FeatureRenderer iterates by capability; hasPersistentFeatures moves onto the modes"
+Task: "T031 — MainUI iterates by capability; refreshPanel added to Analysis and Harmonics"
+```
+
+## Parallel Example: Polish
+
+```bash
+# Once their stories have landed, the three ADRs and two doc updates are independent:
+Task: "T040 — ADR-014 mode state registration seam"
+Task: "T041 — ADR-017 mode capability interfaces"
+Task: "T042 — ADR-018 table.js split"
+Task: "T044 — CLAUDE.md File Structure update"
+Task: "T045 — SC-004 documented exceptions"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP first (User Story 1 only)
+
+1. Phase 1 → Phase 2 (ratchets live and proven to bite)
+2. Phase 3: burn 540 → 0, flip the flags
+3. **STOP and VALIDATE**: `yarn typecheck` now fails on an unguarded
+   `querySelector`. The register's only High finding is closed, and every later
+   refactor is protected by real type checking.
+
+US1 alone is a shippable, defensible increment — which is why it is P1 despite
+touching the most files.
+
+### Incremental delivery
+
+1. Setup + Foundational → four ratchets live
+2. US1 → strict gate real → **MVP**
+3. US2 → 10 cycles gone, mode registration seam
+4. US3 → `table.js` split, last cycle gone, SC-002 at 0
+5. US4 → capability seams, Principle III true in fact
+6. US5 → instance surface halved, public API tested
+7. Polish → ADRs, register resolutions, full quickstart validation
+
+Each step lands on `main` green (FR-011). No long-lived integration branch.
+
+### Parallel team strategy
+
+With three developers after Phase 2:
+
+- **Developer A**: US1 continuously (the largest, most mechanical body of work)
+- **Developer B**: US2 → US4 → US5 (the dependency chain)
+- **Developer C**: US3 (fully independent) → Phase 8 ADRs
+
+Coordinate on `src/core/viewport.js`, the one file two chains touch (T011 and
+T025), and on the shared `hygiene-baseline.json`, which every chain lowers.
+
+---
+
+## Notes
+
+- **Baselines only go down.** If a count rises, the fix is the diff, not the baseline.
+- **Refactor PRs never carry behaviour changes.** US2–US4 are move-and-rewire;
+  US1 is annotations and behaviour-preserving guards. Anything else gets its own
+  task and its own test (research §R2).
+- **A spec file edited during US3 means the move was not a move** (AS-3.1).
+- `strictPropertyInitialization` is not an independent burn-down — TypeScript
+  rejects it without `strictNullChecks` (`TS5052`) and it adds zero errors once
+  that flag is on. It flips with `strictNullChecks` in T014 (research §R1).
+- Commit after each task or logical group; stop at any checkpoint to validate a
+  story independently.


### PR DESCRIPTION
Planning output for [specs/167-structural-refactor](https://github.com/DeepBlueCLtd/GramFrame/blob/claude/speckit-plan-167-c3qiwi/specs/167-structural-refactor/spec.md) (`/speckit.plan`). Documentation only — no source change.

## What's here

| Artefact | Contents |
|---|---|
| `plan.md` | Summary, technical context, constitution check (PASS), 19-PR sequencing table, risks |
| `baseline.md` | Every ratchet source, measured at HEAD, with the commands to re-measure |
| `research.md` | Decisions R1–R9 with rejected alternatives |
| `data-model.md` | Structural entities; no persisted-state change in this phase |
| `quickstart.md` | How to run and verify each story |
| `contracts/` | Strict ratchet, mode registration, capabilities, axes |

## Measurements that changed the plan

Every baseline was re-measured at `7115a8a` rather than carried over from the audit (whose figures predate Phase 2). Two results are load-bearing:

**`strictPropertyInitialization` is not an independent burn-down.** TypeScript rejects it without `strictNullChecks` (`TS5052`), and with `strictNullChecks` on it adds *zero* errors. An early probe that appeared to show "2 errors" was counting the two config-error lines. So the three flags become two burn-downs behind a single ceiling of **540**, measured under the end-state configuration — monotone by construction, with no mid-phase re-baselining. This means spec AS-1.1 ("record a ceiling for each disabled flag") cannot be satisfied literally for the third flag; FR-001's substance is satisfied in full.

| Configuration | Errors |
|---|---|
| Current `tsconfig.json` | 0 |
| `+ noImplicitAny` | 143 |
| `+ strictNullChecks` | 401 |
| `+ strictNullChecks + strictPropertyInitialization` | 401 |
| **All three (the ceiling)** | **540** |

**`instance.state` reach-ins are 243, not 371.** Phase 2's coordinate and drag consolidations already removed 128. A ratchet starting 128 above the current value cannot fail, so SC-005 is interpreted by its *endpoint* (≤ 185) rather than its *percentage* (which would demand a further 50% cut from an already-halved number).

Other measured figures: 11 madge cycles (all 11 traced to their dissolving PR), `table.js` 713 lines across 6 responsibilities with line ranges, `BaseMode` hook audit confirming `renderCursor`/`getStateSnapshot` as the only zero-override hooks, 56 constructor fields grouped into four cohesive sets.

## Scope observations surfaced, not reinterpreted

Two Success Criteria are not fully reachable from the spec's own stories. Both are recorded in `plan.md` for a call rather than quietly redefined:

- **SC-004** (~350-line guideline) — Stories 3 and 5 fix `table.js` and `main.js`, leaving seven modules over the line that no story touches (`HarmonicsMode.js` 1016, `DopplerMode.js` 657, `AnalysisMode.js` 612, `keyboardControl.js` 561, `GramFrameAPI.js` 413, `events.js` 395, plus `types.js` as a declaration file). The plan records them as documented exceptions.
- **SC-005** — as above.

## Incidental finding

The 20 `TS2783` errors point at a real latent bug: `src/core/state.js:38-39` sets `version` and `timestamp` and then spreads `buildModeInitialState()` over them, so a mode returning either key would silently win. PR 4 touches that exact composition and owns the fix.

## Verification

`yarn typecheck`, `yarn hygiene` green; working tree clean of probe files.

---
_Generated by [Claude Code](https://claude.ai/code/session_018d3PeDxrbrJvS2iFR7vfHE)_