### PR TITLE
Fix hover minting harmonic sets: hover finds, only mousedown creates

### DIFF
--- a/specs/166-consolidation/contracts/drag-engine.md
+++ b/specs/166-consolidation/contracts/drag-engine.md
@@ -34,6 +34,17 @@ new BaseDragHandler(instance, {
    */
   resolveTarget(position, event),
 
+  /**
+   * Side-effect-free finder used for hover cursor feedback (grab vs
+   * crosshair). REQUIRED when resolveTarget creates a feature on mousedown
+   * (harmonics `create`, doppler `place`) — hover otherwise falls back to
+   * resolveTarget, and a resolver that mints would create a feature per
+   * mousemove.
+   * @param {DataCoordinates} position
+   * @returns {DragTarget|null}
+   */
+  resolveHoverTarget(position),
+
   /** Called once, after the threshold is crossed. */
   onDragStart(target, position),
 

--- a/src/modes/doppler/DopplerMode.js
+++ b/src/modes/doppler/DopplerMode.js
@@ -38,6 +38,9 @@ export class DopplerMode extends BaseMode {
       // A feature drag always carries a data position. Only the pan drag passes
       // null, and it runs on its own handler in `core/events.js`.
       resolveTarget: (position) => this.resolveDopplerDrag(/** @type {DataCoordinates} */ (position)),
+      // Hover only ever *finds* — resolveDopplerDrag seeds f+ when no markers
+      // exist, which is right for a mousedown and wrong for a hover.
+      resolveHoverTarget: (position) => this.findDopplerMarkerAtPosition(/** @type {DataCoordinates} */ (position)),
       onDragStart: (target, position) => this.onMarkerDragStart(target, /** @type {DataCoordinates} */ (position)),
       onDragMove: (target, currentPos, startPos) => this.onMarkerDragUpdate(target, /** @type {DataCoordinates} */ (currentPos), /** @type {DataCoordinates} */ (startPos)),
       onDragEnd: (target, position) => this.onMarkerDragEnd(target, position),

--- a/src/modes/harmonics/HarmonicsMode.js
+++ b/src/modes/harmonics/HarmonicsMode.js
@@ -31,6 +31,10 @@ export class HarmonicsMode extends BaseMode {
       // A feature drag always carries a data position. Only the pan drag passes
       // null, and it runs on its own handler in `core/events.js`.
       resolveTarget: (position) => this.resolveHarmonicDrag(/** @type {DataCoordinates} */ (position)),
+      // Hover only ever *finds* — resolveHarmonicDrag mints a new set when the
+      // cursor is over empty gram, which is right for a mousedown and wrong for
+      // a hover (a hover that creates features floods the gram with sets).
+      resolveHoverTarget: (position) => this.findHarmonicSetTarget(/** @type {DataCoordinates} */ (position)),
       onDragStart: (target, position) => this.onHarmonicSetDragStart(target, /** @type {DataCoordinates} */ (position)),
       onDragMove: (target, currentPos, startPos) => this.onHarmonicSetDragUpdate(target, /** @type {DataCoordinates} */ (currentPos), /** @type {DataCoordinates} */ (startPos)),
       onDragEnd: (target, position) => this.onHarmonicSetDragEnd(target, position),

--- a/src/modes/shared/BaseDragHandler.js
+++ b/src/modes/shared/BaseDragHandler.js
@@ -282,13 +282,20 @@ export class BaseDragHandler {
   }
 
   /**
-   * Update cursor style based on proximity to drag targets
+   * Update cursor style based on proximity to drag targets.
+   *
+   * Hover must never change state, so this uses the mode's side-effect-free
+   * `resolveHoverTarget` when one is supplied. `resolveTarget` is only a safe
+   * fallback for modes whose resolver is pure — a mode whose resolver mints a
+   * feature on mousedown (harmonics `create`, doppler `place`) MUST supply
+   * `resolveHoverTarget`, or every hover would create a feature.
    * @param {DataCoordinates} position - Current mouse position
    */
   updateCursorForHover(position) {
     if (this.dragState.isDragging) return
 
-    const target = this.callbacks.resolveTarget(position)
+    const resolve = this.callbacks.resolveHoverTarget || this.callbacks.resolveTarget
+    const target = resolve(position)
     const cursorStyle = target ? 'grab' : 'crosshair'
 
     if (this.callbacks.updateCursor) {

--- a/src/types.js
+++ b/src/types.js
@@ -197,6 +197,7 @@
  * argument. Every feature drag receives a real position.
  * @typedef {Object} DragCallbacks
  * @property {function(DataCoordinates|null, MouseEvent=): DragTarget|null} resolveTarget - Decide whether this mousedown starts a drag, and of what kind
+ * @property {function(DataCoordinates|null): DragTarget|null} [resolveHoverTarget] - Side-effect-free finder used for hover cursor feedback. REQUIRED when resolveTarget creates a feature (harmonics `create`, doppler `place`); without it hover falls back to resolveTarget
  * @property {function(DragTarget, DataCoordinates|null, MouseEvent=): void} onDragStart - Called once, when the drag starts
  * @property {function(DragTarget, DataCoordinates|null, DataCoordinates|null, MouseEvent=): void} onDragMove - Called per move
  * @property {function(DragTarget, DataCoordinates|null, MouseEvent=): void} onDragEnd - Called on mouseup, or with a null position when a drag is cancelled

--- a/tests/harmonic-hover-regression.spec.js
+++ b/tests/harmonic-hover-regression.spec.js
@@ -1,0 +1,121 @@
+import { test, expect } from './helpers/fixtures.js'
+
+/**
+ * @fileoverview Regression tests for the harmonic-hover bug.
+ *
+ * The drag engine's hover path (`updateCursorForHover`) once called the mode's
+ * `resolveTarget` — the mousedown resolver. In harmonics mode that resolver
+ * *mints a new harmonic set* when the cursor is over empty gram, so simply
+ * moving the mouse flooded the gram with sets. And because every new set is
+ * auto-selected, a colour picked afterwards restyled the latest phantom set
+ * instead of setting the next-feature colour — so deliberately created sets
+ * ignored the picked colour.
+ *
+ * These tests pin the fixed behaviour: hover finds, only mousedown creates,
+ * and the picked colour reaches the next deliberately created set.
+ */
+
+test.describe('Harmonic hover regression', () => {
+  test.beforeEach(async ({ gramFramePage }) => {
+    await gramFramePage.clickMode('Harmonics')
+    await gramFramePage.waitForImageDimensions()
+  })
+
+  test('hovering over the gram creates no harmonic sets', async ({ gramFramePage }) => {
+    // Sweep the cursor across the image without pressing any button.
+    for (const [fx, fy] of [[0.2, 0.3], [0.4, 0.5], [0.6, 0.4], [0.8, 0.6], [0.5, 0.2]]) {
+      const p = await gramFramePage.imageSVGPoint(fx, fy)
+      await gramFramePage.moveMouse(p.x, p.y)
+    }
+
+    const state = await gramFramePage.getState()
+    expect(state.harmonics.harmonicSets).toEqual([])
+    // Nothing was created, so nothing should have been auto-selected either.
+    expect(state.selection.selectedType).toBeNull()
+  })
+
+  test('hovering near an existing set neither creates nor selects another', async ({ gramFramePage }) => {
+    // Debug config spans freq 0-100 Hz over time 0-60 s.
+    const setId = await gramFramePage.addHarmonicSet(30, 10)
+
+    for (const [fx, fy] of [[0.3, 0.3], [0.5, 0.5], [0.7, 0.7], [0.45, 0.5]]) {
+      const p = await gramFramePage.imageSVGPoint(fx, fy)
+      await gramFramePage.moveMouse(p.x, p.y)
+    }
+
+    const state = await gramFramePage.getState()
+    expect(state.harmonics.harmonicSets).toHaveLength(1)
+    expect(state.harmonics.harmonicSets[0].id).toBe(setId)
+  })
+
+  test('a mousedown-drag still creates exactly one harmonic set', async ({ gramFramePage }) => {
+    const svgBox = await gramFramePage.svg.boundingBox()
+    const start = await gramFramePage.imageSVGPoint(0.5, 0.5)
+    const end = await gramFramePage.imageSVGPoint(0.6, 0.5)
+
+    await gramFramePage.dragSVG(
+      svgBox.x + start.x, svgBox.y + start.y,
+      svgBox.x + end.x, svgBox.y + end.y
+    )
+    await gramFramePage.waitForHarmonicSetCount(1)
+
+    // Hovering onward after the drag must not add more.
+    for (const [fx, fy] of [[0.2, 0.2], [0.7, 0.6]]) {
+      const p = await gramFramePage.imageSVGPoint(fx, fy)
+      await gramFramePage.moveMouse(p.x, p.y)
+    }
+    const state = await gramFramePage.getState()
+    expect(state.harmonics.harmonicSets).toHaveLength(1)
+  })
+
+  test('a colour picked after hovering applies to the next created set', async ({ gramFramePage }) => {
+    // Hover first — with the bug, this minted and auto-selected a phantom set,
+    // diverting the colour pick below into restyling it.
+    const hoverPoint = await gramFramePage.imageSVGPoint(0.4, 0.4)
+    await gramFramePage.moveMouse(hoverPoint.x, hoverPoint.y)
+
+    const before = await gramFramePage.getState()
+    const previousColor = before.selectedColor
+
+    // Pick a colour near the right end of the slider (far from the default).
+    const canvas = gramFramePage.page.locator('.gram-frame-color-canvas')
+    const canvasBox = await canvas.boundingBox()
+    await canvas.click({ position: { x: canvasBox.width - 2, y: canvasBox.height / 2 } })
+
+    // With nothing selected, the pick must land on the next-feature colour.
+    await gramFramePage.waitForState(
+      (s) => s.selectedColor !== previousColor,
+      { message: 'colour pick to update state.selectedColor' }
+    )
+    const picked = (await gramFramePage.getState()).selectedColor
+
+    // Now create a set by dragging; it must carry the picked colour.
+    const svgBox = await gramFramePage.svg.boundingBox()
+    const start = await gramFramePage.imageSVGPoint(0.5, 0.5)
+    const end = await gramFramePage.imageSVGPoint(0.6, 0.5)
+    await gramFramePage.dragSVG(
+      svgBox.x + start.x, svgBox.y + start.y,
+      svgBox.x + end.x, svgBox.y + end.y
+    )
+    await gramFramePage.waitForHarmonicSetCount(1)
+
+    const state = await gramFramePage.getState()
+    expect(state.harmonics.harmonicSets[0].color).toBe(picked)
+  })
+
+  test('hovering in doppler mode places no markers', async ({ gramFramePage }) => {
+    // Doppler's resolver seeds f+ when no markers exist — the same minting
+    // hazard harmonics had, pinned here for the same hover path.
+    await gramFramePage.clickMode('Doppler')
+
+    for (const [fx, fy] of [[0.3, 0.3], [0.5, 0.5], [0.7, 0.4]]) {
+      const p = await gramFramePage.imageSVGPoint(fx, fy)
+      await gramFramePage.moveMouse(p.x, p.y)
+    }
+
+    const state = await gramFramePage.getState()
+    expect(state.doppler.fPlus).toBeNull()
+    expect(state.doppler.fMinus).toBeNull()
+    expect(state.doppler.fZero).toBeNull()
+  })
+})

--- a/tests/unit/drag-hover.test.js
+++ b/tests/unit/drag-hover.test.js
@@ -1,0 +1,131 @@
+import { describe, test, expect, vi } from 'vitest'
+import { BaseDragHandler } from '../../src/modes/shared/BaseDragHandler.js'
+
+/**
+ * @fileoverview Unit tests for the drag engine's hover contract (regression
+ * for the harmonic-hover bug).
+ *
+ * `resolveTarget` is allowed to have side effects — the harmonics `create` and
+ * doppler `place` kinds mint their feature inside it, on mousedown. Hover is
+ * not a mousedown: `updateCursorForHover` must therefore prefer the
+ * side-effect-free `resolveHoverTarget` when the mode supplies one, and must
+ * never start a drag. When the fallback to `resolveTarget` broke this (the
+ * engine used the minting resolver for hover), every mousemove over the gram
+ * created a harmonic set.
+ */
+
+/**
+ * Build a minimal fake GramFrame instance for the handler.
+ * @returns {any} Fake instance
+ */
+function makeInstance() {
+  return {
+    state: { drag: { active: false } },
+    notifyStateListeners: () => {}
+  }
+}
+
+/**
+ * A target descriptor like a mode resolver would return.
+ * @returns {any} Drag target
+ */
+const someTarget = () => ({ kind: 'move', id: 'set-1', type: 'harmonicSet', position: null, data: {} })
+
+describe('BaseDragHandler hover contract', () => {
+  test('hover uses resolveHoverTarget and never calls resolveTarget', () => {
+    const resolveTarget = vi.fn(someTarget)
+    const resolveHoverTarget = vi.fn(() => null)
+    const updateCursor = vi.fn()
+    const handler = new BaseDragHandler(makeInstance(), {
+      resolveTarget,
+      resolveHoverTarget,
+      onDragStart: vi.fn(),
+      onDragMove: vi.fn(),
+      onDragEnd: vi.fn(),
+      updateCursor
+    }, 'harmonics')
+
+    handler.updateCursorForHover({ freq: 10, time: 5 })
+
+    // The minting resolver must not run on a hover — that is the bug.
+    expect(resolveTarget).not.toHaveBeenCalled()
+    expect(resolveHoverTarget).toHaveBeenCalledTimes(1)
+    expect(updateCursor).toHaveBeenCalledWith('crosshair')
+  })
+
+  test('hover over a found target shows the grab cursor', () => {
+    const updateCursor = vi.fn()
+    const handler = new BaseDragHandler(makeInstance(), {
+      resolveTarget: vi.fn(someTarget),
+      resolveHoverTarget: vi.fn(someTarget),
+      onDragStart: vi.fn(),
+      onDragMove: vi.fn(),
+      onDragEnd: vi.fn(),
+      updateCursor
+    }, 'harmonics')
+
+    handler.updateCursorForHover({ freq: 10, time: 5 })
+
+    expect(updateCursor).toHaveBeenCalledWith('grab')
+  })
+
+  test('hover falls back to resolveTarget when no hover resolver is supplied', () => {
+    // The fallback is only safe for modes whose resolver is pure (analysis,
+    // pan) — this pins the fallback so those modes keep their hover cursor.
+    const resolveTarget = vi.fn(someTarget)
+    const updateCursor = vi.fn()
+    const handler = new BaseDragHandler(makeInstance(), {
+      resolveTarget,
+      onDragStart: vi.fn(),
+      onDragMove: vi.fn(),
+      onDragEnd: vi.fn(),
+      updateCursor
+    }, 'analysis')
+
+    handler.updateCursorForHover({ freq: 10, time: 5 })
+
+    expect(resolveTarget).toHaveBeenCalledTimes(1)
+    expect(updateCursor).toHaveBeenCalledWith('grab')
+  })
+
+  test('hover never starts a drag or touches the drag projection', () => {
+    const instance = makeInstance()
+    const onDragStart = vi.fn()
+    const handler = new BaseDragHandler(instance, {
+      resolveTarget: vi.fn(someTarget),
+      resolveHoverTarget: vi.fn(someTarget),
+      onDragStart,
+      onDragMove: vi.fn(),
+      onDragEnd: vi.fn(),
+      updateCursor: vi.fn()
+    }, 'harmonics')
+
+    handler.updateCursorForHover({ freq: 10, time: 5 })
+
+    expect(handler.isDragging()).toBe(false)
+    expect(onDragStart).not.toHaveBeenCalled()
+    expect(instance.state.drag).toEqual({ active: false })
+  })
+
+  test('hover during an active drag is ignored entirely', () => {
+    const resolveHoverTarget = vi.fn(() => null)
+    const updateCursor = vi.fn()
+    const handler = new BaseDragHandler(makeInstance(), {
+      resolveTarget: vi.fn(someTarget),
+      resolveHoverTarget,
+      onDragStart: vi.fn(),
+      onDragMove: vi.fn(),
+      onDragEnd: vi.fn(),
+      updateCursor
+    }, 'harmonics')
+
+    handler.startDrag({ freq: 10, time: 5 })
+    updateCursor.mockClear()
+    resolveHoverTarget.mockClear()
+
+    handler.updateCursorForHover({ freq: 12, time: 6 })
+
+    expect(resolveHoverTarget).not.toHaveBeenCalled()
+    expect(updateCursor).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## The bug

In Harmonics mode, hovering the mouse over the gram created a stream of new harmonic sets. Root cause: the spec-166 drag-engine consolidation collapsed the hover and mousedown paths onto a single `resolveTarget` callback. Harmonics' resolver *mints* a new set when the cursor is over empty gram — correct on mousedown (that's the drag-to-create gesture), disastrous on hover, where the engine was calling it on every mousemove just to pick a cursor style. Before the refactor, hover used a separate side-effect-free `findTargetAt`.

This also explains the second reported symptom — new sets not reflecting the selected colour. Every hover-minted phantom set was auto-selected, so a colour pick restyled the latest phantom (the feature-161 restyle-in-place path) instead of setting the next-feature colour, leaving `state.selectedColor` stale for subsequently created sets.

## The fix

- `BaseDragHandler` gains an optional side-effect-free `resolveHoverTarget` callback; `updateCursorForHover` prefers it and only falls back to `resolveTarget` for modes whose resolver is pure (analysis, pan).
- `HarmonicsMode` supplies its pure hit-test (`findHarmonicSetTarget`) as the hover resolver.
- `DopplerMode` gets the same treatment (`findDopplerMarkerAtPosition`) — its resolver seeds f+ when no markers exist; a mode-level guard currently hides that hazard, but the engine no longer relies on it.
- `DragCallbacks` typedef and the spec-166 drag-engine contract doc document the requirement: a mode whose `resolveTarget` creates a feature MUST supply `resolveHoverTarget`.

## Testing

- **New Playwright spec** `tests/harmonic-hover-regression.spec.js` (5 tests): hovering creates no sets and selects nothing; hovering near an existing set adds nothing; a mousedown-drag still creates exactly one set; a colour picked after hovering reaches the next created set; doppler hover places no markers. **4 of the 5 fail against the unfixed engine** (verified by stashing the fix), so the suite demonstrably catches this regression.
- **New Vitest spec** `tests/unit/drag-hover.test.js` (5 tests) pins the engine's hover contract: hover uses the hover resolver and never the minting one, falls back only when no hover resolver is supplied, never starts a drag or touches `state.drag`, and is inert mid-drag.
- Full verification sweep, all green: `yarn typecheck`, `yarn lint` (0 errors), `yarn hygiene` (all ratchets at baseline), `yarn test:unit` (49/49), `yarn test` (262/262 Playwright).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LwiZSBCWmbzSK5y9Gtmgp

---
_Generated by [Claude Code](https://claude.ai/code/session_016LwiZSBCWmbzSK5y9Gtmgp)_