### PR TITLE
Reorganise the styles panel by what each control affects

### DIFF
--- a/src/components/ColorPicker.js
+++ b/src/components/ColorPicker.js
@@ -117,7 +117,7 @@ export function createColorPicker(instance) {
   container.appendChild(symbolGroup)
 
   const symbolRow = document.createElement('div')
-  symbolRow.className = 'gram-frame-style-symbol-row'
+  symbolRow.className = 'gram-frame-style-row'
   symbolGroup.appendChild(symbolRow)
 
   symbolRow.appendChild(createGroupLabel('Symbol'))
@@ -139,9 +139,15 @@ export function createColorPicker(instance) {
 
   const harmonicsGroup = document.createElement('div')
   harmonicsGroup.className = 'gram-frame-style-group'
-  harmonicsGroup.appendChild(createGroupLabel('Harmonics'))
-  harmonicsGroup.appendChild(createPinToggle(instance))
   container.appendChild(harmonicsGroup)
+
+  // Caption and control share a row, as in the Symbol band above.
+  const harmonicsRow = document.createElement('div')
+  harmonicsRow.className = 'gram-frame-style-row'
+  harmonicsGroup.appendChild(harmonicsRow)
+
+  harmonicsRow.appendChild(createGroupLabel('Harmonics'))
+  harmonicsRow.appendChild(createPinToggle(instance))
 
   // Add click handler for color selection
   canvas.addEventListener('click', (event) => {

--- a/src/components/ColorPicker.js
+++ b/src/components/ColorPicker.js
@@ -1,9 +1,18 @@
 /**
- * Combined colour + symbol picker for GramFrame
+ * Style panel for GramFrame overlays.
  *
- * Provides colour selection (gradient slider) and, alongside it, the symbol
- * drop-down for harmonic overlays, plus a harmonic-pin visibility toggle, under
- * a single "Symbol" panel.
+ * One panel, three bands, grouped by what each control actually affects:
+ *
+ * - **Colour** — the gradient slider. The widest-reaching control there is: it
+ *   styles analysis markers, harmonic sets AND doppler curves.
+ * - **Symbol** — the symbol drop-down and the (temporary) large-symbol toggle.
+ *   Both apply to markers and harmonic sets; neither applies to doppler.
+ * - **Harmonics** — the pin toggle, fenced off below a rule because it is the
+ *   one control here that harmonic sets alone understand.
+ *
+ * The panel used to be headed "Symbol" with all four controls stacked
+ * undifferentiated, which named the narrowest scope in the panel and left the
+ * rest to guesswork.
  */
 
 /// <reference path="../types.js" />
@@ -32,15 +41,26 @@ const COLOR_PALETTE = [
 ]
 
 /**
- * Create the combined "Symbol" control: a colour slider on the left and a
- * symbol drop-down (tinted with the selected colour) on the right.
+ * Create a band caption ("Colour", "Symbol", "Harmonics") for the style panel.
+ * @param {string} text - Caption text
+ * @returns {HTMLDivElement} The caption element
+ */
+function createGroupLabel(text) {
+  const label = document.createElement('div')
+  label.className = 'gram-frame-style-group-label'
+  label.textContent = text
+  return label
+}
+
+/**
+ * Create the "Style" panel: a colour band, a symbol band and a harmonics band.
  *
  * When a marker or harmonic set is selected, this panel restyles that feature
  * in place; otherwise it sets the colour/symbol for the next created feature
  * (feature 161). The panel also syncs its displayed colour/symbol to whichever
  * feature is selected via `instance.interaction.syncStyleControls`.
  * @param {GramFrame} instance - GramFrame instance
- * @returns {HTMLDivElement} The combined colour/symbol picker element
+ * @returns {HTMLDivElement} The style panel element
  */
 export function createColorPicker(instance) {
   const state = instance.state
@@ -48,25 +68,27 @@ export function createColorPicker(instance) {
   container.className = 'gram-frame-color-picker'
   container.style.display = 'block'
 
-  // Label
+  // Panel heading
   const label = document.createElement('div')
   label.className = 'gram-frame-color-picker-label'
-  label.textContent = 'Symbol'
+  label.textContent = 'Style'
   container.appendChild(label)
 
-  // Palette container - horizontal row with the colour slider and symbol select
+  // --- Colour band: applies to markers, harmonic sets and doppler curves ---
+  const colorGroup = document.createElement('div')
+  colorGroup.className = 'gram-frame-style-group'
+  colorGroup.appendChild(createGroupLabel('Colour'))
+  container.appendChild(colorGroup)
+
+  // Palette container - holds the full-width colour slider
   const paletteContainer = document.createElement('div')
   paletteContainer.className = 'gram-frame-color-palette'
-  paletteContainer.style.display = 'flex'
-  paletteContainer.style.alignItems = 'center'
-  paletteContainer.style.gap = '8px'
-  container.appendChild(paletteContainer)
+  colorGroup.appendChild(paletteContainer)
 
   // Slider container for canvas and indicator
   const sliderContainer = document.createElement('div')
   sliderContainer.className = 'gram-frame-color-slider'
   sliderContainer.style.position = 'relative'
-  sliderContainer.style.flex = '1'
   paletteContainer.appendChild(sliderContainer)
 
   // Create continuous color palette using canvas
@@ -89,18 +111,37 @@ export function createColorPicker(instance) {
   indicator.className = 'gram-frame-color-indicator'
   sliderContainer.appendChild(indicator)
 
-  // Symbol drop-down on the right (where the colour swatch used to be); its
-  // glyphs are tinted with the currently selected colour, so it doubles as the
-  // colour readout.
+  // --- Symbol band: applies to markers and harmonic sets, not to doppler ---
+  const symbolGroup = document.createElement('div')
+  symbolGroup.className = 'gram-frame-style-group'
+  container.appendChild(symbolGroup)
+
+  const symbolRow = document.createElement('div')
+  symbolRow.className = 'gram-frame-style-symbol-row'
+  symbolGroup.appendChild(symbolRow)
+
+  symbolRow.appendChild(createGroupLabel('Symbol'))
+
+  // The drop-down's glyphs are tinted with the currently selected colour, so it
+  // doubles as the colour readout.
   const symbolSelect = createSymbolSelect(instance)
-  paletteContainer.appendChild(symbolSelect)
+  symbolRow.appendChild(symbolSelect)
 
-  // Harmonic-pin visibility toggle, below the colour/symbol row.
-  container.appendChild(createPinToggle(instance))
+  // TEMPORARY (size experiment): the size toggle sits alongside the drop-down
+  // it modifies, for feedback on whether larger symbols read better on a real
+  // gram.
+  symbolRow.appendChild(createLargeSymbolToggle(instance))
 
-  // TEMPORARY (size experiment): size toggle beneath the pin toggle, for
-  // feedback on whether the larger symbols read better on a real gram.
-  container.appendChild(createLargeSymbolToggle(instance))
+  // --- Harmonics band: the pin toggle is the one harmonics-only control ---
+  const divider = document.createElement('div')
+  divider.className = 'gram-frame-style-divider'
+  container.appendChild(divider)
+
+  const harmonicsGroup = document.createElement('div')
+  harmonicsGroup.className = 'gram-frame-style-group'
+  harmonicsGroup.appendChild(createGroupLabel('Harmonics'))
+  harmonicsGroup.appendChild(createPinToggle(instance))
+  container.appendChild(harmonicsGroup)
 
   // Add click handler for color selection
   canvas.addEventListener('click', (event) => {

--- a/src/components/MainUI.js
+++ b/src/components/MainUI.js
@@ -74,7 +74,7 @@ export function createUnifiedLayout(instance) {
   
   controlsColumn.appendChild(cursorContainer)
   
-  // Combined colour + symbol control (labelled "Symbol") in controls column
+  // Style panel (colour, symbol, size, pin) in controls column
   const colorPicker = createColorPicker(instance)
   controlsColumn.appendChild(colorPicker)
 

--- a/src/components/PinToggle.js
+++ b/src/components/PinToggle.js
@@ -1,8 +1,10 @@
 /**
  * Harmonic-pin visibility toggle for GramFrame overlays.
  *
- * A checkbox in the combined "Symbol" panel (see ColorPicker.js) that controls
- * whether a harmonic set draws its vertical pin lines. With the pin off, a set
+ * A checkbox in the style panel's Harmonics band (see ColorPicker.js) that
+ * controls whether a harmonic set draws its vertical pin lines. Pins are the
+ * only style in that panel harmonic sets alone understand, which is why the
+ * band is fenced off below a rule. With the pin off, a set
  * renders as its symbols and numbers alone — the style experienced analysts use
  * to stack many harmonic sets over dense data without the lines swamping it.
  *

--- a/src/components/SymbolPicker.js
+++ b/src/components/SymbolPicker.js
@@ -1,9 +1,9 @@
 /**
  * Symbol selector for GramFrame overlays.
  *
- * Renders a compact native drop-down of symbol glyphs. It is embedded in the
- * combined "Symbol" panel (see ColorPicker.js) to the right of the colour
- * slider, and its glyphs are tinted with the currently selected colour.
+ * Renders a compact native drop-down of symbol glyphs. It heads the Symbol band
+ * of the style panel (see ColorPicker.js), below the colour slider, and its
+ * glyphs are tinted with the currently selected colour.
  *
  * When a marker or harmonic set is selected, changing the symbol restyles that
  * feature in place (feature 161); otherwise the chosen symbol is written to
@@ -90,7 +90,7 @@ export function createSymbolSelect(instance) {
 }
 
 /**
- * Create the temporary "Large symbols" toggle for the Symbol panel.
+ * Create the temporary "Large" toggle for the style panel's Symbol band.
  *
  * EXPERIMENT: an on/off switch between the current symbol size and
  * {@link LARGE_SYMBOL_SCALE}× that size, so analysts can compare the two on a
@@ -138,7 +138,9 @@ export function createLargeSymbolToggle(instance) {
 
   const text = document.createElement('span')
   text.className = 'gram-frame-large-symbols-label'
-  text.textContent = 'Large symbols'
+  // Short label: the control sits inline beside the symbol drop-down it
+  // modifies, so "Symbols" would be redundant as well as too wide.
+  text.textContent = 'Large'
 
   label.appendChild(checkbox)
   label.appendChild(text)

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -31,11 +31,11 @@ const initialState = {
   selectedColor: '#ff6b6b', // Currently selected color for new features across all modes
   selectedSymbol: 'cross', // Currently selected symbol; 'cross' (default) means no drawn symbol shape (feature 161)
   // Whether the NEXT created harmonic set draws its vertical pin lines. Shown
-  // as a toggle in the Symbol panel; on by default at the start of a browser
+  // as a toggle in the style panel; on by default at the start of a browser
   // session and remembered (sessionStorage) for the rest of it.
   showHarmonicPin: true,
   // EXPERIMENT (temporary): large-symbol size for the NEXT created feature, set
-  // from the Symbol panel's toggle when nothing is selected (with a feature
+  // from the style panel's toggle when nothing is selected (with a feature
   // selected, the toggle resizes that feature instead). In-memory only, default
   // off, never persisted — it exists to gather feedback on the preferred size.
   largeSymbols: false,

--- a/src/gramframe.css
+++ b/src/gramframe.css
@@ -472,15 +472,16 @@ table.gram-config.gram-frame-config-error tr:first-child td::after {
   margin-bottom: 4px;
 }
 
-/* The Symbol band is a single row, so its caption sits inline with the controls
-   rather than above them. */
-.gram-frame-style-symbol-row {
+/* A band whose controls fit on one line puts its caption inline with them
+   rather than above. Used by the Symbol and Harmonics bands; the Colour band
+   keeps its caption stacked, because the slider spans the panel. */
+.gram-frame-style-row {
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
-.gram-frame-style-symbol-row .gram-frame-style-group-label {
+.gram-frame-style-row .gram-frame-style-group-label {
   margin-bottom: 0;
 }
 

--- a/src/gramframe.css
+++ b/src/gramframe.css
@@ -422,7 +422,7 @@ table.gram-config.gram-frame-config-error tr:first-child td::after {
     0 1px 2px rgba(0,0,0,0.2);
 }
 
-/* Color picker for harmonics */
+/* Style panel: colour band, symbol band, harmonics band */
 .gram-frame-color-picker {
   margin-top: 0;
   padding: 8px;
@@ -451,6 +451,47 @@ table.gram-config.gram-frame-config-error tr:first-child td::after {
   position: relative;
 }
 
+/* One band of the style panel, grouping controls that share a scope. */
+.gram-frame-style-group {
+  margin-bottom: 6px;
+}
+
+.gram-frame-style-group:last-child {
+  margin-bottom: 0;
+}
+
+/* Band caption. Same micro-caps treatment as the panel heading, but ranged left
+   so the bands read as a list beneath the centred title. */
+.gram-frame-style-group-label {
+  font-size: 10px;
+  color: #00ff00;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-weight: bold;
+  text-align: left;
+  margin-bottom: 4px;
+}
+
+/* The Symbol band is a single row, so its caption sits inline with the controls
+   rather than above them. */
+.gram-frame-style-symbol-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.gram-frame-style-symbol-row .gram-frame-style-group-label {
+  margin-bottom: 0;
+}
+
+/* Fences the harmonics-only band off from the controls above it. Lighter than
+   the panel border (#333), which is invisible against the panel's near-black
+   fill — the rule has to be seen to do its job. */
+.gram-frame-style-divider {
+  border-top: 1px solid #4a4a4a;
+  margin: 8px 0 6px;
+}
+
 /* Symbol drop-down embedded to the right of the colour slider. Its `color` is
    set inline to the selected colour so the glyphs render in that colour. */
 .gram-frame-symbol-select {
@@ -464,18 +505,24 @@ table.gram-config.gram-frame-config-error tr:first-child td::after {
   cursor: pointer;
 }
 
-/* Harmonic-pin visibility toggle, below the colour slider / symbol row.
-   TEMPORARY (symbol-size experiment): the "Large symbols" toggle sits under the
-   pin toggle and shares its styling. Remove that selector, and the block below,
-   together with the control once a symbol size is agreed. */
+/* Harmonic-pin visibility toggle, in the panel's harmonics band.
+   TEMPORARY (symbol-size experiment): the "Large" toggle sits inline in the
+   symbol row and shares this styling. Remove that selector, the margin-left
+   override and the blocks below, together with the control once a symbol size
+   is agreed. */
 .gram-frame-pin-toggle,
 .gram-frame-large-symbols-toggle {
   display: flex;
   align-items: center;
   gap: 5px;
-  margin-top: 6px;
   cursor: pointer;
   user-select: none;
+}
+
+/* Push the size toggle to the far edge of the symbol row, clear of the
+   drop-down. */
+.gram-frame-large-symbols-toggle {
+  margin-left: auto;
 }
 
 .gram-frame-pin-toggle-input,
@@ -503,9 +550,14 @@ table.gram-config.gram-frame-config-error tr:first-child td::after {
   cursor: default;
 }
 
+/* The slider has the band to itself, so it spans the panel: a wider gradient is
+   an easier target. The canvas keeps its 140px backing store — the click
+   handler rescales by the rendered width, and the indicator is positioned in
+   percent, so both follow the CSS width. */
 .gram-frame-color-canvas {
-  width: 140px;
-  max-width: 140px;
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
   height: 20px;
   border: 1px solid #555;
   border-radius: 2px;

--- a/src/modes/analysis/AnalysisMode.js
+++ b/src/modes/analysis/AnalysisMode.js
@@ -33,7 +33,7 @@ export class AnalysisMode extends BaseMode {
   /**
    * Base pixel size (width/height) of a marker's symbol mark when it carries a
    * shaped symbol (feature 161). Roughly matches the crosshair's visual weight.
-   * The drawn size is this scaled by the temporary "Large symbols" toggle, so a
+   * The drawn size is this scaled by the temporary "Large" toggle, so a
    * marker's symbol tracks the harmonic pins' symbols.
    * @type {number}
    */

--- a/src/modes/harmonics/HarmonicsMode.js
+++ b/src/modes/harmonics/HarmonicsMode.js
@@ -144,7 +144,7 @@ export class HarmonicsMode extends BaseMode {
 
   /**
    * Base pixel size (width/height) of a pin's symbol mark. The effective size is
-   * this scaled by the "Large symbols" experiment toggle — use
+   * this scaled by the "Large" symbol-size experiment toggle — use
    * {@link HarmonicsMode#symbolSize} rather than reading this directly.
    * @type {number}
    */
@@ -390,7 +390,7 @@ export class HarmonicsMode extends BaseMode {
     const symbol = this.instance.state.selectedSymbol || 'cross'
 
     // Use the session's pin-visibility preference (on unless the analyst turned
-    // it off via the Symbol panel toggle)
+    // it off via the style panel toggle)
     const showPin = this.instance.state.showHarmonicPin !== false
 
     /** @type {HarmonicSet} */
@@ -889,7 +889,7 @@ export class HarmonicsMode extends BaseMode {
 
   /**
    * Effective pixel size of a set's symbol marks: the base size scaled by that
-   * set's own "Large symbols" flag, so sets at both sizes can share a gram. The
+   * set's own large-symbol flag, so sets at both sizes can share a gram. The
    * whole label/symbol stack layout derives from this, so the label spacing and
    * top-edge clamping follow the set's chosen size.
    * @param {HarmonicSet} harmonicSet - Harmonic set configuration

--- a/src/rendering/symbols.js
+++ b/src/rendering/symbols.js
@@ -48,7 +48,7 @@ export const SYMBOL_DISPLAY_NAMES = {
 
 /**
  * EXPERIMENT (temporary — feature-feedback trial): multiplier applied to the
- * on-image symbol marks when the "Large symbols" toggle in the Symbol panel is
+ * on-image symbol marks when the "Large" toggle in the style panel is
  * on. It exists only so analysts can compare the two sizes and tell us which to
  * keep; once a size is chosen, fold the winner into the base sizes and delete
  * both this constant and the toggle.

--- a/src/types.js
+++ b/src/types.js
@@ -446,7 +446,7 @@
  * @property {function(): void} syncStyleControls - Sync the controls to the selection
  * @property {{setValue: function(SymbolType): void, setTint: function(string): void}|null} _symbolControl - Symbol drop-down handle
  * @property {{setValue: function(boolean): void, setEnabled: function(boolean): void}|null} _pinControl - Pin toggle handle
- * @property {{setValue: function(boolean): void}|null} _largeSymbolsControl - "Large symbols" checkbox handle
+ * @property {{setValue: function(boolean): void}|null} _largeSymbolsControl - "Large" symbol-size checkbox handle
  * @property {Array<{target: EventTarget, type: string, handler: EventListener, options?: AddEventListenerOptions}>} _registeredListeners - Listeners kept for removal on destroy
  * @property {import('./modes/shared/BaseDragHandler.js').BaseDragHandler|null} _wheelPanHandler - Drag engine for a middle-button pan
  * @property {{x: number, y: number}|null} _wheelPanLast - Last pointer position during a middle-button pan
@@ -481,7 +481,7 @@
  * @property {HTMLDivElement} mainCell - Main display cell
  * @property {HTMLElement|null} modeLED - Mode LED; never assigned today, so always null
  * @property {HTMLElement|null} rateLED - Rate LED; never assigned today, so always null
- * @property {HTMLElement} colorPicker - Combined colour/symbol picker
+ * @property {HTMLElement} colorPicker - Style panel (colour, symbol, size, pin)
  * @property {SVGSVGElement} svg - Root SVG
  * @property {SVGGElement} cursorGroup - Group holding cursors and persistent features
  * @property {SVGGElement} axesGroup - Group holding the axes
@@ -530,7 +530,7 @@
  * @property {HTMLElement} timeLED - Time readout
  * @property {HTMLElement} freqLED - Frequency readout
  * @property {HTMLElement} speedLED - Speed readout
- * @property {HTMLElement} colorPicker - Colour picker control
+ * @property {HTMLElement} colorPicker - Style panel (colour, symbol, size, pin)
  */
 
 /**


### PR DESCRIPTION
## Why

The controls panel was headed **SYMBOL**, but symbol is only one of the four things it controls, and all four sat stacked with no visual grouping. The heading named the *narrowest* scope in the panel — the colour slider is the widest-reaching control in the whole component.

Verified scope of each control (`src/core/keyboardControl.js:450-473` plus the modes):

| Control | Analysis markers | Harmonic sets | Doppler |
|---|---|---|---|
| Colour slider | ✓ | ✓ | ✓ |
| Symbol drop-down | ✓ | ✓ | ✗ |
| Large symbols | ✓ | ✓ | ✗ |
| Pin | ✗ | ✓ | ✗ |

**Pin is the only harmonics-only control** — symbol and size apply to markers too. The code already knew this (`pinApplies: isHarmonicSet`, and `PinToggle` disabling itself while a marker is selected); the layout just never showed it.

## What changed

The panel is retitled **Style** and split into three bands matching the real scopes:

```
┌ STYLE ───────────────────┐
│ COLOUR                   │   markers + harmonics + doppler
│ [▬▬▬▬ rainbow ▬▬▬▬]      │
│ SYMBOL  [✕ ˅]  ☐ LARGE   │   markers + harmonics
│ ──────────────────────── │
│ HARMONICS                │   harmonic sets only
│ ☑ PIN                    │
└──────────────────────────┘
```

- `src/components/ColorPicker.js` — restructured into three `.gram-frame-style-group` bands with a rule before the harmonics band. Behaviour untouched: the click handler, `showColor`, and `syncStyleControls` are unchanged.
- `src/components/SymbolPicker.js` — the size toggle moves inline beside the drop-down it modifies and shortens to "Large". Same temporary experiment, same behaviour, same classes.
- `src/gramframe.css` — band/caption/divider/symbol-row styles; the size toggle gains `margin-left: auto`; the colour canvas goes full-width now that the drop-down has vacated its row.
- Stale "Symbol panel" comments corrected across `state.js`, `symbols.js`, `MainUI.js`, `AnalysisMode.js`, `HarmonicsMode.js`, `PinToggle.js`, `types.js`.

Grouping, labelling and CSS only. Selection routing, pin session persistence and the `syncStyleControls` path are untouched, and every class name the tests key off survives on the same element — no test edits were needed.

## Notes

- The colour canvas keeps its 140px backing store; the click handler already rescaled by rendered width (`scaleX = canvas.width / rect.width`) and the indicator is positioned in percent, so both follow the CSS width.
- The divider is `#4a4a4a` rather than the panel border's `#333`, which is invisible against the panel's near-black fill.
- No user-facing docs describe this panel, so none needed updating.

## Verification

- `yarn typecheck` clean; `yarn lint` 0 errors (44 pre-existing warnings in test files); `yarn hygiene` at baseline on all five ratchets.
- `yarn test` — 267 passed. `yarn test:unit` — 92 passed.
- Checked by hand in the browser on `debug.html`:
  - Panel measures 220×145 inside the 242px-tall controls column — no clipping, no horizontal overflow of panel or canvas.
  - Colour picks correctly across the widened slider (`#ff1c00` at 2%, `#00ffc0` at 50%, `#ff009c` at 98%).
  - Marker selected → PIN disabled and dimmed, symbol and LARGE stay live. Harmonic set selected → all four live.
  - Doppler curve created after picking a colour takes that colour, confirming the COLOUR band still reaches doppler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4endT6GVPKG2osAfQu21w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4endT6GVPKG2osAfQu21w)_