### PR TITLE
Show mini-pins when a harmonic set's pin is hidden

### DIFF
--- a/docs/Gram-Modes.md
+++ b/docs/Gram-Modes.md
@@ -69,12 +69,13 @@ multiples of a spacing.
 - Click and drag to create a harmonic set; the drag sets the spacing.
 - Drag an existing set to adjust its spacing and anchor time.
 - **+ Manual** opens a dialog for entering a spacing numerically.
-- Each set draws a symbol and harmonic number per harmonic, optionally with
-  vertical pin lines (the **Pin** toggle; on by default for each browser
-  session).
-- Dense sets are sampled: at most a fixed number of pins are drawn within the
-  visible span, at a regular "nice" interval, so a small spacing over a wide span
-  stays legible.
+- Each set draws a vertical pin line per harmonic, capped by the **Tall Pins**
+  toggle (on by default for each browser session): full-height lines when it is
+  on, short mini-pins hanging from the symbols when it is off.
+- Dense sets are sampled: at most a fixed number of symbols and harmonic numbers
+  are drawn within the visible span, at a regular "nice" interval, so a small
+  spacing over a wide span stays legible. The pins themselves are not thinned, so
+  the unlabelled harmonics still show against the data.
 - Sets are listed in the harmonics panel; selecting a row enables arrow-key
   adjustment and in-place restyling, as for markers.
 

--- a/src/components/PinToggle.js
+++ b/src/components/PinToggle.js
@@ -2,11 +2,15 @@
  * Harmonic-pin visibility toggle for GramFrame overlays.
  *
  * A checkbox in the style panel's Harmonics band (see ColorPicker.js) that
- * controls whether a harmonic set draws its vertical pin lines. Pins are the
- * only style in that panel harmonic sets alone understand, which is why the
- * band is fenced off below a rule. With the pin off, a set
- * renders as its symbols and numbers alone — the style experienced analysts use
- * to stack many harmonic sets over dense data without the lines swamping it.
+ * controls whether a harmonic set draws its full-height vertical pin lines.
+ * Pins are the only style in that panel harmonic sets alone understand, which is
+ * why the band is fenced off below a rule. With the toggle off, a set renders as
+ * its symbols and numbers over short mini-pins — the style experienced analysts
+ * use to stack many harmonic sets over dense data without the lines swamping it.
+ *
+ * It is labelled "Tall Pins" rather than "Pin" because a pin-less set still
+ * draws mini-pins (issue #232): the choice is between tall pins and short ones,
+ * not between pins and none.
  *
  * When a harmonic set is selected, toggling restyles that set in place;
  * otherwise the choice is written to `state.showHarmonicPin` and applied to the
@@ -32,17 +36,17 @@ export function createPinToggle(instance) {
 
   const row = document.createElement('label')
   row.className = 'gram-frame-pin-toggle'
-  row.title = 'Show the vertical pin lines of harmonic sets'
+  row.title = 'Draw harmonic sets with full-height pin lines instead of mini-pins'
 
   const checkbox = document.createElement('input')
   checkbox.type = 'checkbox'
   checkbox.className = 'gram-frame-pin-toggle-input'
   checkbox.checked = state.showHarmonicPin !== false
-  checkbox.setAttribute('aria-label', 'Show harmonic pin')
+  checkbox.setAttribute('aria-label', 'Show tall harmonic pins')
 
   const text = document.createElement('span')
   text.className = 'gram-frame-pin-toggle-label'
-  text.textContent = 'Pin'
+  text.textContent = 'Tall Pins'
 
   row.appendChild(checkbox)
   row.appendChild(text)
@@ -76,8 +80,8 @@ export function createPinToggle(instance) {
       checkbox.disabled = !enabled
       row.classList.toggle('gram-frame-pin-toggle-disabled', !enabled)
       row.title = enabled
-        ? 'Show the vertical pin lines of harmonic sets'
-        : 'Pins apply to harmonic sets only'
+        ? 'Draw harmonic sets with full-height pin lines instead of mini-pins'
+        : 'Tall pins apply to harmonic sets only'
     }
   }
 

--- a/src/gramframe.css
+++ b/src/gramframe.css
@@ -1102,7 +1102,8 @@ table.gram-frame-table {
 /* SVG Harmonic line styles */
 
 
-.gram-frame-harmonic-line {
+.gram-frame-harmonic-line,
+.gram-frame-harmonic-mini-pin {
   stroke-width: 2;
   fill: none;
   pointer-events: none;

--- a/src/modes/harmonics/HarmonicsMode.js
+++ b/src/modes/harmonics/HarmonicsMode.js
@@ -163,6 +163,18 @@ export class HarmonicsMode extends BaseMode {
   static PIN_HEIGHT_RATIO = 0.2
 
   /**
+   * Height (px) of a mini-pin: the stub line drawn under each harmonic of a set
+   * whose full pin is hidden.
+   *
+   * Fixed rather than derived, by design (spec: issue #232). It is half the
+   * height of a "Large" symbol mark (SYMBOL_SIZE * LARGE_SYMBOL_SCALE = 20px),
+   * which is enough to tie each harmonic to the data beneath it without
+   * reinstating the clutter the pin toggle exists to remove.
+   * @type {number}
+   */
+  static MINI_PIN_HEIGHT = 10
+
+  /**
    * Maximum pin lines rendered per harmonic set. At the 0.1 Hz minimum spacing
    * a standard 0–20 kHz config has 200,000 visible harmonics; drawing an SVG
    * line for each — rebuilt on every drag frame — locked the browser (BH-2).
@@ -487,10 +499,11 @@ export class HarmonicsMode extends BaseMode {
    * Find the harmonic set whose drawn geometry contains the given position.
    *
    * Hit-testing follows exactly what is drawn — nothing more, nothing less.
-   * Every visible part of a pin grabs it: the pin line's fixed-pixel span AND
-   * the number label + symbol stacked above it. A set with its pin hidden is
-   * grabbable by its label/symbol stack alone; the span where its line would
-   * have been is empty on screen, so it is empty to the mouse too.
+   * Every visible part of a pin grabs it: the line's fixed-pixel span AND the
+   * number label + symbol stacked above it. A set with its pin hidden draws
+   * mini-pins, so its line region shrinks to that stub — the empty span below,
+   * where a full pin would have reached, is blank on screen and blank to the
+   * mouse too.
    *
    * Takes the probe position as a parameter rather than reading
    * `state.cursorPosition`: the stored cursor goes stale during pans (wheel-pan
@@ -523,8 +536,11 @@ export class HarmonicsMode extends BaseMode {
         const stack = this.calculateLabelStackBounds(lineTop, harmonicSet)
         // Only the thinned subset is labelled, so only those pins carry a stack.
         const labelled = this.getLabelledHarmonics(minHarmonic, maxHarmonic)
-        // A hidden pin draws no lines, so its line span is not a grab region.
+        // A hidden pin draws mini-pins instead of full lines, so its line grab
+        // region is the mini-pin stub hanging from the stack's underside.
         const pinDrawn = harmonicSet.showPin !== false
+        const lineFrom = pinDrawn ? lineTop : stack.bottom
+        const lineTo = lineFrom + (pinDrawn ? lineHeight : HarmonicsMode.MINI_PIN_HEIGHT)
 
         const tolerance = getUniformTolerance(this.getViewport(), this.instance.ui.spectrogramImage)
         const cursorSVG = dataToSVG(
@@ -533,10 +549,10 @@ export class HarmonicsMode extends BaseMode {
           this.instance.ui.spectrogramImage
         )
 
-        // The pin line: frequency tolerance horizontally, the line span
+        // The pin line: frequency tolerance horizontally, the drawn line span
         // vertically. Only the harmonic(s) nearest the probe frequency can
         // pass the horizontal test, so only they are checked.
-        if (pinDrawn && cursorSVG.y >= lineTop && cursorSVG.y <= lineTop + lineHeight) {
+        if (cursorSVG.y >= lineFrom && cursorSVG.y <= lineTo) {
           const nearest = Math.round(freq / harmonicSet.spacing)
           const from = Math.max(minHarmonic, nearest - 1)
           const to = Math.min(maxHarmonic, nearest + 1)
@@ -754,7 +770,9 @@ export class HarmonicsMode extends BaseMode {
     // Clear existing harmonic lines and their symbol marks. Scope the symbol
     // cleanup to harmonic pin symbols (which carry data-harmonic-set-id) so it
     // never removes analysis-marker symbols that share the base symbol class.
-    const existingHarmonics = this.instance.ui.cursorGroup.querySelectorAll('.gram-frame-harmonic-line')
+    const existingHarmonics = this.instance.ui.cursorGroup.querySelectorAll(
+      '.gram-frame-harmonic-line, .gram-frame-harmonic-mini-pin'
+    )
     existingHarmonics.forEach(line => line.remove())
     const existingSymbols = this.instance.ui.cursorGroup.querySelectorAll('.gram-frame-harmonic-symbol[data-harmonic-set-id]')
     existingSymbols.forEach(symbol => symbol.remove())
@@ -851,6 +869,29 @@ export class HarmonicsMode extends BaseMode {
     line.setAttribute('stroke-linecap', 'round')
     line.setAttribute('opacity', '0.9')
     return line
+  }
+
+  /**
+   * Create the short stub line drawn under a harmonic when the set's full pin is
+   * hidden.
+   *
+   * Same colour and stroke as a full pin line, so a mini-pin reads as the same
+   * feature at a smaller scale; only its class and height differ. The distinct
+   * class keeps the two apart for cleanup, hit-testing and tests — a hidden-pin
+   * set still draws no `.gram-frame-harmonic-line`.
+   *
+   * @param {number} harmonicNumber - Harmonic number
+   * @param {HarmonicSet} harmonicSet - Harmonic set configuration
+   * @param {number} lineX - X position of the mini-pin
+   * @param {number} top - Top Y position of the mini-pin (the symbol's underside)
+   * @returns {SVGLineElement} SVG line element
+   */
+  createMiniPin(harmonicNumber, harmonicSet, lineX, top) {
+    const miniPin = this.createHarmonicLine(
+      harmonicNumber, harmonicSet, lineX, top, HarmonicsMode.MINI_PIN_HEIGHT
+    )
+    miniPin.setAttribute('class', 'gram-frame-harmonic-mini-pin')
+    return miniPin
   }
 
   /**
@@ -1022,11 +1063,13 @@ export class HarmonicsMode extends BaseMode {
    * symbol only for the thinned "major" subset so the overlay stays readable.
    * Lines are appended first so the labels/symbols paint on top of them.
    *
-   * A set with `showPin === false` skips the lines entirely and renders as its
-   * symbols and numbers alone — the low-clutter style for stacking many sets over
-   * dense data. The label/symbol geometry is unchanged, so toggling the pin adds
-   * or removes the lines without moving anything else; the set is then grabbed
-   * by its label/symbol stack, since hit-testing only covers what is drawn.
+   * A set with `showPin === false` draws a mini-pin per harmonic instead of a
+   * full-height line: a stub hanging from the symbol's underside, in the set's
+   * colour. Labels and symbols are thinned, so without them a pin-less set gave
+   * no sign of where the harmonics between the labelled ones actually fell
+   * (issue #232); the mini-pins restore that alignment with the data at a
+   * fraction of the ink. The label/symbol geometry is unchanged either way, so
+   * toggling the pin swaps line lengths without moving anything else.
    *
    * @param {HarmonicSet} harmonicSet - Harmonic set to render
    */
@@ -1042,26 +1085,32 @@ export class HarmonicsMode extends BaseMode {
 
     const { lineHeight, lineTop } = this.calculateHarmonicLineDimensions(harmonicSet)
     const imageTop = getImageBounds(this.getViewport(), this.instance.ui.spectrogramImage).top
+    // The label/symbol stack is laid out first: a mini-pin hangs from the
+    // underside of the symbol, so it needs the stack's (possibly clamped)
+    // vertical position.
+    const { symbolCy, labelY } = this.calculateLabelStackPositions(lineTop, imageTop, harmonicSet)
+    const pinDrawn = harmonicSet.showPin !== false
 
-    // Draw every pin line in the visible span (FR-001) — unless this set is set
-    // to hide its pin. Sets restored from storage without the flag are pinned.
+    // Draw a line for every harmonic in the visible span (FR-001) — full height
+    // when the set is pinned, a mini-pin when it is not. Sets restored from
+    // storage without the flag are pinned.
     // Beyond MAX_PIN_LINES the lines are a regular sample of the span (BH-2):
     // by then adjacent pins have long merged on screen, and an uncapped loop
     // rebuilt hundreds of thousands of SVG elements per drag frame.
-    if (harmonicSet.showPin !== false) {
-      const visibleCount = maxHarmonic - minHarmonic + 1
-      const stride = Math.max(1, Math.ceil(visibleCount / HarmonicsMode.MAX_PIN_LINES))
-      for (let harmonicNumber = minHarmonic; harmonicNumber <= maxHarmonic; harmonicNumber += stride) {
-        const lineX = this.harmonicLineX(harmonicSet, harmonicNumber)
-        const line = this.createHarmonicLine(harmonicNumber, harmonicSet, lineX, lineTop, lineHeight)
-        this.instance.ui.cursorGroup.appendChild(line)
-      }
+    const visibleCount = maxHarmonic - minHarmonic + 1
+    const stride = Math.max(1, Math.ceil(visibleCount / HarmonicsMode.MAX_PIN_LINES))
+    const miniPinTop = symbolCy + this.symbolSize(harmonicSet) / 2
+    for (let harmonicNumber = minHarmonic; harmonicNumber <= maxHarmonic; harmonicNumber += stride) {
+      const lineX = this.harmonicLineX(harmonicSet, harmonicNumber)
+      const line = pinDrawn
+        ? this.createHarmonicLine(harmonicNumber, harmonicSet, lineX, lineTop, lineHeight)
+        : this.createMiniPin(harmonicNumber, harmonicSet, lineX, miniPinTop)
+      this.instance.ui.cursorGroup.appendChild(line)
     }
 
     // Draw labels + symbols only on the thinned major subset (FR-002), stacked
     // above each pin line with a shared, on-screen vertical layout.
     const labelledHarmonics = this.getLabelledHarmonics(minHarmonic, maxHarmonic)
-    const { symbolCy, labelY } = this.calculateLabelStackPositions(lineTop, imageTop, harmonicSet)
 
     labelledHarmonics.forEach(harmonicNumber => {
       const lineX = this.harmonicLineX(harmonicSet, harmonicNumber)

--- a/tests/harmonic-hotspot.spec.js
+++ b/tests/harmonic-hotspot.spec.js
@@ -121,12 +121,21 @@ test.describe('Harmonic set hotspot', () => {
     const setId = await gramFramePage.addHarmonicSet(ANCHOR_TIME, SPACING)
     await updateSet(gramFramePage, setId, { showPin: false })
 
-    // No lines are drawn, so the label/symbol stack is the whole feature.
+    // No full-height lines are drawn, so the label/symbol stack and the
+    // mini-pin stub beneath it are the whole feature.
     expect(await gramFramePage.page.locator(
       `.gram-frame-harmonic-line[data-harmonic-set-id="${setId}"]`
     ).count()).toBe(0)
 
     expect(await probeAt(gramFramePage, labelSelector(setId, CENTRE_HARMONIC))).toBe(setId)
+  })
+
+  test('with the pin hidden, the mini-pin grabs the set', async ({ gramFramePage }) => {
+    const setId = await gramFramePage.addHarmonicSet(ANCHOR_TIME, SPACING)
+    await updateSet(gramFramePage, setId, { showPin: false })
+
+    const miniPin = `.gram-frame-harmonic-mini-pin[data-harmonic-set-id="${setId}"][data-harmonic-number="${CENTRE_HARMONIC}"]`
+    expect(await probeAt(gramFramePage, miniPin)).toBe(setId)
   })
 
   test('with the pin hidden, the blank span below the label does not grab the set', async ({ gramFramePage }) => {

--- a/tests/harmonic-pin-toggle.spec.js
+++ b/tests/harmonic-pin-toggle.spec.js
@@ -4,8 +4,9 @@ import { GramFramePage } from './helpers/gram-frame-page.js'
 /**
  * @fileoverview E2E tests for the harmonic-pin visibility toggle in the Symbol
  * panel. Covers the default-on session preference, pin-less creation, editing an
- * existing set in place, persistence within the browser session, and the
- * restore of harmonic sets saved before the toggle existed.
+ * existing set in place, persistence within the browser session, the restore of
+ * harmonic sets saved before the toggle existed, and the mini-pins a pin-less
+ * set draws in place of full pin lines.
  */
 
 /**
@@ -277,5 +278,80 @@ test.describe('US4: Legacy harmonic sets restore with pins shown', () => {
     expect(await gfp.getHarmonicLineCount('legacy-pin-1')).toBeGreaterThan(0)
 
     expect(consoleErrors).toEqual([])
+  })
+})
+
+// ──────────────────────────────────────────────────────────────
+// User Story 5 — Mini-pins keep a pin-less set tied to the data (issue #232)
+// ──────────────────────────────────────────────────────────────
+
+test.describe('US5: Pin-less sets draw mini-pins', () => {
+  // Debug config spans 0-100 Hz, so a 0.5 Hz set has 200 visible harmonics —
+  // far more than the 25-label sampling cap.
+  const SPACING = 0.5
+  const ANCHOR_TIME = 30
+  const MINI_PIN_HEIGHT = 10
+
+  test.beforeEach(async ({ gramFramePage }) => {
+    await gramFramePage.clickMode('Harmonics')
+  })
+
+  test('a mini-pin is drawn for every visible harmonic, not just the labelled ones', async ({ gramFramePage }) => {
+    await gramFramePage.setPinToggle(false)
+    const setId = await gramFramePage.addHarmonicSet(ANCHOR_TIME, SPACING)
+
+    const miniPins = await gramFramePage.getMiniPins(setId)
+    const labels = await gramFramePage.getHarmonicLabelNumbers(setId)
+
+    // Every harmonic in the span gets a mini-pin; only a sampled few are labelled.
+    expect(miniPins.map((p) => p.harmonic)).toEqual(
+      Array.from({ length: 200 }, (_, i) => i + 1)
+    )
+    expect(labels.length).toBeLessThan(miniPins.length)
+
+    // ...and no full-height lines, which is what the toggle turns off.
+    expect(await gramFramePage.getHarmonicLineCount(setId)).toBe(0)
+  })
+
+  test('mini-pins are a fixed short height in the set\'s own colour', async ({ gramFramePage }) => {
+    await gramFramePage.setPinToggle(false)
+    const setId = await gramFramePage.addHarmonicSet(ANCHOR_TIME, SPACING)
+
+    const state = await gramFramePage.getState()
+    const set = state.harmonics.harmonicSets.find((s) => s.id === setId)
+
+    const miniPins = await gramFramePage.getMiniPins(setId)
+    expect(miniPins.length).toBeGreaterThan(0)
+    for (const pin of miniPins) {
+      expect(pin.stroke).toBe(set.color)
+      expect(pin.y2 - pin.y1).toBeCloseTo(MINI_PIN_HEIGHT, 5)
+    }
+  })
+
+  test('mini-pins hang from where the full pin line would start', async ({ gramFramePage }) => {
+    const pinnedId = await gramFramePage.addHarmonicSet(ANCHOR_TIME, SPACING)
+    await gramFramePage.page.evaluate(() => {
+      // @ts-ignore - test-only global
+      window.GramFrame.__test__getInstances()[0].interaction.clearSelection()
+    })
+    await gramFramePage.setPinToggle(false)
+    const pinlessId = await gramFramePage.addHarmonicSet(ANCHOR_TIME, SPACING)
+
+    // A pinned set draws no mini-pins, and vice versa.
+    expect((await gramFramePage.getMiniPins(pinnedId)).length).toBe(0)
+    expect(await gramFramePage.getHarmonicLineCount(pinlessId)).toBe(0)
+
+    // Same anchor time and spacing, so the mini-pin of a given harmonic starts
+    // exactly where the full line of the same harmonic starts — under the symbol.
+    const fullLine = await gramFramePage.page.evaluate((id) => {
+      const line = document.querySelector(
+        `.gram-frame-harmonic-line[data-harmonic-set-id="${id}"][data-harmonic-number="10"]`
+      )
+      return { x: Number(line.getAttribute('x1')), y1: Number(line.getAttribute('y1')) }
+    }, pinnedId)
+
+    const miniPin = (await gramFramePage.getMiniPins(pinlessId)).find((p) => p.harmonic === 10)
+    expect(miniPin.x).toBeCloseTo(fullLine.x, 5)
+    expect(miniPin.y1).toBeCloseTo(fullLine.y1, 5)
   })
 })

--- a/tests/helpers/gram-frame-page.js
+++ b/tests/helpers/gram-frame-page.js
@@ -683,6 +683,36 @@ class GramFramePage {
   }
 
   /**
+   * Build a CSS selector for mini-pins (the stubs a pin-less set draws under
+   * each harmonic), optionally scoped to one set.
+   * @param {string} [setId] - Restrict to a single harmonic set's mini-pins
+   * @returns {string} Selector string
+   */
+  miniPinSelector(setId) {
+    return setId
+      ? `.gram-frame-harmonic-mini-pin[data-harmonic-set-id="${setId}"]`
+      : '.gram-frame-harmonic-mini-pin'
+  }
+
+  /**
+   * Read the geometry of each rendered mini-pin, in document order, optionally
+   * for a single set.
+   * @param {string} [setId] - Restrict to one harmonic set
+   * @returns {Promise<Array<{harmonic: number, x: number, y1: number, y2: number, stroke: string}>>} Mini-pin geometry
+   */
+  async getMiniPins(setId) {
+    return this.page.evaluate((selector) => {
+      return Array.from(document.querySelectorAll(selector)).map((pin) => ({
+        harmonic: Number(pin.getAttribute('data-harmonic-number')),
+        x: Number(pin.getAttribute('x1')),
+        y1: Number(pin.getAttribute('y1')),
+        y2: Number(pin.getAttribute('y2')),
+        stroke: String(pin.getAttribute('stroke'))
+      }))
+    }, this.miniPinSelector(setId))
+  }
+
+  /**
    * Read the `data-harmonic-number` of each rendered harmonic line, in document
    * order, optionally for a single set.
    * @param {string} [setId] - Restrict to one harmonic set


### PR DESCRIPTION
Closes #232.

## Problem

With a harmonic set's pin switched off, the set drew only its symbols and number labels — and both of those are thinned by the label sampler (max 25 per visible span). On a small spacing, the harmonics between the sampled ones left no mark at all, so the set gave no sign of how the discrete harmonics line up with the data underneath.

## Change

A set with `showPin === false` now draws a **mini-pin** for every visible harmonic instead of nothing: a short stub in the set's colour, hanging from the underside of where the symbol sits (exactly where a full pin line would have started).

- Height is a fixed `MINI_PIN_HEIGHT = 10` px — not derived — being half the height of a "Large" symbol mark (`SYMBOL_SIZE * LARGE_SYMBOL_SCALE = 20`).
- Colour and stroke match the set's full pin line, so a mini-pin reads as the same feature at a smaller scale.
- The label/symbol geometry is untouched, so toggling the pin swaps line lengths without moving anything else. The top-edge clamp is respected — the mini-pin follows the stack down.
- The same `MAX_PIN_LINES` sampling that protects the full-pin path applies, so a dense set costs no more than a pinned one.

Mini-pins carry their own class (`.gram-frame-harmonic-mini-pin`), so a hidden-pin set still draws no `.gram-frame-harmonic-line`. Hit-testing continues to follow exactly what is drawn: the line grab region for a pin-less set shrinks from the full-height span to the mini-pin stub, and the blank space further down still grabs nothing.

## How it looks

On a pin-less set at 2 Hz spacing over the debug config's 0–100 Hz span, the label sampler thins the digits and symbols to every 2nd harmonic. Previously harmonics 1, 3, 5, … were invisible; they now each carry a mini-pin, so the whole comb of harmonics is readable against the gram while the labelling stays sparse. (Screenshot shared with the issue author.)

## Testing

- `yarn typecheck`, `yarn lint`, `yarn hygiene` — clean
- `yarn test` — 271 passed
- `yarn test:unit` — 92 passed
- New coverage: a "US5: Pin-less sets draw mini-pins" block in `tests/harmonic-pin-toggle.spec.js` (one mini-pin per visible harmonic vs. the thinned labels, fixed height + set colour, alignment with where the full line starts, and pinned/pin-less sets not drawing each other's lines), plus a hotspot test that a mini-pin grabs its set.