### PR TITLE
Add cross-cursor labels to analysis markers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ Every path below exists; keep this list in step with `src/` when adding modules.
   - `DiffingTable.js` - Shared row-diffing table behind the markers table and harmonics panel
   - `ColorPicker.js` - Colour selection component
   - `SymbolPicker.js` - Symbol selection component
+  - `MarkerLabelModal.js` - Add/edit/remove a marker's label
   - `PinToggle.js` - Harmonic-pin visibility toggle
   - `ExpandToggle.js` - Expand/collapse the image to fill the space
   - `StorageWarning.js` - Non-blocking banner when a save fails
@@ -120,6 +121,7 @@ Every path below exists; keep this list in step with `src/` when adding modules.
 - `src/rendering/` - Rendering system. These modules draw; they do not dispatch:
   - `axes.js` - The axis engine: `renderAxes` and its private tick/label helpers
   - `symbols.js` - Marker/harmonic symbol shapes
+  - `labels.js` - Marker label placement and element (feature 231)
 - `src/utils/` - Utility modules:
   - `coordinates.js` - The canonical coordinate module: every screen/SVG/image/data
     conversion, zoom-, expand-, render-size- and margin-aware. Also owns
@@ -128,6 +130,7 @@ Every path below exists; keep this list in step with `src/` when adding modules.
   - `calculations.js` - Mathematical calculations
   - `doppler.js` - Doppler-specific calculations
   - `harmonicSampling.js` - Pin sampling for dense harmonic sets
+  - `markerLabel.js` - Marker label normalisation and table abbreviation
   - `tolerance.js` - Shared hit-test tolerances
   - `svg.js` - SVG text halo styling
   - `secureHTML.js` - Guidance-panel rendering without innerHTML
@@ -228,7 +231,8 @@ There is no visual/screenshot regression testing — see
 
 ### Mode-Specific Features
 - **Pan Mode**: The default mode; drag to pan when zoomed in, so a first click never places anything
-- **Analysis Mode**: Persistent draggable markers with cross-mode visibility
+- **Analysis Mode**: Persistent draggable markers with cross-mode visibility and optional
+  haloed text labels (upper-right of a crosshair, centred above a shaped symbol)
 - **Harmonics Mode**: Real-time harmonic calculation and display
 - **Doppler Mode**: Speed calculation from f+/f-/f₀ markers
 

--- a/docs/Gram-Modes.md
+++ b/docs/Gram-Modes.md
@@ -53,6 +53,15 @@ events, broadband pulses or ambient shifts in sonar data.
   that marker, after which the arrow keys nudge it (Shift for larger steps).
 - A marker's colour and symbol come from the style controls; with a marker
   selected, those controls restyle it in place.
+- Each row's **label button** (the tag icon, above the delete ×) opens a dialog
+  for the marker's label. Labels are optional — a marker has none until one is
+  entered — and clearing the field removes the label again.
+- A label is drawn on the gram in black inside a white halo, so it reads over
+  both dark and light pixels: in the upper-right quadrant of a crosshair marker,
+  or centred above a marker that carries a shaped symbol.
+- The table's **Label** column shows labels of five characters or fewer in full,
+  and abbreviates anything longer to its first three characters plus `..`. The
+  full text stays on the gram and in the dialog.
 
 ---
 

--- a/hygiene-baseline.json
+++ b/hygiene-baseline.json
@@ -5,6 +5,6 @@
   "unusedExportModules": 5,
   "waitForTimeoutOccurrences": 1,
   "_comment_instanceSurface": "specs/167-structural-refactor Story 5. instanceStateReachIns counts lines containing `instance.state` under src/; instanceFields counts class-field declarations between `export class GramFrame` and its constructor in src/main.js.",
-  "instanceStateReachIns": 180,
+  "instanceStateReachIns": 170,
   "instanceFields": 11
 }

--- a/src/components/DiffingTable.js
+++ b/src/components/DiffingTable.js
@@ -150,8 +150,22 @@ export function createDiffingTable(container, spec) {
   }
 
   /**
-   * Row clicks: select, unless the click landed on the delete control.
-   * Delegated from the body so rebuilt rows need no re-wiring.
+   * Per-row controls that act instead of selecting, in match order. Delete is
+   * one of these — the original and, for the harmonics panel, the only one —
+   * so it is folded into the same list rather than special-cased twice.
+   * @type {Array<{selector: string, handler: function(string, any, number): void}>}
+   */
+  const rowActions = []
+  if (spec.deleteSelector && spec.onDelete) {
+    rowActions.push({ selector: spec.deleteSelector, handler: spec.onDelete })
+  }
+  if (spec.actions) {
+    rowActions.push(...spec.actions)
+  }
+
+  /**
+   * Row clicks: select, unless the click landed on one of the row's action
+   * controls. Delegated from the body so rebuilt rows need no re-wiring.
    * @param {MouseEvent} event - Click event
    */
   function handleClick(event) {
@@ -167,12 +181,11 @@ export function createDiffingTable(container, spec) {
     const index = Array.prototype.indexOf.call(tbody.children, tr)
     const row = currentRows[index]
 
-    if (spec.deleteSelector && target.closest(spec.deleteSelector)) {
+    const action = rowActions.find(candidate => target.closest(candidate.selector))
+    if (action) {
       event.preventDefault()
       event.stopPropagation()
-      if (spec.onDelete) {
-        spec.onDelete(key, row, index)
-      }
+      action.handler(key, row, index)
       return
     }
 

--- a/src/components/MainUI.js
+++ b/src/components/MainUI.js
@@ -83,20 +83,24 @@ export function createUnifiedLayout(instance) {
   leftColumn.appendChild(guidanceColumn)
   leftColumn.appendChild(controlsColumn)
   
-  // Middle Column (160px) - Analysis Markers table
+  // Middle Column (185-235px) - Analysis Markers table. Elastic since the Label
+  // column was added (feature 231): up to 235px where the host has the width,
+  // down to 185px where it does not, so a narrow page keeps the control row the
+  // height it always had. See the note in gramframe.css.
   const middleColumn = /** @type {HTMLDivElement} */ (createFlexColumn('gram-frame-middle-column'))
-  middleColumn.style.flex = '0 0 160px'
-  middleColumn.style.width = '160px'
+  middleColumn.style.flex = '0 3 235px'
+  middleColumn.style.width = 'auto'
   
   // Create markers container in middle column
   const markersContainer = createMarkersContainer()
   middleColumn.appendChild(markersContainer)
   
-  // Right Column (200px) - Harmonics sets table
+  // Right Column (175px) - Harmonics sets table. Narrowed from 200px to fund
+  // the markers column's Label column (feature 231); its four columns still fit.
   const rightColumn = /** @type {HTMLDivElement} */ (createFlexColumn('gram-frame-right-column'))
-  rightColumn.style.flex = '0 0 200px'
-  rightColumn.style.minWidth = '200px'
-  rightColumn.style.width = '200px'
+  rightColumn.style.flex = '0 0 175px'
+  rightColumn.style.minWidth = '175px'
+  rightColumn.style.width = '175px'
   
   // Create harmonics container in right column
   const harmonicsContainer = createHarmonicsContainer()

--- a/src/components/MarkerLabelModal.js
+++ b/src/components/MarkerLabelModal.js
@@ -1,0 +1,123 @@
+/**
+ * The marker-label dialog (feature 231).
+ *
+ * Opened from the Label button in a markers-table row, it lets an analyst enter
+ * or edit the free text shown next to that marker on the gram. Clearing the
+ * field and saving removes the label, so one dialog covers add, edit and
+ * remove.
+ *
+ * Built with `createElement` rather than `innerHTML`: the current label is user
+ * text being put back into the DOM, and `textContent`/`value` assignment keeps
+ * that unambiguously inert.
+ */
+
+/// <reference path="../types.js" />
+
+import { MAX_MARKER_LABEL_LENGTH, normalizeMarkerLabel } from '../utils/markerLabel.js'
+
+/**
+ * Show the label dialog for one marker.
+ *
+ * The dialog is modal-by-convention (a full-screen overlay), self-closing, and
+ * removes itself on save, cancel, Escape, or a click on the backdrop. `onSave`
+ * fires only on save, with the normalised label — `undefined` when the analyst
+ * cleared the field.
+ *
+ * @param {string|undefined} currentLabel - The marker's existing label, if any
+ * @param {function(string|undefined): void} onSave - Called with the new label on save
+ * @returns {HTMLDivElement} The overlay element, for callers that need to dismiss it
+ */
+export function showMarkerLabelModal(currentLabel, onSave) {
+  const overlay = document.createElement('div')
+  overlay.className = 'gram-frame-modal-overlay gram-frame-marker-label-modal'
+
+  const modal = document.createElement('div')
+  modal.className = 'gram-frame-modal'
+
+  const header = document.createElement('div')
+  header.className = 'gram-frame-modal-header'
+  const heading = document.createElement('h3')
+  heading.textContent = currentLabel ? 'Edit Marker Label' : 'Add Marker Label'
+  header.appendChild(heading)
+
+  const body = document.createElement('div')
+  body.className = 'gram-frame-modal-body'
+  const inputGroup = document.createElement('div')
+  inputGroup.className = 'gram-frame-modal-input-group'
+
+  const inputLabel = document.createElement('label')
+  inputLabel.setAttribute('for', 'gram-frame-marker-label-input')
+  inputLabel.textContent = 'Label:'
+
+  const input = document.createElement('input')
+  input.type = 'text'
+  input.id = 'gram-frame-marker-label-input'
+  input.className = 'gram-frame-marker-label-input'
+  input.maxLength = MAX_MARKER_LABEL_LENGTH
+  input.placeholder = 'Enter a label for this marker'
+  input.value = currentLabel || ''
+
+  const hint = document.createElement('div')
+  hint.className = 'gram-frame-modal-hint'
+  hint.textContent = 'Leave empty to remove the label.'
+
+  inputGroup.appendChild(inputLabel)
+  inputGroup.appendChild(input)
+  inputGroup.appendChild(hint)
+  body.appendChild(inputGroup)
+
+  const footer = document.createElement('div')
+  footer.className = 'gram-frame-modal-footer'
+  const cancelButton = document.createElement('button')
+  cancelButton.className = 'gram-frame-modal-btn gram-frame-modal-cancel'
+  cancelButton.textContent = 'Cancel'
+  const saveButton = document.createElement('button')
+  saveButton.className = 'gram-frame-modal-btn gram-frame-modal-add gram-frame-modal-save'
+  saveButton.textContent = 'Save'
+  footer.appendChild(cancelButton)
+  footer.appendChild(saveButton)
+
+  modal.appendChild(header)
+  modal.appendChild(body)
+  modal.appendChild(footer)
+  overlay.appendChild(modal)
+  document.body.appendChild(overlay)
+
+  /**
+   * Remove the dialog from the page.
+   */
+  function closeModal() {
+    if (overlay.parentNode) {
+      overlay.parentNode.removeChild(overlay)
+    }
+  }
+
+  /**
+   * Commit the entered text and close.
+   */
+  function save() {
+    onSave(normalizeMarkerLabel(input.value))
+    closeModal()
+  }
+
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      save()
+    } else if (e.key === 'Escape') {
+      closeModal()
+    }
+  })
+  cancelButton.addEventListener('click', closeModal)
+  saveButton.addEventListener('click', save)
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) {
+      closeModal()
+    }
+  })
+
+  // Focus and select so editing an existing label can start by typing over it.
+  input.focus()
+  input.select()
+
+  return overlay
+}

--- a/src/core/storage.js
+++ b/src/core/storage.js
@@ -31,6 +31,8 @@
 
 /// <reference path="../types.js" />
 
+import { normalizeMarkerLabel } from '../utils/markerLabel.js'
+
 /** @type {number} */
 const SCHEMA_VERSION = 1
 
@@ -284,6 +286,14 @@ export function sanitizeStoredAnnotations(data) {
         isFiniteNumber(m.time) && isFiniteNumber(m.freq)
       if (!valid) dropped++
       return valid
+    }).map((/** @type {any} */ m) => {
+      // A hand-edited or corrupt record can carry a label of any type or
+      // length. Normalising here — rather than discarding the whole marker —
+      // keeps a usable position while bounding what reaches the gram; an
+      // unusable label simply leaves the marker unlabelled (feature 231).
+      const label = normalizeMarkerLabel(m.label)
+      const { label: _rawLabel, ...rest } = m
+      return label ? { ...rest, label } : rest
     })
   } else if (data && data.analysis && data.analysis.markers != null) {
     dropped++ // markers present but not an array
@@ -407,16 +417,24 @@ export function saveAnnotations(state, instanceIndex, context) {
       // and restore without the identity check (BH-6, BH-23).
       gram: buildGramFingerprint(state),
       analysis: {
-        markers: (state.analysis && state.analysis.markers || []).map(m => ({
-          id: m.id,
-          color: m.color,
-          time: m.time,
-          freq: m.freq,
-          // `symbol` is an ADDITIVE field (feature 161). It MUST NOT trigger a
-          // SCHEMA_VERSION bump: legacy records simply lack it and default to
-          // 'cross' (no drawn symbol) on restore.
-          symbol: m.symbol || 'cross'
-        }))
+        markers: (state.analysis && state.analysis.markers || []).map(m => {
+          const label = normalizeMarkerLabel(m.label)
+          return {
+            id: m.id,
+            color: m.color,
+            time: m.time,
+            freq: m.freq,
+            // `symbol` is an ADDITIVE field (feature 161). It MUST NOT trigger a
+            // SCHEMA_VERSION bump: legacy records simply lack it and default to
+            // 'cross' (no drawn symbol) on restore.
+            symbol: m.symbol || 'cross',
+            // `label` is likewise ADDITIVE (feature 231) and MUST NOT bump
+            // SCHEMA_VERSION. Written only when the marker carries one, so an
+            // unlabelled marker's record is identical to what it was before
+            // labels existed, and restores as unlabelled.
+            ...(label ? { label } : {})
+          }
+        })
       },
       harmonics: {
         harmonicSets: (state.harmonics && state.harmonics.harmonicSets || []).map(hs => ({

--- a/src/gramframe.css
+++ b/src/gramframe.css
@@ -703,12 +703,18 @@ table.gram-frame-table {
 .gram-frame-table th {
   background: #222;
   color: #00ff00;
-  padding: 4px;
+  /*
+   * Horizontal padding and letter-spacing are deliberately tight (feature 231):
+   * the markers table gained a fifth column in the same 160px, and at 4px/0.5px
+   * the headers no longer fitted their own text. The narrow columns are the
+   * constraint here, not the label copy.
+   */
+  padding: 4px 1px;
   text-align: center;
   border-top: 1px solid #444;
   font-weight: bold;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: 0;
   /* Header row stays pinned while the body scrolls beneath it. The z-index sits
      above the positioned body rows, including a selected row's cells (11). */
   position: sticky;
@@ -717,7 +723,8 @@ table.gram-frame-table {
 }
 
 .gram-frame-table td {
-  padding: 4px;
+  /* Matches the header's tight horizontal padding — see the note above. */
+  padding: 4px 1px;
   text-align: center;
   background: #1a1a1a;
 }
@@ -804,6 +811,45 @@ table.gram-frame-table {
   color: #fff !important;
 }
 
+/*
+ * Marker row actions (feature 231): the Label button sits above the Delete
+ * button in the cell that used to hold Delete alone, so the column keeps its
+ * narrow width and the two controls never share a click target.
+ */
+.gram-frame-marker-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.gram-frame-marker-label-btn {
+  background: none;
+  border: none;
+  color: #8ab4d8;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 2px;
+  line-height: 0;
+  transition: background-color 0.2s;
+}
+
+.gram-frame-marker-label-btn:hover {
+  background-color: #8ab4d8;
+  color: #1a1a1a;
+}
+
+/*
+ * The Label column shows an abbreviated label (see formatMarkerLabelForTable),
+ * so it should never wrap or stretch the row; anything unexpectedly long is
+ * clipped rather than allowed to reflow the table.
+ */
+.gram-frame-marker-label-cell {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Marker rendering styles */
 .gram-frame-marker-line {
   opacity: 0.8;
@@ -811,6 +857,19 @@ table.gram-frame-table {
 
 .gram-frame-marker-point {
   opacity: 0.9;
+}
+
+/*
+ * A marker's on-gram label. Legibility comes from the halo (black glyphs in a
+ * white outline) set as presentation attributes by applyTextHalo() — see
+ * src/utils/svg.js. Never a click target: the marker underneath is.
+ */
+.gram-frame-marker-label {
+  font-family: Arial, sans-serif;
+  font-size: 12px;
+  font-weight: bold;
+  pointer-events: none;
+  user-select: none;
 }
 
 /* Military-style mode selection header */
@@ -1363,6 +1422,12 @@ table.gram-frame-table {
   margin-top: 4px;
 }
 
+/* Supporting note under a modal input (e.g. how to clear a marker label) */
+.gram-frame-modal-hint {
+  color: #999;
+  font-size: 11px;
+}
+
 .gram-frame-modal-footer {
   padding: 15px 20px;
   border-top: 1px solid #444;
@@ -1469,13 +1534,28 @@ table.gram-frame-table {
   border: none;
 }
 
+/*
+ * Markers column. Widened from a flat 160px when the Label column was added
+ * (feature 231), and made elastic rather than fixed: it takes up to 235px where
+ * the host has the width, and gives back down to 185px where it does not.
+ *
+ * The floor matters. Shrinking the LEFT column past ~620px rewraps the guidance
+ * text onto extra lines and grows the whole control row ~50px taller, pushing
+ * the gram down the page — so the markers column must not simply be pinned
+ * wide. 185px is the floor because it is what the five columns need, and it is
+ * funded by the harmonics column next door (200 → 175px) rather than by the
+ * left column, leaving the narrow-window layout exactly as it was.
+ *
+ * These values — and the matching inline styles in
+ * MainUI.createUnifiedLayout — must agree.
+ */
 .gram-frame-middle-column {
   display: flex;
   flex-direction: column;
-  flex: 0 0 160px;
-  width: 160px;
-  min-width: 160px;
-  max-width: 160px;
+  flex: 0 3 235px;
+  width: auto;
+  min-width: 185px;
+  max-width: 235px;
   padding: 5px;
   background: linear-gradient(180deg, #2a2a2a 0%, #1a1a1a 50%, #0a0a0a 100%);
   border: 2px solid #333;
@@ -1483,12 +1563,13 @@ table.gram-frame-table {
   box-shadow: inset 0 1px 3px rgba(0,0,0,0.3);
 }
 
+/* Harmonics column. 200 → 175px; see the markers-column note above. */
 .gram-frame-right-column {
   display: flex;
   flex-direction: column;
-  flex: 0 0 200px;
-  min-width: 200px;
-  width: 200px;
+  flex: 0 0 175px;
+  min-width: 175px;
+  width: 175px;
   padding: 5px;
   background: linear-gradient(180deg, #2a2a2a 0%, #1a1a1a 50%, #0a0a0a 100%);
   border: 2px solid #333;

--- a/src/modes/analysis/AnalysisMode.js
+++ b/src/modes/analysis/AnalysisMode.js
@@ -1,6 +1,10 @@
 import { BaseMode } from '../BaseMode.js'
 import { dispatch, markAnnotationsChanged } from '../../core/state.js'
 import { createDiffingTable } from '../../components/DiffingTable.js'
+import { showMarkerLabelModal } from '../../components/MarkerLabelModal.js'
+
+/** SVG namespace, for the label button's icon */
+const SVG_NS = 'http://www.w3.org/2000/svg'
 
 /**
  * Build a marker row's delete button. Markup unchanged from before the table
@@ -19,11 +23,71 @@ function createMarkerDeleteButton() {
   button.style.fontWeight = 'bold'
   return button
 }
+
+/**
+ * Build a marker row's label button (feature 231) — a luggage-tag icon that
+ * opens the label dialog for that marker.
+ *
+ * Drawn as inline SVG rather than a glyph or an image so it stays crisp, needs
+ * no font or network asset, and inherits the button's colour.
+ *
+ * @param {AnalysisMarker} marker - The row's marker, for the button's title
+ * @returns {HTMLButtonElement} The label button
+ */
+function createMarkerLabelButton(marker) {
+  const button = document.createElement('button')
+  button.className = 'gram-frame-marker-label-btn'
+  button.title = marker.label ? `Edit label: ${marker.label}` : 'Add label'
+  button.setAttribute('aria-label', button.title)
+
+  const icon = document.createElementNS(SVG_NS, 'svg')
+  icon.setAttribute('viewBox', '0 0 16 16')
+  icon.setAttribute('width', '13')
+  icon.setAttribute('height', '13')
+  icon.setAttribute('aria-hidden', 'true')
+
+  // Tag outline: a pentagon-ish body pointing down-left.
+  const body = document.createElementNS(SVG_NS, 'path')
+  body.setAttribute('d', 'M8.5 1H15v6.5L7.5 15 1 8.5 8.5 1z')
+  body.setAttribute('fill', 'none')
+  body.setAttribute('stroke', 'currentColor')
+  body.setAttribute('stroke-width', '1.6')
+  body.setAttribute('stroke-linejoin', 'round')
+
+  // The tag's eyelet.
+  const hole = document.createElementNS(SVG_NS, 'circle')
+  hole.setAttribute('cx', '11.5')
+  hole.setAttribute('cy', '4.5')
+  hole.setAttribute('r', '1.2')
+  hole.setAttribute('fill', 'currentColor')
+
+  icon.appendChild(body)
+  icon.appendChild(hole)
+  button.appendChild(icon)
+  return button
+}
+
+/**
+ * Build the actions cell for a marker row: the label button stacked above the
+ * delete button, in the cell that used to hold the delete button alone
+ * (feature 231).
+ * @param {AnalysisMarker} marker - The row's marker
+ * @returns {HTMLDivElement} Container holding both controls
+ */
+function createMarkerActions(marker) {
+  const actions = document.createElement('div')
+  actions.className = 'gram-frame-marker-actions'
+  actions.appendChild(createMarkerLabelButton(marker))
+  actions.appendChild(createMarkerDeleteButton())
+  return actions
+}
 import { formatTime } from '../../utils/timeFormatter.js'
 import { dataToSVG } from '../../utils/coordinates.js'
 import { BaseDragHandler } from '../shared/BaseDragHandler.js'
 import { getUniformTolerance, isWithinToleranceRadius } from '../../utils/tolerance.js'
 import { createSymbolMark, createColorIndicator, resolveSymbolScale } from '../../rendering/symbols.js'
+import { createMarkerLabel } from '../../rendering/labels.js'
+import { formatMarkerLabelForTable, normalizeMarkerLabel } from '../../utils/markerLabel.js'
 
 /**
  * Analysis mode implementation
@@ -59,6 +123,29 @@ export class AnalysisMode extends BaseMode {
   }
 
   /**
+   * This mode's markers, as the live array state holds.
+   *
+   * The single reach-in for marker data (spec 167, Story 5): every read below
+   * goes through here rather than walking `instance.state.analysis.markers`
+   * again. Yields an empty array before the slice exists, which reads the same
+   * as "no markers" for every caller.
+   * @returns {AnalysisMarker[]} The markers
+   */
+  get markers() {
+    const analysis = this.instance.state.analysis
+    return (analysis && analysis.markers) || []
+  }
+
+  /**
+   * Find one of this mode's markers by id.
+   * @param {string|null|undefined} markerId - Marker id to look for
+   * @returns {AnalysisMarker|undefined} The marker, or `undefined` if it has gone
+   */
+  findMarker(markerId) {
+    return this.markers.find(m => m.id === markerId)
+  }
+
+  /**
    * Start dragging a marker
    * @param {DragTarget} target - Drag target with id and type
    * @param {DataCoordinates} position - Start position
@@ -69,7 +156,7 @@ export class AnalysisMode extends BaseMode {
     void position
 
     // Auto-select the marker being dragged
-    const markers = this.instance.state.analysis.markers
+    const markers = this.markers
     const marker = markers.find(m => m.id === target.id)
     if (marker) {
       const index = markers.findIndex(m => m.id === target.id)
@@ -85,7 +172,7 @@ export class AnalysisMode extends BaseMode {
    * @param {DataCoordinates} _startPos - Start position (unused)
    */
   onMarkerDragUpdate(target, currentPos, _startPos) {
-    const marker = this.instance.state.analysis.markers.find(m => m.id === target.id)
+    const marker = this.findMarker(target.id)
     if (marker) {
       // Update marker position
       marker.freq = currentPos.freq
@@ -258,15 +345,14 @@ export class AnalysisMode extends BaseMode {
    * @returns {boolean} True if at least one marker exists
    */
   hasPersistentFeatures() {
-    const analysis = this.instance.state.analysis
-    return !!(analysis && analysis.markers && analysis.markers.length > 0)
+    return this.markers.length > 0
   }
 
   /**
    * Render persistent features for analysis mode
    */
   renderPersistentFeatures() {
-    if (!this.instance.ui.cursorGroup || !this.instance.state.analysis?.markers) {
+    if (!this.instance.ui.cursorGroup) {
       return
     }
     
@@ -275,7 +361,7 @@ export class AnalysisMode extends BaseMode {
     existingMarkers.forEach(marker => marker.remove())
     
     // Render all markers
-    this.instance.state.analysis.markers.forEach(marker => {
+    this.markers.forEach(marker => {
       this.renderMarker(marker)
     })
   }
@@ -352,6 +438,13 @@ export class AnalysisMode extends BaseMode {
       markerGroup.appendChild(circle)
     }
 
+    // The marker's label, if it carries one (feature 231). Appended last so the
+    // haloed text sits above the crosshair or symbol it annotates.
+    const label = createMarkerLabel(marker, currentX, currentY, symbolSize)
+    if (label) {
+      markerGroup.appendChild(label)
+    }
+
     this.instance.ui.cursorGroup.appendChild(markerGroup)
   }
 
@@ -408,9 +501,10 @@ export class AnalysisMode extends BaseMode {
     // makes this the *markers* table (spec 166, FR-009).
     this.markersTable = createDiffingTable(markersContainer, {
       columns: [
-        { label: '', width: '15%', cellClassName: 'gram-frame-marker-color' },
-        { label: 'Time (mm:ss)', width: '35%' },
-        { label: 'Freq (Hz)', width: '35%' },
+        { label: '', width: '13%', cellClassName: 'gram-frame-marker-color' },
+        { label: 'Label', width: '22%', cellClassName: 'gram-frame-marker-label-cell' },
+        { label: 'Time (mm:ss)', width: '25%' },
+        { label: 'Freq (Hz)', width: '25%' },
         { label: '', width: '15%' }
       ],
       rowAttribute: 'data-marker-id',
@@ -419,11 +513,20 @@ export class AnalysisMode extends BaseMode {
         // Colour/symbol cell — a shaped symbol shows the colour-coded symbol;
         // the cross (symbol-less) style shows a filled colour rectangle (FR-010).
         createColorIndicator(marker.symbol, marker.color, 20),
+        // Label cell — abbreviated so the column keeps its width; the full text
+        // stays on the gram and in the edit dialog (feature 231).
+        formatMarkerLabelForTable(marker.label),
         formatTime(marker.time),
         marker.freq.toFixed(2),
-        createMarkerDeleteButton()
+        createMarkerActions(marker)
       ],
       deleteSelector: '.gram-frame-marker-delete-btn',
+      actions: [
+        {
+          selector: '.gram-frame-marker-label-btn',
+          handler: (markerId) => this.editMarkerLabel(markerId)
+        }
+      ],
       onSelect: (markerId, _marker, index) => {
         // Toggle selection
         const selection = this.instance.state.selection
@@ -463,10 +566,8 @@ export class AnalysisMode extends BaseMode {
    */
   updateMarkersTable() {
     if (!this.markersTable) return
-    const analysis = this.instance.state.analysis
-    if (!analysis || !analysis.markers) return
 
-    this.markersTable.update(this.instance.state.analysis.markers)
+    this.markersTable.update(this.markers)
   }
 
   /**
@@ -523,9 +624,8 @@ export class AnalysisMode extends BaseMode {
    * @param {string} markerId - ID of marker to remove
    */
   removeMarker(markerId) {
-    if (!this.instance.state.analysis || !this.instance.state.analysis.markers) return
-    
-    const index = this.instance.state.analysis.markers.findIndex(m => m.id === markerId)
+    const markers = this.markers
+    const index = markers.findIndex(m => m.id === markerId)
     if (index !== -1) {
       // Clear selection if removing the selected marker
       if (this.instance.state.selection.selectedType === 'marker' && 
@@ -533,7 +633,7 @@ export class AnalysisMode extends BaseMode {
         this.instance.interaction.clearSelection()
       }
       
-      this.instance.state.analysis.markers.splice(index, 1)
+      markers.splice(index, 1)
       markAnnotationsChanged(this.instance)
 
       // Update markers table
@@ -550,18 +650,58 @@ export class AnalysisMode extends BaseMode {
   }
 
   /**
+   * Open the label dialog for a marker (feature 231).
+   *
+   * Does nothing when the marker has gone — a row's controls are rebuilt from
+   * state, but a click can still race a deletion.
+   * @param {string} markerId - ID of the marker to label
+   */
+  editMarkerLabel(markerId) {
+    const marker = this.findMarker(markerId)
+    if (!marker) return
+
+    showMarkerLabelModal(marker.label, (label) => this.setMarkerLabel(markerId, label))
+  }
+
+  /**
+   * Set (or clear) a marker's label and re-render everything that shows it.
+   *
+   * Passing an empty or whitespace-only label removes it, so "clear the field
+   * and save" is how a label is deleted.
+   * @param {string} markerId - ID of the marker to update
+   * @param {string|undefined} label - New label, or `undefined`/empty to remove it
+   */
+  setMarkerLabel(markerId, label) {
+    const marker = this.findMarker(markerId)
+    if (!marker) return
+
+    const normalized = normalizeMarkerLabel(label)
+    if (normalized) {
+      marker.label = normalized
+    } else {
+      // Absent rather than empty: "no label" has exactly one representation.
+      delete marker.label
+    }
+    markAnnotationsChanged(this.instance)
+
+    this.updateMarkersTable()
+    if (this.instance.featureRenderer) {
+      this.instance.featureRenderer.renderAllPersistentFeatures()
+    }
+    dispatch(this.instance)
+  }
+
+  /**
    * Find marker at given position (with tolerance)
    * Returns a drag target object compatible with BaseDragHandler
    * @param {DataCoordinates} position - Position to check
    * @returns {DragTarget|null} Drag target if found, null otherwise
    */
   findMarkerAtPosition(position) {
-    if (!this.instance.state.analysis || !this.instance.state.analysis.markers) return null
-    
     const tolerance = getUniformTolerance(this.getViewport(), this.instance.ui.spectrogramImage)
     
     // Check each marker to see if position hits the crosshair lines
-    const marker = this.instance.state.analysis.markers.find(marker => {
+    const marker = this.markers.find(marker => {
       // Check if we're close to the marker center (original behavior)
       if (isWithinToleranceRadius(
         position, 

--- a/src/rendering/labels.js
+++ b/src/rendering/labels.js
@@ -1,0 +1,60 @@
+/**
+ * In-gram text labels for analysis markers (feature 231).
+ *
+ * A marker's label is drawn as black glyphs inside a white halo — the same
+ * treatment the harmonic numbers use — so it reads over both dark and light
+ * spectrogram pixels. Marker identity is still carried by the crosshair or
+ * symbol colour; the label text deliberately is not colour-coded.
+ *
+ * Where the label goes is `markerLabelPlacement`'s decision (see
+ * `utils/markerLabel.js`, where it stays pure and unit-testable). This module
+ * only builds the element.
+ */
+
+/// <reference path="../types.js" />
+
+import { applyTextHalo } from '../utils/svg.js'
+import { markerLabelPlacement } from '../utils/markerLabel.js'
+
+/** SVG namespace for element creation */
+const SVG_NS = 'http://www.w3.org/2000/svg'
+
+/**
+ * Label font size in px. Matches the harmonic-number labels so all in-gram text
+ * reads as one family.
+ * @type {number}
+ */
+const MARKER_LABEL_FONT_SIZE = 12
+
+/**
+ * Build a marker's label as a detached SVG text element.
+ *
+ * Returns `null` when the marker carries no label, so the caller draws nothing
+ * — labels are absent by default. Callers MUST handle a `null` return.
+ *
+ * @param {AnalysisMarker} marker - The marker being rendered
+ * @param {number} cx - Marker centre X in SVG overlay space
+ * @param {number} cy - Marker centre Y in SVG overlay space
+ * @param {number} symbolSize - Drawn diameter of the marker's symbol in px
+ * @returns {SVGTextElement|null} Detached label element, or `null` when unlabelled
+ */
+export function createMarkerLabel(marker, cx, cy, symbolSize) {
+  if (!marker.label) {
+    return null
+  }
+
+  const { x, y, textAnchor } = markerLabelPlacement(marker.symbol, cx, cy, symbolSize)
+
+  const text = /** @type {SVGTextElement} */ (document.createElementNS(SVG_NS, 'text'))
+  text.setAttribute('class', 'gram-frame-marker-label')
+  text.setAttribute('data-marker-id', marker.id)
+  text.setAttribute('x', String(x))
+  text.setAttribute('y', String(y))
+  text.setAttribute('text-anchor', textAnchor)
+  text.setAttribute('font-size', String(MARKER_LABEL_FONT_SIZE))
+  text.setAttribute('font-weight', 'bold')
+  text.setAttribute('font-family', 'Arial, sans-serif')
+  applyTextHalo(text)
+  text.textContent = marker.label
+  return text
+}

--- a/src/rendering/symbols.js
+++ b/src/rendering/symbols.js
@@ -75,6 +75,24 @@ export function resolveSymbolScale(source) {
 }
 
 /**
+ * Resolve any candidate symbol value to a known symbol id.
+ *
+ * Unknown, null and undefined values all resolve to {@link DEFAULT_SYMBOL} —
+ * the same fallback the mark factory applies — so callers that need to branch
+ * on the *effective* symbol (label placement, for one) agree with what is drawn.
+ *
+ * Pure: no DOM, no state.
+ *
+ * @param {SymbolType|string|null|undefined} symbolType - Candidate symbol id
+ * @returns {SymbolType} A member of {@link SYMBOL_CATALOG}
+ */
+export function resolveSymbolType(symbolType) {
+  return SYMBOL_CATALOG.includes(/** @type {SymbolType} */ (symbolType))
+    ? /** @type {SymbolType} */ (symbolType)
+    : DEFAULT_SYMBOL
+}
+
+/**
  * Build a `points` attribute string from an array of [x, y] pairs.
  * @param {Array<[number, number]>} pts - Point pairs
  * @returns {string} Space-separated "x,y" points
@@ -126,9 +144,7 @@ export function createSymbolMark(symbolType, cx, cy, size, color) {
 
   // Resolve unknown/absent values to the default so both the drawn shape and the
   // recorded `data-symbol` reflect the actual fallback.
-  const resolved = SYMBOL_CATALOG.includes(/** @type {SymbolType} */ (symbolType))
-    ? /** @type {SymbolType} */ (symbolType)
-    : DEFAULT_SYMBOL
+  const resolved = resolveSymbolType(symbolType)
 
   // The symbol-less `cross` style draws nothing.
   if (resolved === 'cross') {

--- a/src/types.js
+++ b/src/types.js
@@ -72,6 +72,7 @@
  * @property {number} freq - Frequency coordinate
  * @property {SymbolType} [symbol] - Marker symbol; `cross` (default) draws a crosshair, a shaped symbol draws that mark
  * @property {boolean} [largeSymbols] - EXPERIMENT (temporary): draw this marker's symbol at the large size; not persisted
+ * @property {string} [label] - Optional free-text label drawn beside the marker; ABSENT (never empty) when unlabelled
  */
 
 /**
@@ -129,6 +130,13 @@
  */
 
 /**
+ * A per-row control whose clicks act rather than select the row.
+ * @typedef {Object} TableRowAction
+ * @property {string} selector - Selector matching the control inside a row
+ * @property {function(string, any, number): void} handler - Called with the row key, row data and index
+ */
+
+/**
  * What a consumer supplies to `createDiffingTable`: the meaning, not the
  * mechanism (spec 166, FR-009).
  * @typedef {Object} TableSpec
@@ -138,6 +146,7 @@
  * @property {string} [rowClassName] - Class applied to every row
  * @property {function(any, number): Array<string|Node>} cells - Cell content per column
  * @property {string} [deleteSelector] - Selector for the delete control; clicks on it delete rather than select
+ * @property {Array<TableRowAction>} [actions] - Further per-row controls that act instead of selecting
  * @property {function(string, any, number): void} [onSelect] - Row click
  * @property {function(string, any, number): void} [onDelete] - Delete-control click
  * @property {function(string): boolean} [isSelected] - Whether the row with this key is selected
@@ -342,6 +351,7 @@
  * @property {number} time - Time position in seconds
  * @property {number} freq - Frequency position in Hz
  * @property {SymbolType} [symbol] - Persisted symbol; ABSENT in legacy records (default `cross` on restore)
+ * @property {string} [label] - Persisted label; ABSENT in legacy records and in unlabelled markers
  */
 
 /**

--- a/src/utils/markerLabel.js
+++ b/src/utils/markerLabel.js
@@ -1,0 +1,130 @@
+/**
+ * Marker label rules (feature 231).
+ *
+ * A marker label is free text an analyst attaches to a cross-cursor. It is
+ * optional — a marker carries no label unless one is deliberately entered — so
+ * "no label" is represented as `undefined`, never as an empty string, and
+ * nothing downstream has to distinguish the two.
+ *
+ * Everything here is pure — no DOM, no state — which is what lets the unit lane
+ * cover it. The dialog, the overlay renderer, the markers table and the storage
+ * layer all go through these functions, so the same text is accepted, stored
+ * and abbreviated everywhere, and the label lands in the same place every time.
+ * Building the actual SVG element is `rendering/labels.js`'s job.
+ */
+
+/// <reference path="../types.js" />
+
+import { resolveSymbolType } from '../rendering/symbols.js'
+
+/**
+ * Longest label accepted. Long enough for a ship name or a contact
+ * designation, short enough that the on-gram text cannot swamp the image.
+ * Enforced both by the dialog's `maxlength` and by `normalizeMarkerLabel`, so a
+ * label arriving from storage or the API is bounded too.
+ * @type {number}
+ */
+export const MAX_MARKER_LABEL_LENGTH = 32
+
+/**
+ * Longest label shown in full in the markers table's Label column. Above this,
+ * the cell is abbreviated (see {@link formatMarkerLabelForTable}) so the column
+ * keeps a predictable width.
+ * @type {number}
+ */
+const TABLE_LABEL_FULL_LENGTH = 5
+
+/**
+ * How many leading characters survive abbreviation, before the `..` marker.
+ * @type {number}
+ */
+const TABLE_LABEL_HEAD_LENGTH = 3
+
+/**
+ * Normalise a label from any source (dialog input, restored record, API caller)
+ * to either a usable string or `undefined`.
+ *
+ * Whitespace-only input, empty input, and non-string values all mean "no
+ * label". Surrounding whitespace is trimmed and the result is capped at
+ * {@link MAX_MARKER_LABEL_LENGTH}.
+ *
+ * @param {unknown} raw - Candidate label of unknown integrity
+ * @returns {string|undefined} The cleaned label, or `undefined` for "no label"
+ */
+export function normalizeMarkerLabel(raw) {
+  if (typeof raw !== 'string') {
+    return undefined
+  }
+  const trimmed = raw.trim()
+  if (trimmed === '') {
+    return undefined
+  }
+  return trimmed.slice(0, MAX_MARKER_LABEL_LENGTH)
+}
+
+/**
+ * Abbreviate a label for the markers table's Label column.
+ *
+ * Labels of {@link TABLE_LABEL_FULL_LENGTH} characters or fewer are shown
+ * whole; longer ones show their first {@link TABLE_LABEL_HEAD_LENGTH}
+ * characters followed by `..`. A marker with no label yields an empty cell.
+ *
+ * The full text is not lost — it stays on the gram and in the edit dialog.
+ *
+ * @param {string|null|undefined} label - The marker's label
+ * @returns {string} Text for the table cell (empty when there is no label)
+ */
+export function formatMarkerLabelForTable(label) {
+  const normalized = normalizeMarkerLabel(label)
+  if (!normalized) {
+    return ''
+  }
+  if (normalized.length <= TABLE_LABEL_FULL_LENGTH) {
+    return normalized
+  }
+  return `${normalized.slice(0, TABLE_LABEL_HEAD_LENGTH)}..`
+}
+
+/**
+ * Gap in px between a crosshair's arms and the label sitting in the upper-right
+ * quadrant. Clears the crosshair's 3px centre dot without pushing the text away
+ * from the point it annotates.
+ * @type {number}
+ */
+const QUADRANT_GAP = 5
+
+/**
+ * Gap in px between the top of a shaped symbol and the label's baseline above
+ * it. Scales with nothing: the symbol's own size is already in the sum.
+ * @type {number}
+ */
+const ABOVE_SYMBOL_GAP = 4
+
+/**
+ * Where a marker's label goes, given what the marker draws.
+ *
+ * The legacy system's rule, and the reason placement depends on the symbol:
+ *   - a `cross` (symbol-less) marker draws a crosshair, whose arms leave four
+ *     empty quadrants — the label goes in the upper-right one, clear of both
+ *     arms;
+ *   - a marker with a shaped symbol has no free quadrant, so the label is
+ *     centred above the symbol.
+ *
+ * Pure: takes numbers, returns numbers.
+ *
+ * @param {SymbolType|string|null|undefined} symbol - The marker's symbol style
+ * @param {number} cx - Marker centre X in SVG overlay space
+ * @param {number} cy - Marker centre Y in SVG overlay space
+ * @param {number} symbolSize - Drawn diameter of the marker's symbol in px (ignored for `cross`)
+ * @returns {{x: number, y: number, textAnchor: 'start'|'middle'}} Text position and anchor
+ */
+export function markerLabelPlacement(symbol, cx, cy, symbolSize) {
+  if (resolveSymbolType(symbol) === 'cross') {
+    // Upper-right quadrant of the crosshair: right of the vertical arm, above
+    // the horizontal one. `start` anchoring grows the text away from the arms.
+    return { x: cx + QUADRANT_GAP, y: cy - QUADRANT_GAP, textAnchor: 'start' }
+  }
+
+  // Centred above the symbol, baseline clear of its top edge.
+  return { x: cx, y: cy - symbolSize / 2 - ABOVE_SYMBOL_GAP, textAnchor: 'middle' }
+}

--- a/tests/helpers/gram-frame-page.js
+++ b/tests/helpers/gram-frame-page.js
@@ -819,6 +819,80 @@ class GramFramePage {
   }
 
   /**
+   * Open the label dialog from a marker row's Label button (feature 231).
+   * @param {string} markerId - Marker whose row's button to click
+   * @returns {Promise<import('@playwright/test').Locator>} Locator for the dialog's text input
+   */
+  async openMarkerLabelDialog(markerId) {
+    await this.page
+      .locator(`tr[data-marker-id="${markerId}"] .gram-frame-marker-label-btn`)
+      .click()
+    const input = this.page.locator('.gram-frame-marker-label-input')
+    await expect(input).toBeVisible()
+    return input
+  }
+
+  /**
+   * Set a marker's label through the dialog, and wait for state to carry it.
+   *
+   * Passing an empty string clears the label, which is how the dialog removes
+   * one. The wait is on broadcast state rather than a delay, so the caller can
+   * read the overlay and the table immediately afterwards.
+   *
+   * @param {string} markerId - Marker to label
+   * @param {string} label - New label text ('' to remove the label)
+   * @returns {Promise<void>}
+   */
+  async setMarkerLabel(markerId, label) {
+    const input = await this.openMarkerLabelDialog(markerId)
+    await input.fill(label)
+    await this.page.locator('.gram-frame-modal-save').click()
+
+    const expected = label.trim() === '' ? undefined : label.trim()
+    await this.waitForState(
+      (state) => state.analysis.markers.find((m) => m.id === markerId)?.label === expected,
+      { message: `marker ${markerId} to carry label ${JSON.stringify(expected)}` }
+    )
+  }
+
+  /**
+   * Read a marker's on-gram label element, if it has one.
+   * @param {string} markerId - Marker to inspect
+   * @returns {Promise<{text: string, x: number, y: number, textAnchor: string, fill: string, stroke: string, paintOrder: string}|null>}
+   */
+  async getMarkerLabelOverlay(markerId) {
+    return this.page.evaluate((id) => {
+      const el = document.querySelector(
+        `.gram-frame-analysis-marker[data-marker-id="${id}"] .gram-frame-marker-label`
+      )
+      if (!el) return null
+      return {
+        text: el.textContent || '',
+        x: parseFloat(el.getAttribute('x') || '0'),
+        y: parseFloat(el.getAttribute('y') || '0'),
+        textAnchor: el.getAttribute('text-anchor') || '',
+        fill: el.getAttribute('fill') || '',
+        stroke: el.getAttribute('stroke') || '',
+        paintOrder: el.getAttribute('paint-order') || ''
+      }
+    }, markerId)
+  }
+
+  /**
+   * Read the Label column's text for a marker row.
+   * @param {string} markerId - Marker to inspect
+   * @returns {Promise<string>} Cell text (empty when the marker has no label)
+   */
+  async getMarkerLabelCell(markerId) {
+    return this.page.evaluate((id) => {
+      const cell = document.querySelector(
+        `tr[data-marker-id="${id}"] .gram-frame-marker-label-cell`
+      )
+      return cell ? (cell.textContent || '') : ''
+    }, markerId)
+  }
+
+  /**
    * Select a symbol from the control-panel symbol drop-down.
    * @param {string} symbolId - One of 'circle','square','diamond','triangle','triangle-down','star'
    * @returns {Promise<void>}

--- a/tests/marker-labels.spec.js
+++ b/tests/marker-labels.spec.js
@@ -1,0 +1,381 @@
+import { test, expect } from './helpers/fixtures.js'
+import { GramFramePage } from './helpers/gram-frame-page.js'
+
+/**
+ * @fileoverview E2E tests for feature 231 — cross-cursor labels.
+ *
+ * Covers the whole loop an analyst walks: place a marker, open the label
+ * dialog from its row's Label button, enter text, see it on the gram and
+ * abbreviated in the table's Label column, edit it, and clear it. Also covers
+ * the two placement rules (upper-right quadrant for a cross, centred above a
+ * shaped symbol), the halo styling, and persistence across a reload.
+ *
+ * The pure rules behind abbreviation and placement are unit-tested in
+ * tests/unit/marker-label.test.js; what is asserted here is the wiring.
+ *
+ * Waiting note: the dialog's Save handler runs synchronously, so the helper
+ * that drives it waits on the label appearing in broadcast state rather than on
+ * a fixed delay.
+ */
+
+const LABEL_BUTTON = '.gram-frame-marker-label-btn'
+const LABEL_INPUT = '.gram-frame-marker-label-input'
+const MODAL_OVERLAY = '.gram-frame-marker-label-modal'
+
+/**
+ * Place a marker in Cross Cursor mode and return its id.
+ * @param {import('./helpers/gram-frame-page.js').GramFramePage} gramFramePage
+ * @param {number} x - Click X within the SVG
+ * @param {number} y - Click Y within the SVG
+ * @returns {Promise<string>} The new marker's id
+ */
+async function placeMarker(gramFramePage, x, y) {
+  const before = (await gramFramePage.getState()).analysis.markers.length
+  await gramFramePage.clickSpectrogram(x, y)
+  await gramFramePage.waitForMarkerCount(before + 1)
+  const state = await gramFramePage.getState()
+  return state.analysis.markers[before].id
+}
+
+test.describe('Marker labels', () => {
+  test.beforeEach(async ({ gramFramePage }) => {
+    await gramFramePage.clickMode('Cross Cursor')
+  })
+
+  // ──────────────────────────────────────────────────────────
+  // Labels are opt-in
+  // ──────────────────────────────────────────────────────────
+
+  test('a new marker carries no label, draws none, and shows an empty Label cell', async ({ gramFramePage }) => {
+    const markerId = await placeMarker(gramFramePage, 220, 160)
+
+    const state = await gramFramePage.getState()
+    expect(state.analysis.markers[0]).not.toHaveProperty('label')
+
+    expect(await gramFramePage.getMarkerLabelOverlay(markerId)).toBeNull()
+    expect(await gramFramePage.getMarkerLabelCell(markerId)).toBe('')
+  })
+
+  test('the markers table has a Label column', async ({ gramFramePage }) => {
+    const headers = await gramFramePage.page
+      .locator('.gram-frame-markers-panel th, .gram-frame-table th')
+      .allTextContents()
+    expect(headers).toContain('Label')
+  })
+
+  test('every marker row offers a Label button above its Delete button', async ({ gramFramePage }) => {
+    const markerId = await placeMarker(gramFramePage, 220, 160)
+
+    const row = gramFramePage.page.locator(`tr[data-marker-id="${markerId}"]`)
+    await expect(row.locator(LABEL_BUTTON)).toBeVisible()
+    await expect(row.locator('.gram-frame-marker-delete-btn')).toBeVisible()
+
+    // "Above" is a layout claim, so measure it rather than assume the markup.
+    const labelBox = await row.locator(LABEL_BUTTON).boundingBox()
+    const deleteBox = await row.locator('.gram-frame-marker-delete-btn').boundingBox()
+    expect(labelBox).not.toBeNull()
+    expect(deleteBox).not.toBeNull()
+    expect(labelBox.y + labelBox.height).toBeLessThanOrEqual(deleteBox.y + 1)
+  })
+
+  // ──────────────────────────────────────────────────────────
+  // Adding, editing and clearing a label through the dialog
+  // ──────────────────────────────────────────────────────────
+
+  test('the Label button opens a dialog that adds a label to the marker', async ({ gramFramePage }) => {
+    const markerId = await placeMarker(gramFramePage, 220, 160)
+
+    await gramFramePage.setMarkerLabel(markerId, 'Contact A')
+
+    // Dialog closed itself
+    await expect(gramFramePage.page.locator(MODAL_OVERLAY)).toHaveCount(0)
+
+    const overlay = await gramFramePage.getMarkerLabelOverlay(markerId)
+    expect(overlay).not.toBeNull()
+    expect(overlay.text).toBe('Contact A')
+  })
+
+  test('the dialog opens pre-filled when the marker already has a label', async ({ gramFramePage }) => {
+    const markerId = await placeMarker(gramFramePage, 220, 160)
+    await gramFramePage.setMarkerLabel(markerId, 'Contact A')
+
+    const input = await gramFramePage.openMarkerLabelDialog(markerId)
+    await expect(input).toHaveValue('Contact A')
+  })
+
+  test('editing a label replaces it on the gram and in the table', async ({ gramFramePage }) => {
+    const markerId = await placeMarker(gramFramePage, 220, 160)
+    await gramFramePage.setMarkerLabel(markerId, 'Contact A')
+    await gramFramePage.setMarkerLabel(markerId, 'Sub 7')
+
+    const overlay = await gramFramePage.getMarkerLabelOverlay(markerId)
+    expect(overlay.text).toBe('Sub 7')
+    expect(await gramFramePage.getMarkerLabelCell(markerId)).toBe('Sub 7')
+  })
+
+  test('clearing the field and saving removes the label entirely', async ({ gramFramePage }) => {
+    const markerId = await placeMarker(gramFramePage, 220, 160)
+    await gramFramePage.setMarkerLabel(markerId, 'Contact A')
+
+    await gramFramePage.setMarkerLabel(markerId, '')
+
+    const state = await gramFramePage.getState()
+    // Absent, not empty: "no label" has one representation.
+    expect(state.analysis.markers[0]).not.toHaveProperty('label')
+    expect(await gramFramePage.getMarkerLabelOverlay(markerId)).toBeNull()
+    expect(await gramFramePage.getMarkerLabelCell(markerId)).toBe('')
+  })
+
+  test('a whitespace-only entry is treated as no label', async ({ gramFramePage }) => {
+    const markerId = await placeMarker(gramFramePage, 220, 160)
+
+    const input = await gramFramePage.openMarkerLabelDialog(markerId)
+    await input.fill('    ')
+    await gramFramePage.page.locator('.gram-frame-modal-save').click()
+
+    await expect(gramFramePage.page.locator(MODAL_OVERLAY)).toHaveCount(0)
+    const state = await gramFramePage.getState()
+    expect(state.analysis.markers[0]).not.toHaveProperty('label')
+  })
+
+  test('Cancel and Escape both leave the existing label untouched', async ({ gramFramePage }) => {
+    const markerId = await placeMarker(gramFramePage, 220, 160)
+    await gramFramePage.setMarkerLabel(markerId, 'Contact A')
+
+    // Cancel
+    let input = await gramFramePage.openMarkerLabelDialog(markerId)
+    await input.fill('Discarded')
+    await gramFramePage.page.locator('.gram-frame-modal-cancel').click()
+    await expect(gramFramePage.page.locator(MODAL_OVERLAY)).toHaveCount(0)
+    expect((await gramFramePage.getState()).analysis.markers[0].label).toBe('Contact A')
+
+    // Escape
+    input = await gramFramePage.openMarkerLabelDialog(markerId)
+    await input.fill('Also discarded')
+    await input.press('Escape')
+    await expect(gramFramePage.page.locator(MODAL_OVERLAY)).toHaveCount(0)
+    expect((await gramFramePage.getState()).analysis.markers[0].label).toBe('Contact A')
+  })
+
+  test('Enter in the input saves the label', async ({ gramFramePage }) => {
+    const markerId = await placeMarker(gramFramePage, 220, 160)
+
+    const input = await gramFramePage.openMarkerLabelDialog(markerId)
+    await input.fill('Contact B')
+    await input.press('Enter')
+
+    await gramFramePage.waitForState(
+      (state) => state.analysis.markers[0].label === 'Contact B',
+      { message: 'the label entered with Enter' }
+    )
+    await expect(gramFramePage.page.locator(MODAL_OVERLAY)).toHaveCount(0)
+  })
+
+  test('clicking the Label button does not toggle the row selection', async ({ gramFramePage }) => {
+    const markerId = await placeMarker(gramFramePage, 220, 160)
+    // A newly placed marker is auto-selected.
+    await gramFramePage.waitForSelectedRow('markers', markerId)
+
+    await gramFramePage.page
+      .locator(`tr[data-marker-id="${markerId}"] ${LABEL_BUTTON}`)
+      .click()
+    await expect(gramFramePage.page.locator(LABEL_INPUT)).toBeVisible()
+
+    const state = await gramFramePage.getState()
+    expect(state.selection.selectedId).toBe(markerId)
+    await gramFramePage.page.locator('.gram-frame-modal-cancel').click()
+  })
+
+  test('the label applies to the marker whose row was clicked', async ({ gramFramePage }) => {
+    const first = await placeMarker(gramFramePage, 180, 120)
+    const second = await placeMarker(gramFramePage, 300, 200)
+
+    await gramFramePage.setMarkerLabel(second, 'Second')
+
+    expect(await gramFramePage.getMarkerLabelCell(second)).toBe('Sec..')
+    expect(await gramFramePage.getMarkerLabelCell(first)).toBe('')
+    expect(await gramFramePage.getMarkerLabelOverlay(first)).toBeNull()
+  })
+
+  // ──────────────────────────────────────────────────────────
+  // Table abbreviation
+  // ──────────────────────────────────────────────────────────
+
+  test('the Label column shows short labels whole and abbreviates longer ones', async ({ gramFramePage }) => {
+    const markerId = await placeMarker(gramFramePage, 220, 160)
+
+    await gramFramePage.setMarkerLabel(markerId, 'ABCDE') // exactly five
+    expect(await gramFramePage.getMarkerLabelCell(markerId)).toBe('ABCDE')
+
+    await gramFramePage.setMarkerLabel(markerId, 'ABCDEF') // six
+    expect(await gramFramePage.getMarkerLabelCell(markerId)).toBe('ABC..')
+
+    // The gram still carries the full text — abbreviation is the table's alone.
+    const overlay = await gramFramePage.getMarkerLabelOverlay(markerId)
+    expect(overlay.text).toBe('ABCDEF')
+  })
+
+  // ──────────────────────────────────────────────────────────
+  // On-gram placement and styling
+  // ──────────────────────────────────────────────────────────
+
+  test('a cross marker draws its label in the upper-right quadrant', async ({ gramFramePage }) => {
+    const markerId = await placeMarker(gramFramePage, 220, 160)
+    await gramFramePage.setMarkerLabel(markerId, 'UR')
+
+    const state = await gramFramePage.getState()
+    expect(state.analysis.markers[0].symbol).toBe('cross')
+
+    const overlay = await gramFramePage.getMarkerLabelOverlay(markerId)
+    const centre = await gramFramePage.page.evaluate((id) => {
+      const dot = document.querySelector(
+        `.gram-frame-analysis-marker[data-marker-id="${id}"] circle`
+      )
+      return dot
+        ? { x: parseFloat(dot.getAttribute('cx')), y: parseFloat(dot.getAttribute('cy')) }
+        : null
+    }, markerId)
+
+    expect(centre).not.toBeNull()
+    expect(overlay.x).toBeGreaterThan(centre.x)
+    expect(overlay.y).toBeLessThan(centre.y)
+    expect(overlay.textAnchor).toBe('start')
+  })
+
+  test('a shaped marker draws its label centred above the symbol', async ({ gramFramePage }) => {
+    await gramFramePage.selectSymbol('square')
+    const markerId = await placeMarker(gramFramePage, 220, 160)
+    await gramFramePage.setMarkerLabel(markerId, 'Above')
+
+    const symbol = await gramFramePage.page.evaluate((id) => {
+      const el = document.querySelector(`.gram-frame-marker-symbol[data-marker-id="${id}"]`)
+      if (!el) return null
+      const box = /** @type {SVGGraphicsElement} */ (el).getBBox()
+      return { centreX: box.x + box.width / 2, top: box.y }
+    }, markerId)
+
+    const overlay = await gramFramePage.getMarkerLabelOverlay(markerId)
+    expect(symbol).not.toBeNull()
+    expect(overlay.textAnchor).toBe('middle')
+    expect(overlay.x).toBeCloseTo(symbol.centreX, 1)
+    expect(overlay.y).toBeLessThan(symbol.top)
+  })
+
+  test('the label is drawn black inside a white halo, painted behind the glyphs', async ({ gramFramePage }) => {
+    const markerId = await placeMarker(gramFramePage, 220, 160)
+    await gramFramePage.setMarkerLabel(markerId, 'Halo')
+
+    const overlay = await gramFramePage.getMarkerLabelOverlay(markerId)
+    expect(overlay.fill).toBe('#000')
+    expect(overlay.stroke).toBe('#fff')
+    expect(overlay.paintOrder).toBe('stroke fill')
+  })
+
+  test('the label moves with the marker when it is dragged', async ({ gramFramePage }) => {
+    const markerId = await placeMarker(gramFramePage, 220, 160)
+    await gramFramePage.setMarkerLabel(markerId, 'Moves')
+
+    const before = await gramFramePage.getMarkerLabelOverlay(markerId)
+
+    const svgBox = await gramFramePage.svg.boundingBox()
+    await gramFramePage.page.mouse.move(svgBox.x + 220, svgBox.y + 160)
+    await gramFramePage.page.mouse.down()
+    await gramFramePage.page.mouse.move(svgBox.x + 300, svgBox.y + 200, { steps: 5 })
+    await gramFramePage.page.mouse.up()
+
+    await expect
+      .poll(async () => (await gramFramePage.getMarkerLabelOverlay(markerId)).x)
+      .toBeGreaterThan(before.x)
+
+    const after = await gramFramePage.getMarkerLabelOverlay(markerId)
+    expect(after.text).toBe('Moves')
+    expect(after.y).toBeGreaterThan(before.y) // moved down the gram
+  })
+
+  test('a label survives a switch to another mode and back', async ({ gramFramePage }) => {
+    const markerId = await placeMarker(gramFramePage, 220, 160)
+    await gramFramePage.setMarkerLabel(markerId, 'Persist')
+
+    await gramFramePage.clickMode('Harmonics')
+    // Markers stay visible across modes, and so do their labels.
+    expect((await gramFramePage.getMarkerLabelOverlay(markerId)).text).toBe('Persist')
+
+    await gramFramePage.clickMode('Cross Cursor')
+    expect((await gramFramePage.getMarkerLabelOverlay(markerId)).text).toBe('Persist')
+    expect(await gramFramePage.getMarkerLabelCell(markerId)).toBe('Per..')
+  })
+
+  test('the dialog caps how long a label can be', async ({ gramFramePage }) => {
+    const markerId = await placeMarker(gramFramePage, 220, 160)
+
+    const input = await gramFramePage.openMarkerLabelDialog(markerId)
+    await expect(input).toHaveAttribute('maxlength', '32')
+    await input.fill('x'.repeat(60))
+    await expect(input).toHaveValue('x'.repeat(32))
+    await gramFramePage.page.locator('.gram-frame-modal-cancel').click()
+  })
+})
+
+// ──────────────────────────────────────────────────────────────
+// Persistence — a label is saved with its marker
+// ──────────────────────────────────────────────────────────────
+
+test.describe('Marker labels persist', () => {
+  test('a label survives a page reload on a trainer page', async ({ page }) => {
+    await page.goto('/tests/fixtures/trainer-page.html')
+    await page.evaluate(() => localStorage.clear())
+
+    const gfp = new GramFramePage(page)
+    await page.goto('/tests/fixtures/trainer-page.html')
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+
+    await page.locator('.gram-frame-mode-btn:text("Cross Cursor")').click()
+    await gfp.svg.click({ position: { x: 200, y: 150 } })
+
+    const markerRow = page.locator('tr[data-marker-id]').first()
+    await expect(markerRow).toBeVisible()
+    const markerId = await markerRow.getAttribute('data-marker-id')
+
+    await markerRow.locator(LABEL_BUTTON).click()
+    await page.locator(LABEL_INPUT).fill('Saved label')
+    await page.locator('.gram-frame-modal-save').click()
+    await expect(page.locator(`tr[data-marker-id="${markerId}"] .gram-frame-marker-label-cell`))
+      .toHaveText('Sav..')
+
+    await page.reload()
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+
+    const restored = await page.evaluate(() => {
+      // @ts-ignore test-only global
+      const instances = window.GramFrame.__test__getInstances()
+      return instances[0].state.analysis.markers.map((/** @type {any} */ m) => m.label)
+    })
+    expect(restored).toEqual(['Saved label'])
+
+    await expect(page.locator('.gram-frame-marker-label')).toHaveText('Saved label')
+  })
+
+  test('a marker with no label persists without one', async ({ page }) => {
+    await page.goto('/tests/fixtures/trainer-page.html')
+    await page.evaluate(() => localStorage.clear())
+    await page.goto('/tests/fixtures/trainer-page.html')
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+
+    const gfp = new GramFramePage(page)
+    await page.locator('.gram-frame-mode-btn:text("Cross Cursor")').click()
+    await gfp.svg.click({ position: { x: 200, y: 150 } })
+    await expect(page.locator('tr[data-marker-id]')).toHaveCount(1)
+
+    await page.reload()
+    await page.locator('.gram-frame-container').waitFor({ timeout: 10000 })
+
+    const hasLabel = await page.evaluate(() => {
+      // @ts-ignore test-only global
+      const instances = window.GramFrame.__test__getInstances()
+      return instances[0].state.analysis.markers.map(
+        (/** @type {any} */ m) => Object.prototype.hasOwnProperty.call(m, 'label')
+      )
+    })
+    expect(hasLabel).toEqual([false])
+  })
+})

--- a/tests/unit/marker-label.test.js
+++ b/tests/unit/marker-label.test.js
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest'
+import {
+  MAX_MARKER_LABEL_LENGTH,
+  normalizeMarkerLabel,
+  formatMarkerLabelForTable,
+  markerLabelPlacement
+} from '../../src/utils/markerLabel.js'
+
+/**
+ * @fileoverview Unit coverage for feature 231 — cross-cursor labels.
+ *
+ * Two pure rules live behind the feature and are tested here without a browser:
+ * what counts as a label ({@link normalizeMarkerLabel}, and its table
+ * abbreviation), and where a label goes relative to the marker it annotates
+ * ({@link markerLabelPlacement}). The DOM wiring — the dialog, the table
+ * column, the overlay element — is covered in tests/marker-labels.spec.js.
+ */
+
+describe('normalizeMarkerLabel', () => {
+  it('keeps ordinary text as-is', () => {
+    expect(normalizeMarkerLabel('Contact A')).toBe('Contact A')
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeMarkerLabel('  Contact A  ')).toBe('Contact A')
+  })
+
+  it('treats empty and whitespace-only input as "no label"', () => {
+    expect(normalizeMarkerLabel('')).toBeUndefined()
+    expect(normalizeMarkerLabel('   ')).toBeUndefined()
+    expect(normalizeMarkerLabel('\t\n ')).toBeUndefined()
+  })
+
+  it('treats absent and non-string values as "no label"', () => {
+    expect(normalizeMarkerLabel(undefined)).toBeUndefined()
+    expect(normalizeMarkerLabel(null)).toBeUndefined()
+    expect(normalizeMarkerLabel(42)).toBeUndefined()
+    expect(normalizeMarkerLabel({ label: 'x' })).toBeUndefined()
+    expect(normalizeMarkerLabel(['x'])).toBeUndefined()
+  })
+
+  it('caps an over-long label rather than rejecting it', () => {
+    const long = 'x'.repeat(MAX_MARKER_LABEL_LENGTH + 20)
+    const result = normalizeMarkerLabel(long)
+    expect(result).toHaveLength(MAX_MARKER_LABEL_LENGTH)
+    expect(result).toBe('x'.repeat(MAX_MARKER_LABEL_LENGTH))
+  })
+
+  it('trims before capping, so padded input is not truncated by its padding', () => {
+    const padded = `   ${'a'.repeat(MAX_MARKER_LABEL_LENGTH)}   `
+    expect(normalizeMarkerLabel(padded)).toBe('a'.repeat(MAX_MARKER_LABEL_LENGTH))
+  })
+})
+
+describe('formatMarkerLabelForTable', () => {
+  it('yields an empty cell for a marker with no label', () => {
+    expect(formatMarkerLabelForTable(undefined)).toBe('')
+    expect(formatMarkerLabelForTable(null)).toBe('')
+    expect(formatMarkerLabelForTable('   ')).toBe('')
+  })
+
+  it('shows a label of five characters or fewer in full', () => {
+    expect(formatMarkerLabelForTable('A')).toBe('A')
+    expect(formatMarkerLabelForTable('AB12')).toBe('AB12')
+    expect(formatMarkerLabelForTable('ABCDE')).toBe('ABCDE')
+  })
+
+  it('abbreviates a longer label to its first three characters plus ".."', () => {
+    expect(formatMarkerLabelForTable('ABCDEF')).toBe('ABC..')
+    expect(formatMarkerLabelForTable('Contact Alpha')).toBe('Con..')
+  })
+
+  it('abbreviates on the trimmed length, not the raw one', () => {
+    // Five characters once trimmed: shown whole, despite the raw string being longer.
+    expect(formatMarkerLabelForTable('  ABCDE  ')).toBe('ABCDE')
+  })
+})
+
+describe('markerLabelPlacement', () => {
+  const CX = 100
+  const CY = 80
+  const SYMBOL_SIZE = 14
+
+  it('puts a cross marker\'s label in the upper-right quadrant', () => {
+    const placement = markerLabelPlacement('cross', CX, CY, SYMBOL_SIZE)
+
+    expect(placement.x).toBeGreaterThan(CX) // right of the vertical arm
+    expect(placement.y).toBeLessThan(CY)    // above the horizontal arm
+    // `start` anchoring grows the text rightwards, away from the crosshair.
+    expect(placement.textAnchor).toBe('start')
+  })
+
+  it('centres a shaped marker\'s label above the symbol', () => {
+    const placement = markerLabelPlacement('circle', CX, CY, SYMBOL_SIZE)
+
+    expect(placement.x).toBe(CX)
+    expect(placement.y).toBeLessThan(CY - SYMBOL_SIZE / 2) // clear of the symbol's top edge
+    expect(placement.textAnchor).toBe('middle')
+  })
+
+  it('places every shaped symbol the same way', () => {
+    const shaped = ['circle', 'square', 'diamond', 'triangle', 'triangle-down', 'star']
+    const expected = markerLabelPlacement('circle', CX, CY, SYMBOL_SIZE)
+
+    for (const symbol of shaped) {
+      expect(markerLabelPlacement(symbol, CX, CY, SYMBOL_SIZE)).toEqual(expected)
+    }
+  })
+
+  it('lifts the label further for a larger symbol', () => {
+    const small = markerLabelPlacement('square', CX, CY, 14)
+    const large = markerLabelPlacement('square', CX, CY, 28)
+
+    expect(large.y).toBeLessThan(small.y)
+    expect(small.y - large.y).toBe((28 - 14) / 2)
+  })
+
+  it('treats an unknown, null or absent symbol as a cross', () => {
+    const cross = markerLabelPlacement('cross', CX, CY, SYMBOL_SIZE)
+
+    expect(markerLabelPlacement('pentagon', CX, CY, SYMBOL_SIZE)).toEqual(cross)
+    expect(markerLabelPlacement(null, CX, CY, SYMBOL_SIZE)).toEqual(cross)
+    expect(markerLabelPlacement(undefined, CX, CY, SYMBOL_SIZE)).toEqual(cross)
+  })
+
+  it('ignores the symbol size for a cross, whose geometry is fixed', () => {
+    expect(markerLabelPlacement('cross', CX, CY, 14))
+      .toEqual(markerLabelPlacement('cross', CX, CY, 40))
+  })
+
+  it('follows the marker when it moves', () => {
+    const moved = markerLabelPlacement('cross', CX + 25, CY - 10, SYMBOL_SIZE)
+    const base = markerLabelPlacement('cross', CX, CY, SYMBOL_SIZE)
+
+    expect(moved.x - base.x).toBe(25)
+    expect(moved.y - base.y).toBe(-10)
+  })
+})

--- a/tests/unit/storage-validation.test.js
+++ b/tests/unit/storage-validation.test.js
@@ -107,6 +107,42 @@ describe('sanitizeStoredAnnotations (BH-1, BH-16)', () => {
       expect(annotations.doppler.fPlus).toBeNull()
     }
   })
+
+  // Marker labels (feature 231): an ADDITIVE field, so a record without one is
+  // valid and a bad one costs the label, never the marker.
+  it('restores a marker label unchanged', () => {
+    const rec = validRecord()
+    rec.analysis.markers[0].label = 'Contact A'
+    const { annotations, dropped } = sanitizeStoredAnnotations(rec)
+    expect(dropped).toBe(0)
+    expect(annotations.analysis.markers[0].label).toBe('Contact A')
+  })
+
+  it('leaves a legacy label-less marker unlabelled without dropping it', () => {
+    const { annotations, dropped } = sanitizeStoredAnnotations(validRecord())
+    expect(dropped).toBe(0)
+    expect(annotations.analysis.markers).toHaveLength(1)
+    expect(annotations.analysis.markers[0]).not.toHaveProperty('label')
+  })
+
+  it('strips an unusable label but keeps the marker', () => {
+    for (const label of [42, {}, [], null, '', '   ']) {
+      const rec = validRecord()
+      // @ts-ignore deliberate corruption
+      rec.analysis.markers[0].label = label
+      const { annotations, dropped } = sanitizeStoredAnnotations(rec)
+      expect(annotations.analysis.markers).toHaveLength(1)
+      expect(annotations.analysis.markers[0]).not.toHaveProperty('label')
+      expect(dropped).toBe(0) // the marker itself is still usable
+    }
+  })
+
+  it('trims and caps an over-long stored label', () => {
+    const rec = validRecord()
+    rec.analysis.markers[0].label = `  ${'x'.repeat(200)}  `
+    const { annotations } = sanitizeStoredAnnotations(rec)
+    expect(annotations.analysis.markers[0].label).toHaveLength(32)
+  })
 })
 
 describe('buildGramFingerprint (BH-6, BH-23)', () => {


### PR DESCRIPTION
Closes #231.

## What this adds

Analysts can attach free text to a marker. The label is drawn on the gram in **black inside a white halo** — the same treatment the harmonic numbers use — so it reads over both dark and light spectrogram pixels. Marker identity is still carried by the crosshair/symbol colour; the label text is deliberately not colour-coded.

Placement follows the legacy rule:

- **cross (symbol-less) marker** — the crosshair's arms leave four empty quadrants, so the label goes in the **upper-right** one, anchored `start`;
- **shaped symbol** — no free quadrant, so the label is **centred above** the symbol, clear of its top edge.

Labels are opt-in: a marker carries none until one is deliberately entered.

## UI

- Each markers-table row gains a **tag-icon Label button above its delete ×**, in the cell that previously held delete alone. Clicking it opens a dialog to add, edit or (by clearing the field and saving) remove the label. Enter saves; Escape, Cancel and a backdrop click discard.
- A new **Label column** shows labels of five characters or fewer whole, and abbreviates longer ones to their first three characters plus `..`. The full text stays on the gram and in the dialog.
- Text is trimmed and capped at 32 characters; "no label" has exactly one representation (`undefined`, never `''`).

## Persistence

`label` is an **additive** persisted field. It does **not** bump `SCHEMA_VERSION`, is written only when the marker actually carries one (so an unlabelled marker's record is unchanged from before), and a corrupt or hand-edited label costs the label rather than the whole marker.

## Layout

Five columns did not fit the markers column's old flat 160px. Widening it by taking width from the **left** column turned out to rewrap the mode guidance onto extra lines and grow the whole control row ~50px taller, pushing the gram down — so instead:

- the markers column is now **elastic**: `flex: 0 3 235px`, floor 185px, ceiling 235px. It takes the extra width where the host has it and gives it back where it does not, and the biased shrink factor means it, not the guidance column, absorbs the squeeze first;
- its 185px floor is funded by the harmonics column (200 → 175px), whose four columns still fit comfortably;
- table header padding and letter-spacing tighten so every header fits its own text.

Measured across 1024–1920px: at ≤1440 the left column, control-row height and gram position are **byte-identical to before**; at ≥1600 the row is actually shorter than it was, and the Label column gets 43–50px.

## Incidental cleanups

- `DiffingTable`'s delete special-case generalises into a list of row actions, so a row can carry more than one control that acts instead of selecting. The harmonics panel is unchanged.
- `AnalysisMode`'s marker reads route through a single `markers` accessor, dropping the `instance.state` reach-in ratchet from 180 → 170 (baseline lowered in this PR).
- `resolveSymbolType` extracted from `createSymbolMark`, so label placement branches on the same effective symbol that gets drawn.

## Testing

- **Unit** (`tests/unit/marker-label.test.js`, 24 cases): normalisation (trim, empty, non-string, cap), table abbreviation (boundaries at 5/6 chars), and placement geometry (quadrant vs centred-above, scaling with symbol size, unknown/null symbols, following the marker).
- **Unit** (`storage-validation.test.js`): label round-trips; a legacy label-less record is not dropped; unusable labels are stripped without dropping the marker; over-long stored labels are capped.
- **E2E** (`tests/marker-labels.spec.js`, 21 cases): the full add/edit/clear loop through the dialog; Enter/Escape/Cancel; the Label button not stealing row selection; targeting the right marker; abbreviation in the cell vs full text on the gram; both placement rules measured against the drawn crosshair/symbol; halo attributes; the label following a dragged marker; surviving a mode switch; the `maxlength` cap; and persistence across a reload on a trainer page (labelled and unlabelled).

`yarn typecheck`, `yarn lint` (0 errors), `yarn hygiene`, `yarn test:unit` (113) and `yarn test` (288) all pass.

## Open question for review

The Label column sits between the colour/symbol swatch and Time — treating it as part of "which marker is this" rather than as a measurement. It will often be empty. Happy to move it right of Freq instead if you'd rather sparse columns live at the edge; it's a one-line change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8hGS43PMpJtEuYtuMjSX5)_