### PR TITLE
Replace the hand cursors on feature drags with hollow corner brackets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,9 @@ Every path below exists; keep this list in step with `src/` when adding modules.
   - `harmonicSampling.js` - Pin sampling for dense harmonic sets
   - `markerLabel.js` - Marker label normalisation and table abbreviation
   - `tolerance.js` - Shared hit-test tolerances
+  - `cursors.js` - The pointer's cursors. Feature drags use hollow corner
+    brackets, never the opaque `grab`/`grabbing` hands, so the marker and the
+    gram under the hotspot stay visible; panning keeps the hand
   - `svg.js` - SVG text halo styling
   - `secureHTML.js` - Guidance-panel rendering without innerHTML
   - `timeFormatter.js` - Time formatting utilities
@@ -215,6 +218,11 @@ There is no visual/screenshot regression testing — see
 - Zoom resizes the image element (viewBox stays fixed) — see ADR-015
 - Drag state has one owner (`BaseDragHandler`) and one read-only projection
   (`state.drag`); modes never write drag fields into state
+- The engine hands `cursorFor(kind, phase)` a phase name (`idle`/`hover`/`drag`),
+  not a ready-made CSS value, so a mode decides what its own drag kind looks
+  like — pan keeps the hand, every feature drag takes the hollow brackets from
+  `utils/cursors.js`. Hover goes through `applyCursor` like every other
+  transition, so a mode's opinion covers it too
 - `core/state.js` imports no mode. `ModeFactory.getModeInitialStates()` composes
   the initial-state slices and `createInitialState(modeStates)` receives them;
   mode slices are additive and can never overwrite a core key (ADR-014)

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -10,6 +10,7 @@ import { dispatch } from './state.js'
 import { updateUniversalCursorReadouts } from '../components/MainUI.js'
 import { setFocusedInstance } from './FocusManager.js'
 import { zoomAtImagePoint, pixelDeltaToNormalizedPan, panByNormalized } from './viewport.js'
+import { IDLE_CURSOR, PAN_DRAG_CURSOR } from '../utils/cursors.js'
 
 /**
  * Per-notch multiplicative zoom factor for Ctrl+wheel zoom (smoother than the
@@ -121,9 +122,10 @@ function wheelPanHandler(instance) {
           instance.ui.svg.style.cursor = style
         }
       },
-      // Restore whatever cursor the mode had, rather than forcing a crosshair
-      cursorFor: (_kind, fallback) => (
-        fallback === 'grabbing' ? 'grabbing' : (previousCursor || 'crosshair')
+      // The middle-button pan is a pan, so it keeps the hand. On release it
+      // restores whatever cursor the mode had, rather than forcing a crosshair.
+      cursorFor: (_kind, phase) => (
+        phase === 'drag' ? PAN_DRAG_CURSOR : (previousCursor || IDLE_CURSOR)
       )
     }, null)
   }

--- a/src/modes/BaseMode.js
+++ b/src/modes/BaseMode.js
@@ -216,7 +216,7 @@ export class BaseMode {
 
   /**
    * Update cursor style for drag operations
-   * @param {string} style - Cursor style ('crosshair', 'grab', 'grabbing')
+   * @param {string} style - A CSS cursor value, as resolved by `utils/cursors.js`
    */
   updateCursorStyle(style) {
     if (this.instance.ui.spectrogramImage) {

--- a/src/modes/analysis/AnalysisMode.js
+++ b/src/modes/analysis/AnalysisMode.js
@@ -209,7 +209,7 @@ export class AnalysisMode extends BaseMode {
 
   /**
    * Update cursor style for drag operations
-   * @param {string} style - Cursor style ('crosshair', 'grab', 'grabbing')
+   * @param {string} style - A CSS cursor value, as resolved by `utils/cursors.js`
    */
   updateCursorStyle(style) {
     if (this.instance.ui.svg) {

--- a/src/modes/doppler/DopplerMode.js
+++ b/src/modes/doppler/DopplerMode.js
@@ -7,6 +7,7 @@ import { calculateDopplerSpeed, calculateMidpoint, MS_TO_KNOTS } from '../../uti
 import { dataToSVG } from '../../utils/coordinates.js'
 import { BaseDragHandler } from '../shared/BaseDragHandler.js'
 import { getUniformTolerance, isWithinDataTolerance, findClosestTarget } from '../../utils/tolerance.js'
+import { IDLE_CURSOR } from '../../utils/cursors.js'
 
 // Doppler marker types
 /** @type {Record<DopplerDraggedMarker, DopplerDraggedMarker>} */
@@ -506,8 +507,8 @@ export class DopplerMode extends BaseMode {
     this.updateSpeedLED() // Reset the speed LED display
     this.renderDopplerFeatures()
     // With no markers left there is nothing to grab: drop any lingering
-    // hover 'grab' cursor from the marker that was just deleted.
-    this.updateCursorStyle('crosshair')
+    // hover cursor from the marker that was just deleted.
+    this.updateCursorStyle(IDLE_CURSOR)
   }
 
   /**

--- a/src/modes/harmonics/HarmonicsMode.js
+++ b/src/modes/harmonics/HarmonicsMode.js
@@ -128,7 +128,7 @@ export class HarmonicsMode extends BaseMode {
 
   /**
    * Update cursor style for drag operations
-   * @param {string} style - Cursor style ('crosshair', 'grab', 'grabbing')
+   * @param {string} style - A CSS cursor value, as resolved by `utils/cursors.js`
    */
   updateCursorStyle(style) {
     if (this.instance.ui.svg) {

--- a/src/modes/pan/PanMode.js
+++ b/src/modes/pan/PanMode.js
@@ -2,6 +2,7 @@ import { BaseMode } from '../BaseMode.js'
 import { BaseDragHandler } from '../shared/BaseDragHandler.js'
 import { getVersion } from '../../utils/version.js'
 import { pixelDeltaToNormalizedPan, panByNormalized, zoomIn, zoomOut } from '../../core/viewport.js'
+import { IDLE_CURSOR, PAN_IDLE_CURSOR, PAN_DRAG_CURSOR } from '../../utils/cursors.js'
 import { WHEEL_NAV_GUIDANCE } from '../../utils/wheelGuidance.js'
 
 /**
@@ -27,10 +28,11 @@ export class PanMode extends BaseMode {
       onDragEnd: () => this.onPanEnd(),
       onDragCancel: () => this.onPanEnd(),
       updateCursor: (style) => this.applyCursor(style),
-      // A pan shows the grabbing hand, not the crosshair the other kinds use
-      cursorFor: (kind, fallback) => {
-        if (kind !== 'pan') return fallback
-        return fallback === 'grabbing' ? 'grabbing' : this.idleCursor()
+      // A pan keeps the hand, rather than the hollow brackets feature drags use:
+      // there is no target under the pointer for it to obscure.
+      cursorFor: (kind, phase) => {
+        if (kind !== 'pan') return null
+        return phase === 'drag' ? PAN_DRAG_CURSOR : this.idleCursor()
       }
     }, 'pan')
   }
@@ -52,7 +54,7 @@ export class PanMode extends BaseMode {
    * @returns {string} Cursor style
    */
   idleCursor() {
-    return this.instance.state.zoom.level > 1.0 ? 'grab' : 'crosshair'
+    return this.instance.state.zoom.level > 1.0 ? PAN_IDLE_CURSOR : IDLE_CURSOR
   }
 
   /**
@@ -109,7 +111,7 @@ export class PanMode extends BaseMode {
   activate() {
     // Set cursor to grab if zoomed
     if (this.instance.state.zoom.level > 1.0) {
-      this.applyCursor('grab')
+      this.applyCursor(PAN_IDLE_CURSOR)
     }
 
     // Reset any existing drag state
@@ -122,7 +124,7 @@ export class PanMode extends BaseMode {
   deactivate() {
     // Clear drag state, then reset the cursor
     this.dragHandler.reset()
-    this.applyCursor('crosshair')
+    this.applyCursor(IDLE_CURSOR)
   }
 
   /**

--- a/src/modes/shared/BaseDragHandler.js
+++ b/src/modes/shared/BaseDragHandler.js
@@ -20,6 +20,7 @@
 /// <reference path="../../types.js" />
 
 import { dispatch } from '../../core/state.js'
+import { featureCursor } from '../../utils/cursors.js'
 
 /**
  * Which handler currently owns the active drag, per GramFrame instance.
@@ -241,7 +242,7 @@ export class BaseDragHandler {
     activeDragOwners.set(this.instance, this)
     publishDragProjection(this.instance)
 
-    this.applyCursor(this.dragState.kind, 'grabbing')
+    this.applyCursor(this.dragState.kind, 'drag')
 
     this.callbacks.onDragStart(this.currentTarget(position), position, event)
 
@@ -260,7 +261,7 @@ export class BaseDragHandler {
 
     this.callbacks.onDragEnd(target, position, event)
 
-    this.applyCursor(this.dragState.kind, 'crosshair')
+    this.applyCursor(this.dragState.kind, 'idle')
     this.clearDragState()
   }
 
@@ -276,7 +277,7 @@ export class BaseDragHandler {
       this.callbacks.onDragCancel(target)
     }
 
-    this.applyCursor(this.dragState.kind, 'crosshair')
+    this.applyCursor(this.dragState.kind, 'idle')
     this.clearDragState()
   }
 
@@ -298,16 +299,21 @@ export class BaseDragHandler {
   }
 
   /**
-   * Apply the cursor for a drag kind, falling back to the generic style.
-   * @param {DragKind|null} kind - Drag kind
-   * @param {string} fallback - Cursor to use when the mode has no per-kind opinion
+   * Apply the cursor for a drag kind and phase.
+   *
+   * The phase is passed as a name rather than as a ready-made CSS value so a
+   * mode can decide what "dragging" looks like for its own kind — pan keeps the
+   * hand, everything else takes the hollow brackets. Passing the value and
+   * having modes sniff it (`fallback === 'grabbing'`) tied every mode's cursor
+   * to the exact strings the engine happened to use.
+   * @param {DragKind|null} kind - Drag kind, or null when nothing is targeted
+   * @param {CursorPhase} phase - Which phase the pointer is in
    */
-  applyCursor(kind, fallback) {
+  applyCursor(kind, phase) {
     if (!this.callbacks.updateCursor) return
 
-    const style = this.callbacks.cursorFor
-      ? (this.callbacks.cursorFor(kind, fallback) || fallback)
-      : fallback
+    const style = (this.callbacks.cursorFor && this.callbacks.cursorFor(kind, phase))
+      || featureCursor(phase)
     this.callbacks.updateCursor(style)
   }
 
@@ -319,6 +325,10 @@ export class BaseDragHandler {
    * fallback for modes whose resolver is pure — a mode whose resolver mints a
    * feature on mousedown (harmonics `create`, doppler `place`) MUST supply
    * `resolveHoverTarget`, or every hover would create a feature.
+   *
+   * Routed through `applyCursor` like every other transition, so a mode's
+   * `cursorFor` opinion covers hover too. Calling `updateCursor` directly here
+   * made hover the one transition a mode could not influence.
    * @param {DataCoordinates} position - Current mouse position
    */
   updateCursorForHover(position) {
@@ -326,11 +336,8 @@ export class BaseDragHandler {
 
     const resolve = this.callbacks.resolveHoverTarget || this.callbacks.resolveTarget
     const target = resolve(position)
-    const cursorStyle = target ? 'grab' : 'crosshair'
 
-    if (this.callbacks.updateCursor) {
-      this.callbacks.updateCursor(cursorStyle)
-    }
+    this.applyCursor(target ? (target.kind || 'move') : null, target ? 'hover' : 'idle')
   }
 
   /**

--- a/src/types.js
+++ b/src/types.js
@@ -212,7 +212,12 @@
  * @property {function(DragTarget, DataCoordinates|null, MouseEvent=): void} onDragEnd - Called on mouseup, or with a null position when a drag is cancelled
  * @property {function(DragTarget): void} [onDragCancel] - Called on mouseleave / cancel; must restore prior state
  * @property {function(string): void} [updateCursor] - Apply a cursor style
- * @property {function(DragKind|null, string): string|null} [cursorFor] - Optional per-kind cursor
+ * @property {function(DragKind|null, CursorPhase): string|null} [cursorFor] - Optional per-kind cursor for a phase; return null to take the default for that phase
+ */
+
+/**
+ * Which cursor a drag phase calls for. Defined in `utils/cursors.js`.
+ * @typedef {import('./utils/cursors.js').CursorPhase} CursorPhase
  */
 
 /**

--- a/src/utils/cursors.js
+++ b/src/utils/cursors.js
@@ -1,0 +1,146 @@
+/**
+ * The cursors the pointer takes over the gram.
+ *
+ * A spectrogram is read *through* the pointer: the analyst is judging the pixel
+ * under the hotspot, so anything opaque drawn there defeats the interaction it
+ * is meant to support. The platform `grab`/`grabbing` hands are ~32px opaque
+ * bitmaps whose hotspot sits in the middle of the palm, which put the glyph on
+ * exactly the marker, pin or tonal being aimed at.
+ *
+ * Feature drags therefore use a corner-bracket cursor instead: four L-shaped
+ * marks framing empty space, with nothing drawn on the horizontal or vertical
+ * through the hotspot. Those are the two directions a gram carries signal in —
+ * tonals and time lines run straight through the cursor uninterrupted, and the
+ * marker under it stays visible while it is dragged.
+ *
+ * Hovering a grabbable feature opens the brackets; dragging closes them in and
+ * thickens them, so the gesture reads as gripping without a colour change that
+ * could collide with a marker's own colour (markers can be any colour, green
+ * and yellow included).
+ *
+ * Panning keeps the hand: there is no target under the pointer to obscure, and
+ * the hand is the honest metaphor for dragging the whole viewport.
+ */
+
+/**
+ * Which cursor a drag phase calls for.
+ *
+ * - `idle` — over the gram with nothing grabbable under the pointer
+ * - `hover` — over a grabbable feature, no button down
+ * - `drag` — a drag is running
+ * @typedef {'idle'|'hover'|'drag'} CursorPhase
+ */
+
+/**
+ * Corner brackets framing a clear 20px square, in a 32x32 box.
+ *
+ * The arms run along the edges of that square and stop well short of its
+ * mid-points, so the centre row and centre column are unpainted across the
+ * cursor's full width and height.
+ * @type {string[]}
+ */
+const HOVER_BRACKETS = [
+  'M6 12V6h6',
+  'M26 12V6h-6',
+  'M6 20v6h6',
+  'M26 20v6h-6'
+]
+
+/**
+ * The same brackets closed in to a 14px square, for a drag in progress.
+ *
+ * The arms are a pixel shorter than the hover set's, not for looks: the drag
+ * stroke is thicker, and at equal length its round caps reached across the
+ * centre column, clipping any tonal running through the hotspot.
+ * @type {string[]}
+ */
+const DRAG_BRACKETS = [
+  'M9 13V9h4',
+  'M23 13V9h-4',
+  'M9 19v4h4',
+  'M23 19v4h-4'
+]
+
+/**
+ * Build the cursor artwork.
+ *
+ * Each shape is stroked twice — black underneath, white on top — the halo idiom
+ * already used for marker text (`applyTextHalo` in `svg.js`). It is what keeps
+ * the cursor legible over the blue field and over a saturated yellow tonal
+ * alike, neither of which a single-colour cursor survives.
+ * @param {string[]} shapes - Path data for the brackets
+ * @param {number} coreWidth - Stroke width of the white core
+ * @param {number} haloWidth - Stroke width of the black halo beneath it
+ * @returns {string} SVG document source
+ */
+function bracketSvg(shapes, coreWidth, haloWidth) {
+  const body = shapes.map((d) => `<path d="${d}"/>`).join('')
+  return '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">' +
+    '<g fill="none" stroke-linecap="round" stroke-linejoin="round">' +
+    `<g stroke="#000000" stroke-opacity="0.9" stroke-width="${haloWidth}">${body}</g>` +
+    `<g stroke="#ffffff" stroke-width="${coreWidth}">${body}</g>` +
+    '</g></svg>'
+}
+
+/**
+ * Wrap SVG source as a CSS cursor value with the hotspot at the artwork's
+ * centre.
+ *
+ * The trailing keyword is not decoration: Safari has never reliably accepted
+ * SVG data-URI cursors, and a `url()` cursor with no fallback leaves it showing
+ * the default arrow. `move` degrades to a platform four-arrow, which is still
+ * hollow-centred and still a visible change from the resting crosshair.
+ * @param {string} svg - SVG document source, 32x32
+ * @returns {string} A CSS `cursor` value
+ */
+function cursorValue(svg) {
+  return `url("data:image/svg+xml,${encodeURIComponent(svg)}") 16 16, move`
+}
+
+/**
+ * The resting cursor over the gram.
+ * @type {string}
+ */
+export const IDLE_CURSOR = 'crosshair'
+
+/**
+ * Over a grabbable feature: open corner brackets.
+ *
+ * Private, along with its drag counterpart: `featureCursor` is the whole
+ * public surface, so callers pick a cursor by naming the phase they are in
+ * rather than by knowing which constant goes with which moment.
+ * @type {string}
+ */
+const FEATURE_HOVER_CURSOR = cursorValue(bracketSvg(HOVER_BRACKETS, 2, 4.4))
+
+/**
+ * Dragging a feature: the brackets closed in.
+ * @type {string}
+ */
+const FEATURE_DRAG_CURSOR = cursorValue(bracketSvg(DRAG_BRACKETS, 2.6, 5))
+
+/**
+ * Pan mode at rest, when there is something to pan.
+ * @type {string}
+ */
+export const PAN_IDLE_CURSOR = 'grab'
+
+/**
+ * A pan in progress.
+ * @type {string}
+ */
+export const PAN_DRAG_CURSOR = 'grabbing'
+
+/**
+ * The cursor a feature drag takes in a given phase.
+ *
+ * This is the default every mode gets; a mode with its own opinion supplies a
+ * `cursorFor` callback to the drag engine (pan does, to keep the hand).
+ * @param {CursorPhase} phase - Which phase the pointer is in
+ * @returns {string} A CSS `cursor` value
+ */
+export function featureCursor(phase) {
+  if (phase === 'drag') return FEATURE_DRAG_CURSOR
+  if (phase === 'hover') return FEATURE_HOVER_CURSOR
+  return IDLE_CURSOR
+}

--- a/tests/cursor-hover.spec.js
+++ b/tests/cursor-hover.spec.js
@@ -1,0 +1,102 @@
+import { test, expect } from './helpers/fixtures.js'
+
+/**
+ * @fileoverview E2E coverage for the cursor over a grabbable feature.
+ *
+ * The hand cursors (`grab` / `grabbing`) are opaque bitmaps whose hotspot sits
+ * mid-palm, so they landed on exactly the marker and gram pixels being aimed
+ * at. Feature drags now use a hollow corner-bracket cursor instead.
+ *
+ * The artwork's geometry is covered in `tests/unit/cursors.test.js`; what these
+ * tests pin is the wiring — that the value actually reaches the SVG element on
+ * hover, in every mode that owns draggable features, and that panning still
+ * gets the hand.
+ */
+
+/** Matches a data-URI cursor: the brackets rather than a keyword. */
+const BRACKET_CURSOR = /^url\("data:image\/svg\+xml/
+
+/**
+ * Read the cursor style currently applied to the component's SVG.
+ * @param {import('./helpers/gram-frame-page.js').default} gramFramePage - Page object
+ * @returns {Promise<string>} The inline cursor style
+ */
+async function svgCursor(gramFramePage) {
+  return gramFramePage.page.evaluate(() => {
+    const svg = document.querySelector('.gram-frame-svg')
+    return svg instanceof SVGElement ? svg.style.cursor : ''
+  })
+}
+
+test.describe('Cursor over a draggable feature', () => {
+  test('a cross-cursor marker takes the hollow cursor, empty gram stays crosshair', async ({ gramFramePage }) => {
+    await gramFramePage.clickMode('Cross Cursor')
+
+    await gramFramePage.clickSpectrogram(200, 150)
+    await gramFramePage.waitForMarkerCount(1)
+
+    // Off the marker: the resting crosshair, which never obscured anything.
+    await gramFramePage.moveMouseToSpectrogram(340, 240)
+    expect(await svgCursor(gramFramePage)).toBe('crosshair')
+
+    // On the marker: the brackets, and emphatically not a hand.
+    await gramFramePage.moveMouseToSpectrogram(200, 150)
+    const overMarker = await svgCursor(gramFramePage)
+    expect(overMarker).toMatch(BRACKET_CURSOR)
+    expect(overMarker).not.toContain('grab')
+
+    // And it goes back, so the switch is a real affordance rather than a
+    // one-way change the analyst stops noticing.
+    await gramFramePage.moveMouseToSpectrogram(340, 240)
+    expect(await svgCursor(gramFramePage)).toBe('crosshair')
+  })
+
+  test('the cursor stays hollow for the whole drag', async ({ gramFramePage }) => {
+    await gramFramePage.clickMode('Cross Cursor')
+
+    await gramFramePage.clickSpectrogram(200, 150)
+    await gramFramePage.waitForMarkerCount(1)
+
+    await gramFramePage.startDragSVG(200, 150)
+    const duringDrag = await svgCursor(gramFramePage)
+
+    // The old `grabbing` fist covered the placement point at the exact moment
+    // placement accuracy mattered most.
+    expect(duringDrag).toMatch(BRACKET_CURSOR)
+    expect(duringDrag).not.toContain('grabbing')
+
+    await gramFramePage.endDragSVG(260, 190)
+    expect(await svgCursor(gramFramePage)).toBe('crosshair')
+  })
+
+  test('a harmonic set takes the hollow cursor too', async ({ gramFramePage }) => {
+    await gramFramePage.clickMode('Harmonics')
+    await gramFramePage.waitForImageDimensions()
+
+    // Debug config spans 0-100 Hz over 0-60 s; harmonic 5 of a 10 Hz spacing
+    // lands near the horizontal centre.
+    const setId = await gramFramePage.addHarmonicSet(30, 10)
+    const pin = gramFramePage.page.locator(
+      `.gram-frame-harmonic-line[data-harmonic-set-id="${setId}"][data-harmonic-number="5"]`
+    )
+
+    const box = await pin.boundingBox()
+    await gramFramePage.page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+
+    const overSet = await svgCursor(gramFramePage)
+    expect(overSet).toMatch(BRACKET_CURSOR)
+    expect(overSet).not.toContain('grab')
+  })
+
+  test('panning keeps the hand — there is no feature under it to hide', async ({ gramFramePage }) => {
+    // Zoom before switching, because pan mode applies its resting cursor when
+    // it activates: panning is only meaningful once zoomed in.
+    await gramFramePage.setZoom(2.0, 0.5, 0.5)
+    await gramFramePage.clickMode('Pan')
+
+    expect(await svgCursor(gramFramePage)).toBe('grab')
+
+    await gramFramePage.moveMouseToSpectrogram(200, 150)
+    expect(await svgCursor(gramFramePage)).toBe('grab')
+  })
+})

--- a/tests/unit/cursors.test.js
+++ b/tests/unit/cursors.test.js
@@ -1,0 +1,192 @@
+import { describe, test, expect } from 'vitest'
+import {
+  IDLE_CURSOR,
+  PAN_IDLE_CURSOR,
+  PAN_DRAG_CURSOR,
+  featureCursor
+} from '../../src/utils/cursors.js'
+
+/** The module's public surface is the phase accessor, so test through it. */
+const FEATURE_HOVER_CURSOR = featureCursor('hover')
+const FEATURE_DRAG_CURSOR = featureCursor('drag')
+
+/**
+ * @fileoverview Unit coverage for the feature-drag cursors.
+ *
+ * The whole point of these cursors is what they *do not* paint: the centre row
+ * and centre column of the artwork must stay clear, so a tonal or a time line
+ * running under the hotspot is still readable and the marker being dragged is
+ * not hidden by the thing dragging it. That is a geometric property, and the
+ * tests below check it against the artwork rather than trusting the constants,
+ * because it is exactly what a well-meaning tweak to the path data would break.
+ */
+
+/** Where the hotspot sits, and the size of the box the artwork is drawn in. */
+const CENTRE = 16
+const BOX = 32
+
+/**
+ * Pull the SVG source back out of a CSS cursor value.
+ * @param {string} value - A CSS `cursor` value produced by the module
+ * @returns {string} The decoded SVG source
+ */
+function decodeSvg(value) {
+  const match = /^url\("data:image\/svg\+xml,(.*)"\) (\d+) (\d+), (\w+)$/.exec(value)
+  if (!match) throw new Error(`not a data-URI cursor value: ${value}`)
+  return decodeURIComponent(match[1])
+}
+
+/**
+ * Parse the module's path data into absolute line segments.
+ *
+ * Deliberately supports only the commands the artwork uses (M/L/H/V and their
+ * relative forms) and throws on anything else, so a path written with an
+ * unsupported command fails loudly rather than being silently skipped — a
+ * skipped segment would make the clearance assertions below vacuously pass.
+ * @param {string} d - SVG path data
+ * @returns {Array<{x1: number, y1: number, x2: number, y2: number}>} Segments
+ */
+function pathSegments(d) {
+  const tokens = d.match(/[A-Za-z]|-?\d+(?:\.\d+)?/g) || []
+  const segments = []
+  let x = 0
+  let y = 0
+  let i = 0
+
+  while (i < tokens.length) {
+    const command = tokens[i++]
+    const num = () => parseFloat(tokens[i++])
+    const from = { x, y }
+
+    switch (command) {
+      case 'M': x = num(); y = num(); continue
+      case 'm': x += num(); y += num(); continue
+      case 'L': x = num(); y = num(); break
+      case 'l': x += num(); y += num(); break
+      case 'H': x = num(); break
+      case 'h': x += num(); break
+      case 'V': y = num(); break
+      case 'v': y += num(); break
+      default: throw new Error(`unsupported path command "${command}" in "${d}"`)
+    }
+
+    segments.push({ x1: from.x, y1: from.y, x2: x, y2: y })
+  }
+
+  return segments
+}
+
+/**
+ * Every segment in a cursor's artwork, with the stroke width it is painted at.
+ *
+ * Both the halo group and the core group are returned, so the clearance check
+ * covers the widest ink actually laid down — the halo, which is what would
+ * encroach on the centre lines first.
+ * @param {string} svg - SVG source
+ * @returns {Array<{x1: number, y1: number, x2: number, y2: number, width: number}>} Painted segments
+ */
+function paintedSegments(svg) {
+  const groups = svg.match(/<g stroke="[^"]*"[^>]*>.*?<\/g>/g) || []
+  expect(groups.length).toBe(2)
+
+  return groups.flatMap((group) => {
+    const width = parseFloat(/stroke-width="([\d.]+)"/.exec(group)[1])
+    const paths = group.match(/ d="([^"]+)"/g) || []
+    return paths.flatMap((attr) =>
+      pathSegments(attr.slice(4, -1)).map((seg) => ({ ...seg, width }))
+    )
+  })
+}
+
+/**
+ * The band of the artwork a segment lays ink on, along one axis, including the
+ * stroke's half-width. Conservative: round caps paint slightly less than this.
+ * @param {number} a - One endpoint's coordinate
+ * @param {number} b - The other endpoint's coordinate
+ * @param {number} width - Stroke width
+ * @returns {{lo: number, hi: number}} Painted extent along that axis
+ */
+function paintedBand(a, b, width) {
+  const radius = width / 2
+  return { lo: Math.min(a, b) - radius, hi: Math.max(a, b) + radius }
+}
+
+/**
+ * Assert that no ink lands on the centre row or the centre column.
+ * @param {string} value - A CSS cursor value from the module
+ */
+function expectClearCentreLines(value) {
+  const segments = paintedSegments(decodeSvg(value))
+  expect(segments.length).toBeGreaterThan(0)
+
+  for (const seg of segments) {
+    const across = paintedBand(seg.x1, seg.x2, seg.width)
+    const down = paintedBand(seg.y1, seg.y2, seg.width)
+
+    // Crossing the centre column would clip a vertical tonal; crossing the
+    // centre row would clip a time line. Either one, anywhere in the box.
+    expect(across.lo <= CENTRE && across.hi >= CENTRE).toBe(false)
+    expect(down.lo <= CENTRE && down.hi >= CENTRE).toBe(false)
+  }
+}
+
+describe('feature drag cursors', () => {
+  test('the hover cursor leaves both centre lines unpainted', () => {
+    expectClearCentreLines(FEATURE_HOVER_CURSOR)
+  })
+
+  test('the drag cursor leaves both centre lines unpainted', () => {
+    expectClearCentreLines(FEATURE_DRAG_CURSOR)
+  })
+
+  test('both are 32x32 with the hotspot at the centre and a keyword fallback', () => {
+    for (const value of [FEATURE_HOVER_CURSOR, FEATURE_DRAG_CURSOR]) {
+      const [, , hotspotX, hotspotY, fallback] =
+        /^url\("data:image\/svg\+xml,(.*)"\) (\d+) (\d+), (\w+)$/.exec(value)
+
+      expect(Number(hotspotX)).toBe(CENTRE)
+      expect(Number(hotspotY)).toBe(CENTRE)
+
+      // Safari does not accept SVG data-URI cursors; without the keyword it
+      // would fall all the way back to the default arrow.
+      expect(fallback).toBe('move')
+
+      const svg = decodeSvg(value)
+      expect(svg).toContain(`width="${BOX}" height="${BOX}"`)
+      expect(svg).toContain(`viewBox="0 0 ${BOX} ${BOX}"`)
+    }
+  })
+
+  test('each shape is haloed, so it reads on blue field and yellow tonal alike', () => {
+    const svg = decodeSvg(FEATURE_HOVER_CURSOR)
+    const halo = /<g stroke="#000000"[^>]*stroke-width="([\d.]+)"/.exec(svg)
+    const core = /<g stroke="#ffffff"[^>]*stroke-width="([\d.]+)"/.exec(svg)
+
+    expect(halo).not.toBeNull()
+    expect(core).not.toBeNull()
+    expect(parseFloat(halo[1])).toBeGreaterThan(parseFloat(core[1]))
+  })
+
+  test('hover and drag are distinguishable from each other and from idle', () => {
+    expect(FEATURE_HOVER_CURSOR).not.toBe(FEATURE_DRAG_CURSOR)
+    expect(FEATURE_HOVER_CURSOR).not.toBe(IDLE_CURSOR)
+    expect(FEATURE_DRAG_CURSOR).not.toBe(IDLE_CURSOR)
+  })
+
+  test('no feature cursor is a hand — that is what obscured the gram', () => {
+    for (const value of [FEATURE_HOVER_CURSOR, FEATURE_DRAG_CURSOR]) {
+      expect(value).not.toContain(PAN_IDLE_CURSOR)
+      expect(value).not.toContain(PAN_DRAG_CURSOR)
+    }
+  })
+})
+
+describe('featureCursor', () => {
+  test('the resting phase is the plain crosshair', () => {
+    expect(featureCursor('idle')).toBe(IDLE_CURSOR)
+  })
+
+  test('an unrecognised phase rests at idle rather than sticking', () => {
+    expect(featureCursor(/** @type {any} */ ('nonsense'))).toBe(IDLE_CURSOR)
+  })
+})

--- a/tests/unit/drag-hover.test.js
+++ b/tests/unit/drag-hover.test.js
@@ -1,5 +1,9 @@
 import { describe, test, expect, vi } from 'vitest'
 import { BaseDragHandler } from '../../src/modes/shared/BaseDragHandler.js'
+import { IDLE_CURSOR, featureCursor } from '../../src/utils/cursors.js'
+
+const FEATURE_HOVER_CURSOR = featureCursor('hover')
+const FEATURE_DRAG_CURSOR = featureCursor('drag')
 
 /**
  * @fileoverview Unit tests for the drag engine's hover contract (regression
@@ -50,10 +54,10 @@ describe('BaseDragHandler hover contract', () => {
     // The minting resolver must not run on a hover — that is the bug.
     expect(resolveTarget).not.toHaveBeenCalled()
     expect(resolveHoverTarget).toHaveBeenCalledTimes(1)
-    expect(updateCursor).toHaveBeenCalledWith('crosshair')
+    expect(updateCursor).toHaveBeenCalledWith(IDLE_CURSOR)
   })
 
-  test('hover over a found target shows the grab cursor', () => {
+  test('hover over a found target shows the feature-hover cursor', () => {
     const updateCursor = vi.fn()
     const handler = new BaseDragHandler(makeInstance(), {
       resolveTarget: vi.fn(someTarget),
@@ -66,7 +70,7 @@ describe('BaseDragHandler hover contract', () => {
 
     handler.updateCursorForHover({ freq: 10, time: 5 })
 
-    expect(updateCursor).toHaveBeenCalledWith('grab')
+    expect(updateCursor).toHaveBeenCalledWith(FEATURE_HOVER_CURSOR)
   })
 
   test('hover falls back to resolveTarget when no hover resolver is supplied', () => {
@@ -85,7 +89,7 @@ describe('BaseDragHandler hover contract', () => {
     handler.updateCursorForHover({ freq: 10, time: 5 })
 
     expect(resolveTarget).toHaveBeenCalledTimes(1)
-    expect(updateCursor).toHaveBeenCalledWith('grab')
+    expect(updateCursor).toHaveBeenCalledWith(FEATURE_HOVER_CURSOR)
   })
 
   test('hover never starts a drag or touches the drag projection', () => {
@@ -105,6 +109,72 @@ describe('BaseDragHandler hover contract', () => {
     expect(handler.isDragging()).toBe(false)
     expect(onDragStart).not.toHaveBeenCalled()
     expect(instance.state.drag).toEqual({ active: false })
+  })
+
+  test('a mode sees the phase, not a cursor string, and can override per kind', () => {
+    // Pan mode keeps the hand this way. The engine used to pass the CSS value
+    // it would otherwise apply, so overriding modes had to sniff it
+    // (`fallback === 'grabbing'`) and broke the moment that string changed.
+    const seen = []
+    const updateCursor = vi.fn()
+    const handler = new BaseDragHandler(makeInstance(), {
+      resolveTarget: vi.fn(someTarget),
+      resolveHoverTarget: vi.fn(someTarget),
+      onDragStart: vi.fn(),
+      onDragMove: vi.fn(),
+      onDragEnd: vi.fn(),
+      updateCursor,
+      cursorFor: (kind, phase) => {
+        seen.push({ kind, phase })
+        return phase === 'drag' ? 'grabbing' : null
+      }
+    }, 'pan')
+
+    handler.updateCursorForHover({ freq: 10, time: 5 })
+    expect(seen.at(-1)).toEqual({ kind: 'move', phase: 'hover' })
+
+    handler.startDrag({ freq: 10, time: 5 })
+    expect(seen.at(-1)).toEqual({ kind: 'move', phase: 'drag' })
+    expect(updateCursor).toHaveBeenLastCalledWith('grabbing')
+
+    handler.endDrag({ freq: 11, time: 6 })
+    expect(seen.at(-1)).toEqual({ kind: 'move', phase: 'idle' })
+  })
+
+  test('a null from cursorFor takes the default for that phase', () => {
+    const updateCursor = vi.fn()
+    const handler = new BaseDragHandler(makeInstance(), {
+      resolveTarget: vi.fn(someTarget),
+      resolveHoverTarget: vi.fn(someTarget),
+      onDragStart: vi.fn(),
+      onDragMove: vi.fn(),
+      onDragEnd: vi.fn(),
+      updateCursor,
+      cursorFor: () => null
+    }, 'harmonics')
+
+    handler.startDrag({ freq: 10, time: 5 })
+
+    expect(updateCursor).toHaveBeenLastCalledWith(FEATURE_DRAG_CURSOR)
+  })
+
+  test('hover with nothing under the pointer reports a null kind', () => {
+    // So a mode's cursorFor can tell "resting over the gram" apart from
+    // "resting after a drag of some kind ended".
+    const seen = []
+    const handler = new BaseDragHandler(makeInstance(), {
+      resolveTarget: vi.fn(() => null),
+      resolveHoverTarget: vi.fn(() => null),
+      onDragStart: vi.fn(),
+      onDragMove: vi.fn(),
+      onDragEnd: vi.fn(),
+      updateCursor: vi.fn(),
+      cursorFor: (kind, phase) => { seen.push({ kind, phase }); return null }
+    }, 'analysis')
+
+    handler.updateCursorForHover({ freq: 10, time: 5 })
+
+    expect(seen).toEqual([{ kind: null, phase: 'idle' }])
   })
 
   test('hover during an active drag is ignored entirely', () => {


### PR DESCRIPTION
## The problem

Hovering or dragging a marker, harmonic set or Doppler marker showed the platform `grab` / `grabbing` cursors. Those are opaque ~32px bitmaps whose hotspot sits in the middle of the palm, so the glyph landed on exactly the feature being aimed at — and on the gram pixels underneath it. Reported from the field against a cross-cursor marker, and reproduced against a harmonic set.

It was worst during a drag, when the closed fist covered the placement point at the moment placement accuracy matters most.

Two lines were responsible: `BaseDragHandler.js:329` (hover) and `:244` (drag).

## The fix

Feature drags now use four L-shaped corner brackets framing empty space, with **nothing painted on the centre row or centre column**. Those are the two directions a spectrogram carries signal in, so tonals and time lines run straight through the cursor and the marker stays visible while it moves.

- **Hover** opens the brackets to a 20px square; **dragging** closes them in to 14px and thickens them. A shape change rather than a colour change, because markers can be any colour — a recoloured cursor would collide with green and yellow markers.
- The drag arms are deliberately a pixel shorter than the hover set's: at equal length the heavier stroke's round caps reached across the centre column and clipped a tonal running under the hotspot.
- Each shape is stroked twice, black under white — the same halo idiom as `applyTextHalo` in `utils/svg.js` — so it reads over the blue field and a saturated yellow tonal alike.
- Every value ends `, move`. Safari has never reliably accepted SVG data-URI cursors, and a `url()` cursor with no fallback leaves it on the default arrow.

**Panning keeps the hand**, including the middle-button pan available in every mode. There is no target under the pointer to obscure, and the hand is the honest metaphor for dragging the whole viewport.

Six candidate shapes were compared against mock gram imagery before picking this one. The corner brackets were chosen over a diagonal four-arrow — which clears the axes equally well — because four arrowheads pointing outward read as "zoom" or "expand", a metaphor this component has already spent on its expand toggle.

## Drag engine change

`cursorFor` now receives a **phase name** (`idle` / `hover` / `drag`) rather than the CSS value the engine would otherwise apply. Modes were sniffing that value (`fallback === 'grabbing'`) to detect a drag, which tied every overriding mode to the exact strings the engine happened to use — changing the drag cursor would have silently broken pan.

Hover also routes through `applyCursor` now, like every other transition. It previously called `updateCursor` directly, making hover the one transition a mode's `cursorFor` could not influence.

## Testing

- `tests/unit/cursors.test.js` — new. Parses the artwork's path data back out of the CSS value and asserts no ink lands on the centre row or centre column, at the painted stroke width. This is the property the whole feature exists for, and it is exactly what a well-meaning geometry tweak would break; the parser throws on unsupported path commands so a skipped segment cannot make the assertion vacuous. It was verified to reject both a plain crosshair and the 5px drag arms that were caught during development.
- `tests/unit/drag-hover.test.js` — extended with the phase contract: modes see `idle`/`hover`/`drag` with the target's kind, `null` falls through to the default, and an untargeted hover reports a null kind.
- `tests/cursor-hover.spec.js` — new E2E. Pins the wiring end to end: a marker and a harmonic set both take the hollow cursor, empty gram stays `crosshair`, the cursor stays hollow for the whole drag and returns afterwards, and pan mode still gets the hand.

`yarn typecheck`, `yarn lint`, `yarn hygiene`, `yarn test:unit` (124 passed) and `yarn test` (296 passed) all green.

## Note, not fixed here

Pan mode applies its resting cursor on activate, so wheel-zooming from 1× to 2× while already in pan mode leaves the cursor as a crosshair until the mode is re-entered. Pre-existing and unrelated to the obscuring problem, so left alone — happy to pick it up separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpdBFRu2zWpxMb84Wio8aD)_