### PR TITLE
Release v0.1.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spectro-component",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Bumps `package.json` from `0.1.15` to `0.1.16` so the `v0.1.16` tag passes the release workflow's version-match gate. This is the only change in the diff — one line.

## Why now

`v0.1.15` was tagged on 31 July at `edfc549`. `main` has moved 65 commits since, with nothing released off it.

## What's in the release

Most of the 65 commits are the two remediation phases, which are internal:

- **Phase 2 consolidation (spec 166)** — one coordinate pipeline replacing four implementations, one drag engine replacing five machines, batched frame-bounded notifications through a single dispatcher, one diffing table behind the markers table and harmonics panel, and the test suite migrated from fixed sleeps to state-based waits (244 down to 1).
- **Phase 3 structural refactor (spec 167)** — the strict type gate closed (540 errors to zero, all three flags on), state decoupled from modes via a single registration seam, capability-based discovery replacing name checks, `table.js` split, and the instance surface grouped from 56 flat fields to 11.

User-visible changes since `v0.1.15`:

- Analysis markers gained optional haloed text labels (#231)
- Harmonic sets show mini-pins when the tall pin is hidden, and the toggle is relabelled "Tall Pins" (#232)
- The styles panel is reorganised by what each control affects, with the pin toggle inline with the Harmonics caption
- Feature drags use hollow corner brackets instead of the opaque grab hands, so the marker and gram under the hotspot stay visible; panning keeps the hand
- `cursorPosition` publishes image-relative `imageX`/`imageY` (additive; nothing removed)

## Verification

Ran the full set locally at this commit, mirroring what `release.yml` will run:

| Gate | Result |
| --- | --- |
| `yarn typecheck` | clean |
| `yarn lint` | 0 errors, 44 warnings (at the `--max-warnings` ceiling) |
| `yarn hygiene` | all 5 ratchets at baseline |
| `yarn test:unit` | 124 passed |
| `yarn test` | 296 passed |
| `yarn build:standalone` | 312 KB, over the workflow's 100 KB floor |
| Version injection | bundle carries `"0.1.16"` — the check that gates the tag |

## After merge

I'll tag the merge commit `v0.1.16` and push it, which fires `release.yml` to build the standalone bundle and publish the GitHub release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMVeqzRsntXEExZx1mHLN3)_