### PR TITLE
Clear the lint backlog and close the warning ratchet

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,21 +47,23 @@ export default [
       'no-implied-eval': 'error',
       'no-new-func': 'error',
 
-      // Warnings — existing occurrences allowed; promote to error once clean.
+      // Formerly warnings with a tolerated backlog. The backlog is now zero, so
+      // these are promoted to errors per the ratchet policy above — a new
+      // occurrence fails the lane rather than eroding a warning ceiling.
       // `_`-prefixed names are the opt-out for a binding that must exist but is
       // deliberately unused — including a caught error the handler ignores on
       // purpose (browserCompatibility.js keeps the binding rather than using
       // optional catch binding, whose ES2019 syntax would fail to parse on the
       // very old browsers that file exists to warn).
-      'no-unused-vars': ['warn', {
+      'no-unused-vars': ['error', {
         argsIgnorePattern: '^_',
         varsIgnorePattern: '^_',
         caughtErrorsIgnorePattern: '^_'
       }],
-      'no-shadow': 'warn',
-      'no-unreachable': 'warn',
-      'prefer-const': 'warn',
-      'eqeqeq': ['warn', 'smart'],
+      'no-shadow': 'error',
+      'no-unreachable': 'error',
+      'prefer-const': 'error',
+      'eqeqeq': ['error', 'smart'],
     },
   },
   {
@@ -70,14 +72,6 @@ export default [
     files: ['src/core/browserCompatibility.js'],
     rules: {
       'no-var': 'off',
-    },
-  },
-  {
-    // Pre-existing empty else block; src/ is frozen in Phase 0 (FR-010).
-    // Drop this override when the block is removed in a later phase.
-    files: ['src/modes/harmonics/HarmonicsMode.js'],
-    rules: {
-      'no-empty': 'warn',
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "playwright test",
     "typecheck": "tsc --noEmit",
     "hygiene": "node scripts/hygiene.js",
-    "lint": "eslint . --max-warnings 44",
+    "lint": "eslint . --max-warnings 0",
     "test:unit": "vitest run"
   },
   "devDependencies": {

--- a/src/core/initialization/ModeInitialization.js
+++ b/src/core/initialization/ModeInitialization.js
@@ -10,8 +10,9 @@
 
 import { ModeFactory } from '../../modes/ModeFactory.js'
 import { FeatureRenderer } from '../FeatureRenderer.js'
-import { BaseMode } from '../../modes/BaseMode.js'
 import { updateGuidancePanel } from '../../utils/secureHTML.js'
+
+/** @typedef {import('../../modes/BaseMode.js').BaseMode} BaseMode */
 
 /**
  * Construct the feature renderer and every registered mode.

--- a/src/modes/analysis/AnalysisMode.js
+++ b/src/modes/analysis/AnalysisMode.js
@@ -701,11 +701,11 @@ export class AnalysisMode extends BaseMode {
     const tolerance = getUniformTolerance(this.getViewport(), this.instance.ui.spectrogramImage)
     
     // Check each marker to see if position hits the crosshair lines
-    const marker = this.markers.find(marker => {
+    const marker = this.markers.find(candidate => {
       // Check if we're close to the marker center (original behavior)
       if (isWithinToleranceRadius(
-        position, 
-        { freq: marker.freq, time: marker.time },
+        position,
+        { freq: candidate.freq, time: candidate.time },
         tolerance
       )) {
         return true
@@ -716,7 +716,7 @@ export class AnalysisMode extends BaseMode {
       // We need to convert this to data space for comparison
       
       // Convert marker position to SVG coordinates
-      const markerPoint = { freq: marker.freq, time: marker.time }
+      const markerPoint = { freq: candidate.freq, time: candidate.time }
       const markerSVG = dataToSVG(markerPoint, this.getViewport(), this.instance.ui.spectrogramImage)
       
       // Convert click position to SVG coordinates

--- a/src/modes/harmonics/HarmonicsMode.js
+++ b/src/modes/harmonics/HarmonicsMode.js
@@ -652,7 +652,7 @@ export class HarmonicsMode extends BaseMode {
     const harmonicSet = this.instance.state.harmonics.harmonicSets.find(set => set.id === setId)
     if (!harmonicSet) return
 
-    let newSpacing, newAnchorTime
+    let newSpacing
 
     // For both new creation and existing drags, keep the clicked harmonic under the cursor
     const clickedHarmonicNumber = (target.data && target.data.clickedHarmonicNumber) || 1
@@ -672,7 +672,7 @@ export class HarmonicsMode extends BaseMode {
       : harmonicSet.anchorTime
     const deltaTime = currentPos.time - startPos.time
     const { timeMin, timeMax } = this.instance.state.config
-    newAnchorTime = Math.max(timeMin, Math.min(timeMax, originalAnchorTime + deltaTime))
+    const newAnchorTime = Math.max(timeMin, Math.min(timeMax, originalAnchorTime + deltaTime))
 
     // Apply updates
     const updates = {}
@@ -694,8 +694,6 @@ export class HarmonicsMode extends BaseMode {
 
     if (this.instance.ui.harmonicPanel) {
       updateHarmonicPanelContent(this.instance.ui.harmonicPanel, this.instance)
-    } else {
-
     }
   }
 

--- a/tests/advanced-interactions.spec.js
+++ b/tests/advanced-interactions.spec.js
@@ -1,11 +1,4 @@
 import { test, expect } from './helpers/fixtures.js'
-import { 
-  expectValidMetadata, 
-  expectValidMode, 
-  expectValidCursorPosition,
-  expectValidConfig,
-  expectValidImageDetails 
-} from './helpers/state-assertions.js'
 
 /**
  * @fileoverview Comprehensive E2E tests for Advanced Mouse Interactions
@@ -17,15 +10,6 @@ import {
  * @description Tests complex interaction patterns, edge cases, error conditions, and performance
  */
 test.describe('Advanced Mouse Interactions - Comprehensive E2E Tests', () => {
-  /**
-   * Setup before each test
-   * @param {TestParams} params - Test parameters
-   * @param {import('./helpers/gram-frame-page.js').default} params.gramFramePage - GramFrame page object
-   * @returns {Promise<void>}
-   */
-  test.beforeEach(async ({ gramFramePage }) => {
-  })
-
   /**
    * Complex interaction patterns test suite
    */  

--- a/tests/analysis-mode.spec.js
+++ b/tests/analysis-mode.spec.js
@@ -300,9 +300,7 @@ test.describe('Cross Cursor Mode - Comprehensive E2E Tests', () => {
       /** @type {import('../src/types.js').GramFrameState} */
       let state = await gramFramePage.getState()
       expect(state.analysis?.markers).toHaveLength(1)
-      /** @type {string} */
-      const markerId = state.analysis.markers[0].id
-      
+
       // Right-click on the marker position to delete it
       await gramFramePage.svg.click({ 
         button: 'right', 
@@ -577,7 +575,7 @@ test.describe('Cross Cursor Mode - Comprehensive E2E Tests', () => {
         // Coordinates should remain the same in data space
         expect(Math.abs(zoomedMarker.time - initialMarker.time)).toBeLessThan(0.01)
         expect(Math.abs(zoomedMarker.freq - initialMarker.freq)).toBeLessThan(1)
-      } catch (error) {
+      } catch (_error) {
         console.log('Zoom functionality not available, skipping zoom coordinate test')
       }
     })

--- a/tests/doppler-mode.spec.js
+++ b/tests/doppler-mode.spec.js
@@ -1,8 +1,7 @@
 import { test, expect } from './helpers/fixtures.js'
 import { 
   expectValidMetadata, 
-  expectValidMode, 
-  expectValidCursorPosition,
+  expectValidMode,
   expectValidConfig,
   expectValidImageDetails 
 } from './helpers/state-assertions.js'
@@ -153,9 +152,6 @@ test.describe('Doppler Mode - Comprehensive E2E Tests', () => {
         return
       }
       
-      /** @type {number} */
-      const originalFZeroTime = state.doppler.fZero.time
-      
       // Calculate approximate f₀ position for dragging
       /** @type {number} */
       const fZeroX = (200 + 300) / 2 // Approximate midpoint
@@ -263,9 +259,6 @@ test.describe('Doppler Mode - Comprehensive E2E Tests', () => {
       if (!state.doppler.fPlus || !state.doppler.fMinus) {
         return
       }
-      
-      /** @type {number} */
-      const initialFreqDiff = Math.abs(state.doppler.fPlus.freq - state.doppler.fMinus.freq)
       
       // Drag one marker to change frequency difference
       await gramFramePage.page.mouse.move(200, 150)
@@ -426,7 +419,7 @@ test.describe('Doppler Mode - Comprehensive E2E Tests', () => {
         
         // Verify display updated
         await expect(resultsDisplay).not.toHaveText(initialText ?? '')
-      } catch (error) {
+      } catch (_error) {
         console.log('Real-time display update not testable')
       }
     })
@@ -485,7 +478,7 @@ test.describe('Doppler Mode - Comprehensive E2E Tests', () => {
         if (count > 0) {
           expect(count).toBeGreaterThan(0)
         }
-      } catch (error) {
+      } catch (_error) {
         // Markers may not be visible
       }
     })
@@ -534,7 +527,7 @@ test.describe('Doppler Mode - Comprehensive E2E Tests', () => {
         if (dopplerCount > 0) {
           expect(dopplerCount).toBeGreaterThan(0)
         }
-      } catch (error) {
+      } catch (_error) {
         // Some markers may not be visible
       }
     })

--- a/tests/expand-image.spec.js
+++ b/tests/expand-image.spec.js
@@ -45,7 +45,6 @@ async function computeAvailable(page) {
   return page.evaluate(() => {
     const cell = document.querySelector('.gram-frame-main-panel')
     const svg = document.querySelector('.gram-frame-svg')
-    const image = document.querySelector('.gram-frame-spectrogram-image')
     const cs = window.getComputedStyle(cell)
     const ss = window.getComputedStyle(svg)
     const padL = parseFloat(cs.paddingLeft)

--- a/tests/harmonic-pin-toggle.spec.js
+++ b/tests/harmonic-pin-toggle.spec.js
@@ -142,7 +142,7 @@ test.describe('US2: Toggling restyles the selected harmonic set in place', () =>
     await gramFramePage.setPinToggle(false)
     await waitForSetPin(gramFramePage, setId, false)
 
-    let state = await gramFramePage.getState()
+    const state = await gramFramePage.getState()
     expect(await gramFramePage.getHarmonicLineCount(setId)).toBe(0)
     // Restyling a selected set must not change the session default
     expect(state.showHarmonicPin).toBe(true)

--- a/tests/harmonic-symbols.spec.js
+++ b/tests/harmonic-symbols.spec.js
@@ -106,16 +106,16 @@ test.describe('US1: Symbols on harmonic pins', () => {
       const label = document.querySelector(
         `.gram-frame-harmonic-number[data-harmonic-set-id="${setId}"]`
       )
-      const symbols = Array.from(document.querySelectorAll(
+      const pinSymbols = Array.from(document.querySelectorAll(
         `.gram-frame-harmonic-symbol[data-harmonic-set-id="${setId}"]`
       ))
-      if (!label || symbols.length === 0) return null
+      if (!label || pinSymbols.length === 0) return null
       const l = label.getBoundingClientRect()
       const lCx = centreX(l)
       // Pick the symbol on the same pin as this label
-      let symbol = symbols[0]
+      let symbol = pinSymbols[0]
       let best = Infinity
-      for (const s of symbols) {
+      for (const s of pinSymbols) {
         const d = Math.abs(centreX(s.getBoundingClientRect()) - lCx)
         if (d < best) { best = d; symbol = s }
       }

--- a/tests/harmonics-mode.spec.js
+++ b/tests/harmonics-mode.spec.js
@@ -1,8 +1,7 @@
 import { test, expect } from './helpers/fixtures.js'
 import { 
   expectValidMetadata, 
-  expectValidMode, 
-  expectValidCursorPosition,
+  expectValidMode,
   expectValidConfig,
   expectValidImageDetails 
 } from './helpers/state-assertions.js'
@@ -244,8 +243,6 @@ test.describe('Harmonics Mode - Comprehensive E2E Tests', () => {
         return
       }
       
-      /** @type {number} */
-      const originalRate = state.harmonics.harmonicSets[0].rate
 
       // Click and drag on the harmonic line to adjust spacing
       await gramFramePage.page.mouse.move(200, 200) // Click on harmonic line
@@ -298,7 +295,7 @@ test.describe('Harmonics Mode - Comprehensive E2E Tests', () => {
         if (groupCount > 0) {
           expect(groupCount).toBeGreaterThan(0)
         }
-      } catch (error) {
+      } catch (_error) {
         // Harmonic rendering may not be visible
       }
     })
@@ -331,7 +328,7 @@ test.describe('Harmonics Mode - Comprehensive E2E Tests', () => {
         if (count > 0) {
           expect(count).toBeGreaterThan(0)
         }
-      } catch (error) {
+      } catch (_error) {
         // Harmonic lines may not be visible at boundaries
       }
     })
@@ -385,7 +382,7 @@ test.describe('Harmonics Mode - Comprehensive E2E Tests', () => {
         /** @type {import('../src/types.js').GramFrameState} */
         const state = await gramFramePage.getState()
         expect(state.harmonics.harmonicSets[0].color).toBe('#2ecc71')
-      } catch (error) {
+      } catch (_error) {
         console.log('Color picker not available in harmonics mode')
       }
     })

--- a/tests/helpers/gram-frame-page.js
+++ b/tests/helpers/gram-frame-page.js
@@ -187,22 +187,22 @@ class GramFramePage {
    * @returns {Promise<void>}
    */
   async wheelAtSVG(x, y, deltaY, ctrl = false) {
-    await this.page.evaluate(({ x, y, deltaY, ctrl }) => {
+    await this.page.evaluate(({ atX, atY, wheelDelta, withCtrl }) => {
       const svg = document.querySelector('.gram-frame-svg')
       if (!svg) {
         return
       }
       const rect = svg.getBoundingClientRect()
       const ev = new WheelEvent('wheel', {
-        clientX: rect.left + x,
-        clientY: rect.top + y,
-        deltaY,
-        ctrlKey: ctrl,
+        clientX: rect.left + atX,
+        clientY: rect.top + atY,
+        deltaY: wheelDelta,
+        ctrlKey: withCtrl,
         bubbles: true,
         cancelable: true
       })
       svg.dispatchEvent(ev)
-    }, { x, y, deltaY, ctrl })
+    }, { atX: x, atY: y, wheelDelta: deltaY, withCtrl: ctrl })
   }
 
   /**
@@ -213,16 +213,16 @@ class GramFramePage {
    * @returns {Promise<{x: number, y: number}>} SVG-relative coordinates
    */
   async imageSVGPoint(fracX, fracY) {
-    return await this.page.evaluate(({ fracX, fracY }) => {
+    return await this.page.evaluate(({ atFracX, atFracY }) => {
       const svg = document.querySelector('.gram-frame-svg')
       const img = document.querySelector('.gram-frame-svg image')
       const svgRect = svg.getBoundingClientRect()
       const imgRect = img.getBoundingClientRect()
       return {
-        x: (imgRect.left - svgRect.left) + fracX * imgRect.width,
-        y: (imgRect.top - svgRect.top) + fracY * imgRect.height
+        x: (imgRect.left - svgRect.left) + atFracX * imgRect.width,
+        y: (imgRect.top - svgRect.top) + atFracY * imgRect.height
       }
-    }, { fracX, fracY })
+    }, { atFracX: fracX, atFracY: fracY })
   }
 
   /**

--- a/tests/mode-integration.spec.js
+++ b/tests/mode-integration.spec.js
@@ -1,10 +1,7 @@
 import { test, expect } from './helpers/fixtures.js'
-import { 
-  expectValidMetadata, 
-  expectValidMode, 
-  expectValidCursorPosition,
-  expectValidConfig,
-  expectValidImageDetails 
+import {
+  expectValidMetadata,
+  expectValidMode
 } from './helpers/state-assertions.js'
 
 /**
@@ -17,15 +14,6 @@ import {
  * @description Tests mode switching, state persistence, feature visibility, and interaction between modes
  */
 test.describe('Cross-Mode Integration - Comprehensive E2E Tests', () => {
-  /**
-   * Setup before each test
-   * @param {TestParams} params - Test parameters
-   * @param {import('./helpers/gram-frame-page.js').default} params.gramFramePage - GramFrame page object
-   * @returns {Promise<void>}
-   */
-  test.beforeEach(async ({ gramFramePage }) => {
-  })
-
   /**
    * Mode switching test suite
    */
@@ -232,7 +220,7 @@ test.describe('Cross-Mode Integration - Comprehensive E2E Tests', () => {
               expect(typeof isVisible).toBe('boolean')
             }
           }
-        } catch (error) {
+        } catch (_error) {
           // Markers may not be visible in all modes
         }
       }
@@ -344,7 +332,7 @@ test.describe('Cross-Mode Integration - Comprehensive E2E Tests', () => {
         expectValidMode(state, 'analysis')
         expectValidMetadata(state)
         expect(state.analysis.markers).toBeDefined()
-      } catch (error) {
+      } catch (_error) {
         // Even if errors occur, system should remain in valid state
         /** @type {import('../src/types.js').GramFrameState} */
         const state = await gramFramePage.getState()
@@ -365,9 +353,7 @@ test.describe('Cross-Mode Integration - Comprehensive E2E Tests', () => {
      */
     test('should synchronize state listeners across mode changes', async ({ gramFramePage }) => {
       // Test that state updates are properly broadcast during mode switches
-      /** @type {import('../src/types.js').GramFrameState | null} */
-      let lastNotifiedState = null
-      
+
       // Add state listener via page evaluation
       await gramFramePage.page.evaluate(() => {
         window.testStateHistory = []

--- a/tests/state-listener.spec.js
+++ b/tests/state-listener.spec.js
@@ -1,5 +1,4 @@
 import { test, expect } from './helpers/fixtures.js'
-import { expectValidMetadata, expectValidMode } from './helpers/state-assertions.js'
 
 /**
  * @fileoverview Tests for the state listener mechanism
@@ -74,7 +73,7 @@ test.describe('State Listener Mechanism', () => {
       
       // Create a listener
       /** @type {import('../src/types.js').StateListener} */
-      const listener = state => {
+      const listener = _state => {
         if (testResult.removalResult) {
           testResult.callbackCalledAfterRemoval = true
         } else {
@@ -124,7 +123,7 @@ test.describe('State Listener Mechanism', () => {
       
       // Create a listener that throws an error
       /** @type {import('../src/types.js').StateListener} */
-      const listener = state => {
+      const listener = _state => {
         throw new Error('Test error in listener')
       }
       


### PR DESCRIPTION
`yarn lint` was passing at **exactly 44 warnings against a `--max-warnings 44` ceiling** — zero headroom. The next stray unused variable anywhere in the repo would have turned CI red for a reason unrelated to whatever PR introduced it. This clears all 44 and drops the ceiling to zero.

## What was fixed

| Rule | Count | Fix |
| --- | --- | --- |
| `no-unused-vars` | 32 | Dropped imports and locals nothing reads; renamed deliberately-ignored catch bindings to `_error`; deleted two empty `beforeEach` hooks |
| `no-shadow` | 8 | Renamed inner `page.evaluate` payload params that shadowed the enclosing method params |
| `prefer-const` | 3 | Split the one `let` that was never reassigned; two test locals |
| `no-empty` | 1 | Removed the empty `else` in `HarmonicsMode.updateHarmonicPanel` |

`_error` and the `_` prefix generally are the config's own documented opt-out for a binding that must exist but is deliberately unused. `tests/loud-failures.spec.js` keeps its plain `catch (error)` because it actually reads it.

The two deleted `beforeEach` hooks had empty bodies; their only effect was to request the `gramFramePage` fixture, which every test in both files already requests individually. Removing the empty `else` also retires the per-file `no-empty` override in `eslint.config.js`, which existed solely for that block and whose comment asked for exactly this.

## Two judgement calls worth a look

**`ModeInitialization.js` imported `BaseMode` purely for JSDoc types.** Deleting the import — the "obvious" fix ESLint suggests — would have satisfied lint and broken `yarn typecheck`, which runs strict. Converted it to a `@typedef` import instead, matching how `main.js` and `UISetup.js` already reference the same type.

**The five debt rules are promoted from `warn` to `error`.** This is the ratchet policy `eslint.config.js` already describes ("style/debt rules … get promoted to errors as the debt is paid down"), now that the backlog is zero. Easy to revert to warnings if you'd rather keep them advisory.

## Something the cleanup surfaced

Four of the removed variables were "capture the original value" reads whose comparison was never written:

- `originalFZeroTime` — captured f₀ time before a drag, never compared after
- `initialFreqDiff` — captured the f+/f− spread, never compared after
- `originalRate` — captured rate before a spacing drag, never compared after
- `markerId` — captured before a right-click delete, never used to verify *which* marker was removed

Deleting them is correct since they were dead, but each marks a test that sets up a before/after check and doesn't complete it. Those tests are weaker than they look. Not fixed here — writing the missing assertions is a behavioural change that belongs in its own PR.

## Verification

| Gate | Result |
| --- | --- |
| `yarn lint` | clean at `--max-warnings 0` |
| `yarn typecheck` | clean |
| `yarn hygiene` | all 5 ratchets at baseline |
| `yarn test:unit` | 124 passed |
| `yarn test` | 296 passed — same count as before, so nothing was silently skipped |

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMVeqzRsntXEExZx1mHLN3)_