### PR TITLE
Note that Codespaces opens in Edge, not Chrome

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,12 @@ There is no visual/screenshot regression testing — see
 4. Component auto-initializes on page load via `DOMContentLoaded`
 5. Use debug.html for isolated testing and state inspection
 
+### Local environment notes
+
+- **Open GitHub Codespaces in MS Edge, not Chrome.** The Codespace fails to
+  open in Chrome on this machine; Edge opens it fine. Reach for Edge first
+  rather than debugging Chrome.
+
 ## Important Implementation Notes
 
 ### Architecture


### PR DESCRIPTION
Adds a short local-environment note to `CLAUDE.md`, under a new `### Local environment notes` heading in the Development Workflow section: the Codespace fails to open in Chrome on this machine but opens fine in MS Edge, so Edge is the first thing to reach for rather than a Chrome debugging detour.

Documentation only — six lines in `CLAUDE.md`, no code, config or test changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMVeqzRsntXEExZx1mHLN3)_