### PR TITLE
Tighten the control row and the tables: trim the panels, align the headings, stop the rows resizing

### DIFF
--- a/src/components/ColorPicker.js
+++ b/src/components/ColorPicker.js
@@ -68,11 +68,9 @@ export function createColorPicker(instance) {
   container.className = 'gram-frame-color-picker'
   container.style.display = 'block'
 
-  // Panel heading
-  const label = document.createElement('div')
-  label.className = 'gram-frame-color-picker-label'
-  label.textContent = 'Style'
-  container.appendChild(label)
+  // No panel heading: each band already labels itself ("Colour", "Symbol",
+  // "Harmonics"), so a "Style" caption above them only cost the control row
+  // height that the host's pages need elsewhere.
 
   // --- Colour band: applies to markers, harmonic sets and doppler curves ---
   const colorGroup = document.createElement('div')

--- a/src/components/ColorPicker.js
+++ b/src/components/ColorPicker.js
@@ -3,8 +3,8 @@
  *
  * One panel, three bands, grouped by what each control actually affects:
  *
- * - **Colour** — the gradient slider. The widest-reaching control there is: it
- *   styles analysis markers, harmonic sets AND doppler curves.
+ * - **Colour** — the gradient slider, uncaptioned. The widest-reaching control
+ *   there is: it styles analysis markers, harmonic sets AND doppler curves.
  * - **Symbol** — the symbol drop-down and the (temporary) large-symbol toggle.
  *   Both apply to markers and harmonic sets; neither applies to doppler.
  * - **Harmonics** — the pin toggle, fenced off below a rule because it is the
@@ -41,7 +41,7 @@ const COLOR_PALETTE = [
 ]
 
 /**
- * Create a band caption ("Colour", "Symbol", "Harmonics") for the style panel.
+ * Create a band caption ("Symbol", "Harmonics") for the style panel.
  * @param {string} text - Caption text
  * @returns {HTMLDivElement} The caption element
  */
@@ -68,14 +68,14 @@ export function createColorPicker(instance) {
   container.className = 'gram-frame-color-picker'
   container.style.display = 'block'
 
-  // No panel heading: each band already labels itself ("Colour", "Symbol",
-  // "Harmonics"), so a "Style" caption above them only cost the control row
-  // height that the host's pages need elsewhere.
+  // No panel heading, and no caption on the colour band: the gradient slider
+  // announces itself, and the two bands below it are captioned, so every line of
+  // text above the slider only cost the control row height the host's pages need
+  // elsewhere.
 
   // --- Colour band: applies to markers, harmonic sets and doppler curves ---
   const colorGroup = document.createElement('div')
   colorGroup.className = 'gram-frame-style-group'
-  colorGroup.appendChild(createGroupLabel('Colour'))
   container.appendChild(colorGroup)
 
   // Palette container - holds the full-width colour slider

--- a/src/components/DiffingTable.js
+++ b/src/components/DiffingTable.js
@@ -62,6 +62,15 @@ export function createDiffingTable(container, spec) {
   let currentRows = []
 
   /**
+   * Row keys rendered by the previous update, so a genuinely new row can be
+   * told apart from one that merely moved or changed. Its emptiness also marks
+   * the first population — a restore from storage, or the initial render — which
+   * is not an "addition" to scroll to.
+   * @type {Set<string>}
+   */
+  let renderedKeys = new Set()
+
+  /**
    * Put one cell's content in place, accepting either a string or a node.
    * @param {HTMLTableCellElement} cell - Cell to fill
    * @param {string|Node} content - New content
@@ -150,6 +159,59 @@ export function createDiffingTable(container, spec) {
   }
 
   /**
+   * Bring the rendered rows into line with `currentRows`.
+   *
+   * Update in place while the keys agree; at the first disagreement rebuild the
+   * tail, because from there on every row would otherwise show another row's
+   * data. Idempotent: an update that changes nothing performs no DOM writes.
+   */
+  function applyDiff() {
+    const existing = tbody.querySelectorAll('tr')
+
+    for (let index = 0; index < currentRows.length; index++) {
+      const tr = /** @type {HTMLTableRowElement} */ (existing[index])
+      const key = spec.rowKey(currentRows[index], index)
+
+      if (tr && tr.getAttribute(spec.rowAttribute) === key) {
+        updateRow(tr, currentRows[index], index)
+      } else {
+        // Keys diverged from here on; rebuild the tail and stop diffing
+        rebuildFrom(currentRows, index)
+        return
+      }
+    }
+
+    // Trailing rows whose data is gone
+    for (let i = currentRows.length; i < existing.length; i++) {
+      existing[i].remove()
+    }
+  }
+
+  /**
+   * Scroll the row at `index` into view, if it is below the fold.
+   *
+   * Sets `scrollTop` on the scroll wrapper rather than calling
+   * `Element.scrollIntoView`, which would also scroll every scrollable ancestor
+   * — including the host page — to bring the table into view. A new marker
+   * should move the table's own scrollbar and nothing else.
+   *
+   * Only ever scrolls DOWN: if the row is already visible the wrapper is left
+   * exactly where the user put it.
+   * @param {number} index - Index of the row to reveal
+   */
+  function revealRow(index) {
+    const tr = /** @type {HTMLElement|undefined} */ (tbody.children[index])
+    if (!tr) return
+
+    // offsetTop is measured against the wrapper, which is the nearest
+    // positioned ancestor (it is absolutely positioned over the table area).
+    const bottom = tr.offsetTop + tr.offsetHeight - wrapper.clientHeight
+    if (bottom > wrapper.scrollTop) {
+      wrapper.scrollTop = bottom
+    }
+  }
+
+  /**
    * Per-row controls that act instead of selecting, in match order. Delete is
    * one of these — the original and, for the harmonics panel, the only one —
    * so it is folded into the same list rather than special-cased twice.
@@ -200,33 +262,33 @@ export function createDiffingTable(container, spec) {
     element: table,
 
     /**
-     * Diff `rows` against what is rendered and apply the difference.
+     * Diff `rows` against what is rendered, apply the difference, and keep any
+     * newly added row in view.
      *
-     * Idempotent: calling it twice with equal input performs no DOM writes.
+     * Idempotent: calling it twice with equal input performs no DOM writes and
+     * no scrolling.
      * @param {any[]} rows - The rows to render
      */
     update(rows) {
       currentRows = rows || []
 
-      const existing = tbody.querySelectorAll('tr')
+      const keys = currentRows.map((row, index) => spec.rowKey(row, index))
+      applyDiff()
 
-      for (let index = 0; index < currentRows.length; index++) {
-        const tr = /** @type {HTMLTableRowElement} */ (existing[index])
-        const key = spec.rowKey(currentRows[index], index)
-
-        if (tr && tr.getAttribute(spec.rowAttribute) === key) {
-          updateRow(tr, currentRows[index], index)
-        } else {
-          // Keys diverged from here on; rebuild the tail and stop diffing
-          rebuildFrom(currentRows, index)
-          return
+      // Keep the last row that wasn't there before in view. Adding a marker
+      // when the list has already overflowed otherwise appends it out of sight,
+      // and the only feedback is a scrollbar that got slightly shorter.
+      let lastAdded = -1
+      for (let index = 0; index < keys.length; index++) {
+        if (!renderedKeys.has(keys[index])) {
+          lastAdded = index
         }
       }
-
-      // Trailing rows whose data is gone
-      for (let i = currentRows.length; i < existing.length; i++) {
-        existing[i].remove()
+      if (renderedKeys.size > 0 && lastAdded !== -1) {
+        revealRow(lastAdded)
       }
+
+      renderedKeys = new Set(keys)
     },
 
     /**

--- a/src/components/MainUI.js
+++ b/src/components/MainUI.js
@@ -151,13 +151,17 @@ function createMarkersContainer() {
   markersContainer.style.flexDirection = 'column'
   markersContainer.style.minHeight = '0'
   
+  // Same header row as the harmonics panel, minus the action slot: both panels
+  // then carry their rule, their spacing and their heading position from one
+  // CSS rule instead of two sets of inline styles that had drifted apart.
+  const markersHeader = document.createElement('div')
+  markersHeader.className = 'gram-frame-panel-header'
+
   const markersLabel = document.createElement('h4')
   markersLabel.textContent = 'Markers'
-  markersLabel.style.margin = '0 0 8px 0'
-  markersLabel.style.textAlign = 'left'
-  markersLabel.style.flexShrink = '0'
-  markersContainer.appendChild(markersLabel)
-  
+  markersHeader.appendChild(markersLabel)
+  markersContainer.appendChild(markersHeader)
+
   return markersContainer
 }
 
@@ -175,19 +179,11 @@ function createHarmonicsContainer() {
   
   // Create header container with title and button area
   const harmonicsHeader = document.createElement('div')
-  harmonicsHeader.className = 'gram-frame-harmonics-header'
-  harmonicsHeader.style.display = 'flex'
-  harmonicsHeader.style.justifyContent = 'space-between'
-  harmonicsHeader.style.alignItems = 'center'
-  harmonicsHeader.style.margin = '0 0 8px 0'
-  harmonicsHeader.style.flexShrink = '0'
-  
+  harmonicsHeader.className = 'gram-frame-panel-header gram-frame-harmonics-header'
+
   const harmonicsLabel = document.createElement('h4')
   harmonicsLabel.textContent = 'Harmonics'
-  harmonicsLabel.style.margin = '0'
-  harmonicsLabel.style.textAlign = 'left'
-  harmonicsLabel.style.flexShrink = '0'
-  
+
   const harmonicsButtonContainer = document.createElement('div')
   harmonicsButtonContainer.className = 'gram-frame-harmonics-button-container'
   harmonicsButtonContainer.style.flexShrink = '0'

--- a/src/components/MainUI.js
+++ b/src/components/MainUI.js
@@ -67,8 +67,12 @@ export function createUnifiedLayout(instance) {
   const freqLED = createLEDDisplay('Frequency (Hz)', '0.0')
   cursorContainer.appendChild(freqLED)
   
-  // Create doppler speed LED (spans full width)
+  // Create doppler speed LED (spans full width). Unlike the time/frequency
+  // readouts it lays its label out beside the value rather than above it: the
+  // label wraps to three short lines in the space the stacked form wasted to
+  // its right, so the readout costs the control row less height.
   const speedLED = createLEDDisplay('Doppler Speed (knots)', '0.0')
+  speedLED.classList.add('gram-frame-led-inline')
   speedLED.style.gridColumn = '1 / -1' // Span both columns
   cursorContainer.appendChild(speedLED)
   

--- a/src/components/MainUI.js
+++ b/src/components/MainUI.js
@@ -69,9 +69,16 @@ export function createUnifiedLayout(instance) {
   
   // Create doppler speed LED (spans full width). Unlike the time/frequency
   // readouts it lays its label out beside the value rather than above it: the
-  // label wraps to three short lines in the space the stacked form wasted to
-  // its right, so the readout costs the control row less height.
-  const speedLED = createLEDDisplay('Doppler Speed (knots)', '0.0')
+  // label wraps into the space the stacked form wasted to its right, so the
+  // readout costs the control row less height.
+  //
+  // The gap between "Doppler" and "Speed" is a non-breaking space, written as a
+  // \u00a0 escape so it stays visible in the source. The label is sized
+  // `width: min-content`, which breaks at every ordinary space and would stack
+  // three lines; gluing the first two words holds it to two - "Doppler Speed"
+  // over "(kts)". Playwright normalises \u00a0 to a plain space, so the
+  // `:text-is("Doppler Speed (kts)")` locators in tests/helpers still match.
+  const speedLED = createLEDDisplay('Doppler\u00a0Speed (kts)', '0.0')
   speedLED.classList.add('gram-frame-led-inline')
   speedLED.style.gridColumn = '1 / -1' // Span both columns
   cursorContainer.appendChild(speedLED)

--- a/src/gramframe.css
+++ b/src/gramframe.css
@@ -415,24 +415,28 @@ table.gram-config.gram-frame-config-error tr:first-child td::after {
   line-height: 1.2;
 }
 
-/* Manual harmonic button */
+/* Manual harmonic button. Sized to sit inside the panel header row beside the
+   "Harmonics" heading: at its old 6px/12px padding and 80px floor it stood
+   28px tall against the heading's 21px, which both pushed the heading down out
+   of line with the markers panel's and made the pair too wide for the 175px
+   column, so the button overlapped the heading. */
 .gram-frame-manual-button {
-  padding: 6px 12px;
+  padding: 3px 6px;
+  min-width: 0;
   background: linear-gradient(180deg, #6a6a6a 0%, #4a4a4a 50%, #2a2a2a 100%);
   color: #ddd;
   border: 2px solid #555;
   border-radius: 4px;
   cursor: pointer;
   font-weight: bold;
-  font-size: 11px;
+  font-size: 10px;
   text-transform: uppercase;
-  letter-spacing: 1px;
-  box-shadow: 
+  letter-spacing: 0.5px;
+  box-shadow:
     inset 0 1px 2px rgba(255,255,255,0.2),
     inset 0 -1px 2px rgba(0,0,0,0.3),
     0 2px 4px rgba(0,0,0,0.3);
   transition: all 0.1s ease;
-  min-width: 80px;
 }
 
 .gram-frame-manual-button:hover {
@@ -833,23 +837,49 @@ table.gram-frame-table {
 }
 
 /*
- * Marker row actions (feature 231): the Label button sits above the Delete
- * button in the cell that used to hold Delete alone, so the column keeps its
- * narrow width and the two controls never share a click target.
+ * The Label column shows an abbreviated label (see formatMarkerLabelForTable),
+ * so it should never wrap or stretch the row; anything unexpectedly long is
+ * clipped rather than allowed to reflow the table.
+ *
+ * It is also the positioning context for the label button in its top-right
+ * corner. The button was stacked above Delete in the actions cell until every
+ * marker row had to be tall enough for two controls; out of the flow it costs
+ * the row no height, and it now sits in the column it edits.
  */
-.gram-frame-marker-actions {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2px;
+.gram-frame-marker-label-cell {
+  position: relative;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Deliberately NOT a positioning context: the button anchors to the CELL, which
+   is the box whose top-right corner it wants. This wrapper is only as tall as
+   the label text and sits vertically centred in the cell, so positioning
+   against it would park the button halfway down instead. */
+.gram-frame-marker-label-content {
+  position: static;
+}
+
+/* Reserves the button's corner so a longer abbreviation is clipped short of it
+   rather than running underneath. */
+.gram-frame-marker-label-text {
+  display: block;
+  padding-right: 14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .gram-frame-marker-label-btn {
+  position: absolute;
+  top: 1px;
+  right: 0;
   background: none;
   border: none;
   color: #8ab4d8;
   cursor: pointer;
-  padding: 2px 6px;
+  padding: 1px 2px;
   border-radius: 2px;
   line-height: 0;
   transition: background-color 0.2s;
@@ -858,17 +888,6 @@ table.gram-frame-table {
 .gram-frame-marker-label-btn:hover {
   background-color: #8ab4d8;
   color: #1a1a1a;
-}
-
-/*
- * The Label column shows an abbreviated label (see formatMarkerLabelForTable),
- * so it should never wrap or stretch the row; anything unexpectedly long is
- * clipped rather than allowed to reflow the table.
- */
-.gram-frame-marker-label-cell {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 /* Marker rendering styles */
@@ -1630,23 +1649,46 @@ table.gram-frame-table {
   min-height: 0;
 }
 
+/*
+ * Panel header: the heading, plus an optional action slot on the right (the
+ * harmonics panel's + Manual button).
+ *
+ * The rule and the spacing live HERE and not on the h4, which is what keeps the
+ * two panels consistent. When the underline was on the heading itself, the
+ * markers h4 — a block filling its column — drew a full-width rule, while the
+ * harmonics h4 — a flex item beside the button — drew one only as wide as the
+ * word. `min-height` holds both rows to the same height so the two headings sit
+ * on the same line as each other across the panel.
+ */
+.gram-frame-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  min-height: 22px;
+  margin: 0 0 8px 0;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #444;
+  flex-shrink: 0;
+}
+
 .gram-frame-markers-persistent-container h4,
 .gram-frame-harmonics-persistent-container h4 {
-  margin: 0 0 8px 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
   flex-shrink: 0;
   color: #ddd;
   font-size: 14px;
-  text-align: center;
+  text-align: left;
   text-transform: uppercase;
   letter-spacing: 1px;
-  border-bottom: 1px solid #444;
-  padding-bottom: 4px;
 }
 
 .gram-frame-harmonics-button-container {
-  margin-bottom: 8px;
   display: flex;
   justify-content: center;
+  flex-shrink: 0;
 }
 
 /* Responsive behavior for smaller screens */

--- a/src/gramframe.css
+++ b/src/gramframe.css
@@ -390,13 +390,14 @@ table.gram-config.gram-frame-config-error tr:first-child td::after {
 /* Label-beside-value LED (the doppler speed readout).
  *
  * The default LED stacks its label above its value, which suits the short
- * "Time (mm:ss)" / "Frequency (Hz)" captions. "Doppler Speed (knots)" is long
+ * "Time (mm:ss)" / "Frequency (Hz)" captions. "Doppler Speed (kts)" is long
  * enough to claim a row of its own, so stacking it spent height on a line that
  * was mostly empty either side of the value. Here the label sits to the LEFT of
- * the value and `width: min-content` wraps it at each space — three words, three
- * short lines — filling the width the stacked form wasted.
+ * the value and `width: min-content` wraps it, filling the width the stacked
+ * form wasted. It breaks into two lines rather than three because MainUI.js
+ * joins "Doppler" and "Speed" with a non-breaking space.
  *
- * The label stays ONE text node ("Doppler Speed (knots)"): the wrap is CSS, not
+ * The label stays ONE text node ("Doppler Speed (kts)"): the wrap is CSS, not
  * markup, so `.gram-frame-led-label:text-is(...)` still matches it (the test
  * helpers locate every LED that way). Do not split it into lines in JS. */
 .gram-frame-led-inline {
@@ -494,7 +495,7 @@ table.gram-config.gram-frame-config-error tr:first-child td::after {
 
 /* A band whose controls fit on one line puts its caption inline with them
    rather than above. Used by the Symbol and Harmonics bands; the Colour band
-   keeps its caption stacked, because the slider spans the panel. */
+   has no caption at all — the gradient slider needs no naming. */
 .gram-frame-style-row {
   display: flex;
   align-items: center;
@@ -944,6 +945,20 @@ table.gram-frame-table {
   text-transform: uppercase;
   letter-spacing: 1px;
   font-weight: bold;
+}
+
+/* Aside inside a guidance heading (e.g. Mouse-Wheel "(available in all modes)").
+   Dropping the heading's uppercase and letter-spacing is what lets the qualifier
+   share the heading's line instead of wrapping onto a second one — it was a
+   bullet of its own until it moved up here, and a two-line heading would have
+   given back the height the move was meant to save. Dimmer than the heading so
+   the section still reads by its name first. */
+.gram-frame-guidance h4 .gram-frame-guidance-qualifier {
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: normal;
+  font-size: 10px;
+  color: #6a6;
 }
 
 .gram-frame-guidance p {

--- a/src/gramframe.css
+++ b/src/gramframe.css
@@ -705,6 +705,14 @@ table.gram-config.gram-frame-config-error tr:first-child td::after {
  */
 table.gram-frame-table {
   width: 100%;
+  /*
+   * Natural height, NOT the 100% the shared class sets for the outer frame.
+   * A table told to fill its container distributes the surplus across its rows,
+   * so a two-row table drew 50px rows, a six-row table 31px ones, and every row
+   * visibly shrank as the next was added. Rows now stay the height their
+   * content needs and the leftover space simply sits below them.
+   */
+  height: auto;
   border: 0;
   border-collapse: separate;
   border-spacing: 0;

--- a/src/gramframe.css
+++ b/src/gramframe.css
@@ -387,6 +387,33 @@ table.gram-config.gram-frame-config-error tr:first-child td::after {
   text-shadow: 0 0 4px #00ff00;
 }
 
+/* Label-beside-value LED (the doppler speed readout).
+ *
+ * The default LED stacks its label above its value, which suits the short
+ * "Time (mm:ss)" / "Frequency (Hz)" captions. "Doppler Speed (knots)" is long
+ * enough to claim a row of its own, so stacking it spent height on a line that
+ * was mostly empty either side of the value. Here the label sits to the LEFT of
+ * the value and `width: min-content` wraps it at each space — three words, three
+ * short lines — filling the width the stacked form wasted.
+ *
+ * The label stays ONE text node ("Doppler Speed (knots)"): the wrap is CSS, not
+ * markup, so `.gram-frame-led-label:text-is(...)` still matches it (the test
+ * helpers locate every LED that way). Do not split it into lines in JS. */
+.gram-frame-led-inline {
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 4px 6px;
+}
+
+.gram-frame-led-inline .gram-frame-led-label {
+  margin-bottom: 0;
+  width: min-content;
+  text-align: right;
+  line-height: 1.2;
+}
+
 /* Manual harmonic button */
 .gram-frame-manual-button {
   padding: 6px 12px;
@@ -437,15 +464,8 @@ table.gram-config.gram-frame-config-error tr:first-child td::after {
   flex-shrink: 0;
 }
 
-.gram-frame-color-picker-label {
-  font-size: 10px;
-  color: #00ff00;
-  margin-bottom: 6px;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  font-weight: bold;
-  text-align: center;
-}
+/* No `.gram-frame-color-picker-label` rule: the panel's "Style" heading is
+ * gone (each band labels itself), so the caption it styled no longer exists. */
 
 .gram-frame-color-palette {
   position: relative;

--- a/src/modes/analysis/AnalysisMode.js
+++ b/src/modes/analysis/AnalysisMode.js
@@ -68,18 +68,31 @@ function createMarkerLabelButton(marker) {
 }
 
 /**
- * Build the actions cell for a marker row: the label button stacked above the
- * delete button, in the cell that used to hold the delete button alone
- * (feature 231).
+ * Build the Label cell's content: the abbreviated label text, with the label
+ * button floated into the cell's top-right corner.
+ *
+ * The button used to sit above the delete button in the actions cell, which
+ * made every marker row tall enough for two stacked controls (53px against the
+ * harmonics table's 45px). Absolutely positioned here it contributes no height
+ * at all, and it sits beside the thing it edits.
+ *
  * @param {AnalysisMarker} marker - The row's marker
- * @returns {HTMLDivElement} Container holding both controls
+ * @returns {HTMLDivElement} Container holding the label text and its button
  */
-function createMarkerActions(marker) {
-  const actions = document.createElement('div')
-  actions.className = 'gram-frame-marker-actions'
-  actions.appendChild(createMarkerLabelButton(marker))
-  actions.appendChild(createMarkerDeleteButton())
-  return actions
+function createMarkerLabelCell(marker) {
+  const content = document.createElement('div')
+  content.className = 'gram-frame-marker-label-content'
+
+  // The text is its own element so it can be clipped independently of the
+  // button — `getMarkerLabelCell` in the test helpers still reads the cell's
+  // textContent, which the icon-only button leaves untouched.
+  const text = document.createElement('span')
+  text.className = 'gram-frame-marker-label-text'
+  text.textContent = formatMarkerLabelForTable(marker.label)
+
+  content.appendChild(text)
+  content.appendChild(createMarkerLabelButton(marker))
+  return content
 }
 import { formatTime } from '../../utils/timeFormatter.js'
 import { dataToSVG } from '../../utils/coordinates.js'
@@ -500,12 +513,17 @@ export class AnalysisMode extends BaseMode {
     // propagation) comes from the shared component; everything below is what
     // makes this the *markers* table (spec 166, FR-009).
     this.markersTable = createDiffingTable(markersContainer, {
+      // Widths rebalanced when the label button moved into the Label cell: that
+      // column now has to hold an icon as well as the text, and the actions
+      // column no longer stacks two controls, so 3% moves from each of Time,
+      // Freq and actions to Label. Time and Freq both show five characters
+      // ("00:42", "24.71") and still have room for them.
       columns: [
-        { label: '', width: '13%', cellClassName: 'gram-frame-marker-color' },
-        { label: 'Label', width: '22%', cellClassName: 'gram-frame-marker-label-cell' },
-        { label: 'Time (mm:ss)', width: '25%' },
-        { label: 'Freq (Hz)', width: '25%' },
-        { label: '', width: '15%' }
+        { label: '', width: '12%', cellClassName: 'gram-frame-marker-color' },
+        { label: 'Label', width: '30%', cellClassName: 'gram-frame-marker-label-cell' },
+        { label: 'Time (mm:ss)', width: '23%' },
+        { label: 'Freq (Hz)', width: '23%' },
+        { label: '', width: '12%' }
       ],
       rowAttribute: 'data-marker-id',
       rowKey: (marker) => marker.id,
@@ -514,11 +532,12 @@ export class AnalysisMode extends BaseMode {
         // the cross (symbol-less) style shows a filled colour rectangle (FR-010).
         createColorIndicator(marker.symbol, marker.color, 20),
         // Label cell — abbreviated so the column keeps its width; the full text
-        // stays on the gram and in the edit dialog (feature 231).
-        formatMarkerLabelForTable(marker.label),
+        // stays on the gram and in the edit dialog (feature 231). Also carries
+        // the label button, floated top-right.
+        createMarkerLabelCell(marker),
         formatTime(marker.time),
         marker.freq.toFixed(2),
-        createMarkerActions(marker)
+        createMarkerDeleteButton()
       ],
       deleteSelector: '.gram-frame-marker-delete-btn',
       actions: [

--- a/src/modes/pan/PanMode.js
+++ b/src/modes/pan/PanMode.js
@@ -168,6 +168,11 @@ export class PanMode extends BaseMode {
    * Pan is the initial mode, so its guidance carries the global mouse-wheel
    * instructions (which apply in every mode) as their own titled section, plus a
    * section for the pan-specific interactions.
+   *
+   * "available in all modes" is a heading qualifier, not a bullet: it qualifies
+   * the whole section rather than standing beside the individual instructions,
+   * and folding it into the heading buys back a line of the control row's
+   * height.
    * @returns {Object} Structured guidance content (multi-section)
    */
   getGuidanceText() {
@@ -175,6 +180,7 @@ export class PanMode extends BaseMode {
       sections: [
         {
           title: 'Mouse-Wheel',
+          qualifier: 'available in all modes',
           items: WHEEL_NAV_GUIDANCE
         },
         {

--- a/src/utils/secureHTML.js
+++ b/src/utils/secureHTML.js
@@ -9,8 +9,9 @@
 /**
  * A single titled block of guidance bullet points.
  * @typedef {Object} GuidanceSection
- * @property {string} title - The section heading text
- * @property {string[]} items - Array of guidance items (rendered as bullet points)
+ * @property {string} [title] - The section heading text
+ * @property {string} [qualifier] - Aside appended to the heading, in parentheses
+ * @property {string[]} [items] - Array of guidance items (rendered as bullet points)
  */
 
 /**
@@ -35,7 +36,9 @@ function renderSecureGuidance(container, content) {
   container.replaceChildren()
 
   // Normalise to a list of sections so single- and multi-section content share
-  // one render path.
+  // one render path. The single-section form may omit either field, which is
+  // why GuidanceSection marks both optional and why each is guarded below.
+  /** @type {GuidanceSection[]} */
   const sections = Array.isArray(content.sections)
     ? content.sections
     : [{ title: content.title, items: content.items }]
@@ -45,6 +48,16 @@ function renderSecureGuidance(container, content) {
     if (section.title) {
       const title = document.createElement('h4')
       title.textContent = section.title
+      // A qualifier rides the heading rather than taking a bullet of its own —
+      // it describes the whole section, and a bullet costs the control row a
+      // full line. Its own element so the CSS can drop the heading's uppercase
+      // and letter-spacing for it, which is what keeps the two on one line.
+      if (section.qualifier) {
+        const qualifier = document.createElement('span')
+        qualifier.className = 'gram-frame-guidance-qualifier'
+        qualifier.textContent = ` (${section.qualifier})`
+        title.appendChild(qualifier)
+      }
       container.appendChild(title)
     }
 

--- a/src/utils/wheelGuidance.js
+++ b/src/utils/wheelGuidance.js
@@ -4,12 +4,13 @@
  *
  * Wheel zoom/pan and wheel-button drag work in every interaction mode. Rather
  * than repeat these lines in each mode's guidance, they are shown once as the
- * "Mouse-Wheel" section of the initial (Pan) mode's guidance, noting that they
- * apply everywhere (spec 160, FR-012).
+ * "Mouse-Wheel" section of the initial (Pan) mode's guidance (spec 160,
+ * FR-012). That they apply everywhere rides the section TITLE rather than a
+ * bullet of its own — see `PanMode.getGuidanceText` — so the note costs the
+ * control row no height.
  * @type {string[]}
  */
 export const WHEEL_NAV_GUIDANCE = [
-  'Available in all modes',
   'Ctrl + scroll to zoom around the pointer',
   'Scroll to pan when zoomed in',
   'Wheel-button drag to pan when zoomed in'

--- a/tests/marker-labels.spec.js
+++ b/tests/marker-labels.spec.js
@@ -63,19 +63,45 @@ test.describe('Marker labels', () => {
     expect(headers).toContain('Label')
   })
 
-  test('every marker row offers a Label button above its Delete button', async ({ gramFramePage }) => {
+  test('every marker row offers a Label button in the top-right of its Label cell', async ({ gramFramePage }) => {
     const markerId = await placeMarker(gramFramePage, 220, 160)
 
     const row = gramFramePage.page.locator(`tr[data-marker-id="${markerId}"]`)
     await expect(row.locator(LABEL_BUTTON)).toBeVisible()
     await expect(row.locator('.gram-frame-marker-delete-btn')).toBeVisible()
 
-    // "Above" is a layout claim, so measure it rather than assume the markup.
+    // "In the Label cell's top-right corner" is a layout claim, so measure it
+    // rather than assume the markup. The button sits out of flow there so it
+    // costs the row no height — it used to stack above Delete, which made every
+    // row tall enough for two controls.
+    const cellBox = await row.locator('.gram-frame-marker-label-cell').boundingBox()
+    const labelBox = await row.locator(LABEL_BUTTON).boundingBox()
+    expect(cellBox).not.toBeNull()
+    expect(labelBox).not.toBeNull()
+
+    // Right-aligned within the cell, and in its top half.
+    expect(cellBox.x + cellBox.width - (labelBox.x + labelBox.width)).toBeLessThanOrEqual(3)
+    expect(labelBox.y).toBeLessThan(cellBox.y + cellBox.height / 2)
+  })
+
+  test('the label button does not make the row taller than the controls beside it', async ({ gramFramePage }) => {
+    // Enough markers to overflow the fixed-height table body. Below that the
+    // rows stretch to fill it, and their height says nothing about what the
+    // content needs — which is the thing under test.
+    let markerId = null
+    for (let i = 0; i < 6; i++) {
+      markerId = await placeMarker(gramFramePage, 150 + i * 20, 120 + i * 15)
+    }
+
+    const row = gramFramePage.page.locator(`tr[data-marker-id="${markerId}"]`)
+    const rowBox = await row.boundingBox()
     const labelBox = await row.locator(LABEL_BUTTON).boundingBox()
     const deleteBox = await row.locator('.gram-frame-marker-delete-btn').boundingBox()
-    expect(labelBox).not.toBeNull()
-    expect(deleteBox).not.toBeNull()
-    expect(labelBox.y + labelBox.height).toBeLessThanOrEqual(deleteBox.y + 1)
+
+    // The row only ever has to be as tall as ONE control plus the cell padding.
+    // Were the label button back in the flow above Delete, the row would need
+    // room for both and this would fail.
+    expect(rowBox.height).toBeLessThan(labelBox.height + deleteBox.height)
   })
 
   // ──────────────────────────────────────────────────────────

--- a/tests/table-scroll.spec.js
+++ b/tests/table-scroll.spec.js
@@ -126,6 +126,67 @@ test.describe('Markers/harmonics tables: fixed height with a scrolling body', ()
     }
   })
 
+  test('rows keep the height they start with as more are added', async ({ page }) => {
+    const gfp = await gotoDemo(page)
+
+    /** First row's height after each addition. */
+    const heights = []
+    for (let i = 0; i < 6; i++) {
+      await gfp.addMarker(i * 2, 100 + i * 10)
+      await gfp.waitForTableRowCount('markers', i + 1)
+      heights.push(await page.evaluate((sel) => {
+        const row = document.querySelector(`${sel} tbody tr`)
+        return Math.round(row.getBoundingClientRect().height)
+      }, MARKERS_TABLE))
+    }
+
+    // One row and six rows are the same height. They used to shrink with every
+    // addition — the table inherited `height: 100%` from the class the outer
+    // frame also uses, so it shared the container's surplus out across however
+    // many rows there happened to be.
+    expect(new Set(heights).size).toBe(1)
+  })
+
+  test('a newly added row is scrolled into view once the table overflows', async ({ page }) => {
+    const gfp = await gotoDemo(page)
+    await fillBothPanels(gfp, MANY_ROWS)
+
+    for (const selector of [MARKERS_TABLE, HARMONICS_TABLE]) {
+      const metrics = await page.evaluate((sel) => {
+        const container = document.querySelector(sel)
+        const rows = container.querySelectorAll('tbody tr')
+        const last = rows[rows.length - 1]
+        return {
+          overflowing: container.scrollHeight > container.clientHeight,
+          lastRowBottom: last.offsetTop + last.offsetHeight,
+          viewportBottom: container.scrollTop + container.clientHeight
+        }
+      }, selector)
+
+      // There is more content than fits...
+      expect(metrics.overflowing).toBe(true)
+      // ...and the row just added is inside the visible band, not below it.
+      expect(metrics.lastRowBottom).toBeLessThanOrEqual(metrics.viewportBottom + 1)
+    }
+  })
+
+  test('scrolling back up is not undone by an update that adds no rows', async ({ page }) => {
+    const gfp = await gotoDemo(page)
+    await fillBothPanels(gfp, MANY_ROWS)
+
+    // Auto-scroll left both tables at the bottom; the analyst scrolls back up.
+    await page.evaluate((sel) => { document.querySelector(sel).scrollTop = 0 }, MARKERS_TABLE)
+
+    // Selecting a row re-renders the table. Nothing was added, so the scroll
+    // position is the analyst's to keep. The helper waits on the selection
+    // reaching broadcast state, so the re-render has happened by the time the
+    // scroll position is read.
+    const markers = (await gfp.getState()).analysis.markers
+    await gfp.clickTableRow('markers', markers[0].id)
+
+    expect(await page.evaluate((sel) => document.querySelector(sel).scrollTop, MARKERS_TABLE)).toBe(0)
+  })
+
   test('the header row stays pinned while the body scrolls under it', async ({ page }) => {
     const gfp = await gotoDemo(page)
     await fillBothPanels(gfp, MANY_ROWS)
@@ -137,6 +198,10 @@ test.describe('Markers/harmonics tables: fixed height with a scrolling body', ()
         // The sticky boxes are the header cells themselves
         const headerCell = table.tHead.rows[0].cells[1]
         const containerTop = container.getBoundingClientRect().top
+
+        // Start from the top: filling the panels leaves the body auto-scrolled
+        // to the newest row, and this test is about scrolling DOWN from rest.
+        container.scrollTop = 0
         const headerTopBefore = headerCell.getBoundingClientRect().top
         const firstRowBefore = table.tBodies[0].rows[0].getBoundingClientRect().top
 


### PR DESCRIPTION
Four commits, all on the same theme — the component claiming more vertical space than the host's pages want, and behaving restlessly while it does it.

## 1–2. The control row (commits 1 and 2)

Measured on `debug.html` at a 1500px viewport, the row drops **229px → 208px**.

- **The style panel's "Style" heading is gone** (`ColorPicker.js`). Each band inside labels itself, so the caption restated what the panel said three times over.
- **The colour band's "Colour" caption is gone too.** It named the gradient slider, and a full-width spectrum needs no naming. Symbol and Harmonics keep theirs — a drop-down and a checkbox do not announce their own scope. Style panel **130px → 98px**.
- **The doppler readout is now "Doppler Speed (kts)", label-beside-value over two lines** (`MainUI.js`, `gramframe.css`). The caption is long enough to claim a row of its own, so stacking the value beneath it left the space either side of "0.0" empty. LED **44px → 32px**.
- **"available in all modes" moved from a bullet into the wheel guidance's heading** (`PanMode.js`, `wheelGuidance.js`, `secureHTML.js`). It qualifies the whole Mouse-Wheel section rather than standing beside the three instructions. `GuidanceSection` grows an optional `qualifier`, rendered as a `<span>` inside the `<h4>`.

## 3. The two panel headings (commit 3)

The markers and harmonics headings did not match, in three ways:

- The underline lived on the `h4`. The markers `h4` is a block filling its column so it drew a full-width rule; the harmonics `h4` is a flex item beside the + Manual button so it drew one only as wide as the word.
- The + Manual button stood 28px against the heading's 21px, pushing the harmonics heading out of line with the markers one.
- At its 80px width floor the button was too wide for the 175px column, so it **overlapped** the heading beside it.

Both panels now use one `.gram-frame-panel-header` row carrying the rule, the spacing and a `min-height`, with an optional action slot on the right; the `h4` carries only type. The + Manual button is sized to fit that row (10px text, 3px/6px padding, no width floor).

## 4. The marker row height (commit 3)

The actions cell stacked the label button above the delete button, so every row had to be tall enough for two controls. The label button moves into the Label cell, absolutely positioned in its top-right corner — out of the flow it costs the row no height, and it sits in the column it edits. Content row height **50px → 31px**.

Column widths rebalanced to suit: 3% moves from each of Time, Freq and actions into Label (22% → 30%). Without that, a five-character label like "Sub 7" clipped to "Su..".

## 5. Rows that resized, and rows added out of sight (commit 4)

Rows started tall and shrank with every addition. `.gram-frame-table` sets `height: 100%` for the component's outer frame `<div>`, and the real `<table>` elements carry the same class — so each table was also told to fill its container and shared the surplus across its rows (two rows drew 50px each, six drew 31px). The element-qualified `table.gram-frame-table` rule already existed to undo the frame's *border* for this same reason; it now sets `height: auto` as well.

The tables have a fixed-height body, so once the list overflowed a new row was appended out of sight with only a slightly shorter scrollbar as feedback. `DiffingTable` now tracks the row keys it drew last time and scrolls the last genuinely new one into view.

Three things the auto-scroll deliberately does not do:

- **Scroll on the first population** — that is a restore from storage or the initial render, where the top of the list is the right place to be.
- **Scroll up.** A row already visible leaves the position alone, so an update that adds nothing cannot yank the analyst back.
- **Use `scrollIntoView`**, which would scroll every scrollable ancestor including the host page. It sets `scrollTop` on the table's own wrapper instead.

## Notes for reviewers

Three details are load-bearing and easy to undo by accident:

- **The doppler label's first space is a non-breaking one**, written as a ` ` escape so it stays visible in the source. `width: min-content` breaks at every ordinary space, so without it the shorter caption still stacks three lines. The label stays a **single text node** — the wrap is CSS, not markup — so the `.gram-frame-led-label:text-is("Doppler Speed (kts)")` locators in `tests/helpers/gram-frame-page.js` still match it. Playwright normalises ` ` to a plain space.
- **The heading qualifier drops the heading's `text-transform: uppercase` and `letter-spacing`.** At the guidance column's width, an uppercase letter-spaced qualifier wraps the heading onto a second line, giving back exactly the height that moving it out of the bullet list saved.
- **`.gram-frame-marker-label-content` is `position: static` on purpose.** The label button anchors to the *cell*, whose top-right corner it wants; that wrapper is only as tall as the label text and sits vertically centred, so positioning against it parks the button halfway down.

`GuidanceSection.title` and `.items` are now marked optional. That is not a loosening — the single-section form has always been able to omit either and `renderSecureGuidance` already guards both; the typedef just said otherwise, and adding `qualifier` made `tsc` notice.

## Tests

Four added, one amended:

- the label button sits in the Label cell's top-right, and does not make the row taller than the controls beside it (it places six markers first — below that the rows stretch to fill the fixed-height body and their height says nothing about what the content needs);
- rows keep the height they start with as more are added;
- a newly added row lands inside the visible band, in both tables;
- a scroll position survives an update that adds no rows.

The pinned-header test now scrolls from the top explicitly. Filling the panels leaves the body auto-scrolled to the newest row, and that test is about scrolling *down* from rest — an assumption it previously got for free and now has to state.

- `yarn typecheck` — clean
- `yarn lint` — clean
- `yarn hygiene` — passed, all five ratchets at baseline
- `yarn test:unit` — 124 passed
- `yarn test` — 300 passed

The Playwright runs needed a local `executablePath` override: this container ships Chromium build 1194 while the pinned `@playwright/test` wants 1181. The override was a scratch config, not committed. The WebKit smoke lane could not be run locally at all — no WebKit build in this container — so that one rests on CI.