### PR TITLE
Make doppler markers grabbable, and show the cursor when they are

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,15 @@ There is no visual/screenshot regression testing — see
   like — pan keeps the hand, every feature drag takes the hollow brackets from
   `utils/cursors.js`. Hover goes through `applyCursor` like every other
   transition, so a mode's opinion covers it too
+- The chosen cursor is applied to the **SVG root** (`BaseMode.updateCursorStyle`,
+  inherited by every mode), never to the `<image>` inside it. `cursor` resolves
+  on whatever element the pointer hits, and features are drawn over the image as
+  its siblings — styling the image leaves the cursor unchanged over the very
+  feature being aimed at
+- Hit-test tolerance (`utils/tolerance.js`) is a pixel radius, not a data-space
+  range: 8 rendered pixels on each axis at any zoom and any gram span. Clamps
+  expressed in seconds and hertz cannot say "8 pixels" and silently shrank the
+  grab region below the size of the drawn glyph
 - `core/state.js` imports no mode. `ModeFactory.getModeInitialStates()` composes
   the initial-state slices and `createInitialState(modeStates)` receives them;
   mode slices are additive and can never overwrite a core key (ADR-014)

--- a/docs/Bug-Hunt-2026-08.md
+++ b/docs/Bug-Hunt-2026-08.md
@@ -4,9 +4,11 @@
 > order below was implemented in full: BH-1 – BH-13, BH-15 – BH-19, BH-21,
 > BH-23 – BH-25 and BH-31 – BH-33 are **fixed**, with regression tests for the
 > headliners in `tests/storage.spec.js` ("Bug-hunt regressions") and
-> `tests/unit/storage-validation.test.js`. Still open, deliberately: BH-14
+> `tests/unit/storage-validation.test.js`. BH-22 was fixed later, once a live
+> report of an ungrabbable Doppler marker confirmed it — see its entry below.
+> Still open, deliberately: BH-14
 > (multi-tab last-writer-wins — needs a `storage`-event merge design), BH-20
-> (config coercions), BH-22 (tolerance vs axis span — needs a fixture), BH-26
+> (config coercions), BH-26
 > (rate ≠ 1, latent by agreement), BH-27/BH-28 (formatTime/axis label polish),
 > BH-29 (button zoom-out centre) and BH-30 (style-picker default dispatches).
 
@@ -46,7 +48,7 @@ All findings verified against commit `91656a5` (code unchanged by the docs/tests
 | BH-19 | "Clear gram" leaves the doppler speed LED and style controls stale | Medium | Confirmed |
 | BH-20 | Silent config coercions: blank cell → 0, `"1,5"` → 1 | Medium | Confirmed |
 | BH-21 | Version-mismatch deletes forward data on read; re-save strips additive fields | Medium | Confirmed |
-| BH-22 | Hit-test tolerance floors/ceilings ignore the axis span | Medium | Plausible |
+| BH-22 | Hit-test tolerance floors/ceilings ignore the axis span | Medium | Confirmed (fixed) |
 | BH-23 | No image/config fingerprint: republished content inherits stale annotations | Medium | Plausible |
 | BH-24–33 | Ten low/latent findings | Low | Mixed |
 
@@ -104,7 +106,9 @@ The storage key is `pathname` + instance index (`storage.js:157-163`), where the
 ### Configuration and geometry
 - **BH-19 — "Clear gram" leaves derived UI stale.** It rebuilds state slices but skips both `updateSpeedLED` (its "refresh LEDs" call targets `modeLED`/`rateLED`, which are never assigned — a no-op) and `clearSelection()` (it replaces the selection object instead), so the doppler LED keeps the deleted curve's speed and the style controls keep the deleted feature's state — including a Pin toggle stuck disabled if a marker was selected (`main.js:371-411`, vs the right-click reset sibling `DopplerMode.js:475-480` which does call `updateSpeedLED`).
 - **BH-20 — Silent config coercions** (`configuration.js:53-59`): an empty value cell becomes `'0'` (`textContent?.trim() || '0'`) — a blank `time-start` yields a plausible-looking 0–60 axis with no warning; `parseFloat` partial parsing turns the European decimal comma `"1,5"` into `1` (halved axis). Duplicate parameter rows: last silently wins. (Range validation itself is good — missing rows, zero and inverted ranges all throw loudly.)
-- **BH-22 — Tolerance floors/ceilings ignore the axis span** (`tolerance.js:32-47`). Wide-band at zoom 1: the 50 Hz ceiling is ~2.5 px of grab radius on a 0–20 kHz/1000 px gram — features are hard to grab. Narrow-band: the 1 Hz floor is 10% of a 0–10 Hz axis and zoom can never shrink it, so two features 0.9 Hz apart are never disambiguable — the `/effectiveZoom` term is dead once floored. Plausible (arithmetic confirmed; UX impact needs a fixture).
+- **BH-22 — Tolerance floors/ceilings ignore the axis span** (`tolerance.js:32-47`). Wide-band at zoom 1: the 50 Hz ceiling is ~2.5 px of grab radius on a 0–20 kHz/1000 px gram — features are hard to grab. Narrow-band: the 1 Hz floor is 10% of a 0–10 Hz axis and zoom can never shrink it, so two features 0.9 Hz apart are never disambiguable — the `/effectiveZoom` term is dead once floored.
+
+  **Confirmed and fixed.** The fixture the entry asked for arrived as a field report: a Doppler marker that could not be picked up at all. The *time* ceiling is the sharper edge of the same bug — 0.5 s on the debug gram (237 px over 60 s) is under 2 px, so the grab band down the time axis was narrower than the 8 px dot drawn on it, and an analyst dead centre on a marker could miss it by 3 px. Both clamps are gone: the tolerance is now exactly `pixelRadius` (8) rendered pixels on each axis at every zoom and every span, which is what the constant always claimed. Pinned by `tests/unit/tolerance.test.js` (radius holds across zoom and span) and `tests/doppler-hotspot.spec.js` (every pixel of a drawn marker grabs it).
 - **BH-23 — No image/config fingerprint in stored records** (`storage.js:237-277`). Republishing a lesson with a different recording at the same path restores old markers onto the new image at coordinates that meant something else — no way to detect the swap. Distinct from BH-6: corrupts meaning even with stable indices.
 
 ---

--- a/src/gramframe.css
+++ b/src/gramframe.css
@@ -1360,6 +1360,16 @@ table.gram-frame-table {
   pointer-events: none;
 }
 
+/*
+ * The vertical extensions are drawn after the f+/f- dots, so while they were
+ * hit-testable they sat on top of the very markers the analyst was aiming at.
+ * Doppler hit-testing is done in data space against the marker positions, not
+ * by hitting an element, so nothing needs these to be targets.
+ */
+.gram-frame-doppler-extension {
+  pointer-events: none;
+}
+
 .gram-frame-doppler-guide {
   pointer-events: none;
 }

--- a/src/modes/BaseMode.js
+++ b/src/modes/BaseMode.js
@@ -215,12 +215,21 @@ export class BaseMode {
   }
 
   /**
-   * Update cursor style for drag operations
+   * Update cursor style for drag operations.
+   *
+   * The style goes on the SVG root, not on the `<image>` inside it. `cursor` is
+   * resolved on whatever element the pointer actually hits, and a feature is
+   * drawn *over* the image as a sibling of it — a marker circle, a harmonic
+   * pin, a Doppler curve. Styling the image therefore left the cursor unchanged
+   * at exactly the moment it mattered: over the feature itself, where the hit
+   * element inherited the SVG's resting `crosshair` instead. On the root, every
+   * descendant inherits the value, so the affordance holds wherever the pointer
+   * is inside the component.
    * @param {string} style - A CSS cursor value, as resolved by `utils/cursors.js`
    */
   updateCursorStyle(style) {
-    if (this.instance.ui.spectrogramImage) {
-      this.instance.ui.spectrogramImage.style.cursor = style
+    if (this.instance.ui.svg) {
+      this.instance.ui.svg.style.cursor = style
     }
   }
 }

--- a/src/modes/analysis/AnalysisMode.js
+++ b/src/modes/analysis/AnalysisMode.js
@@ -221,16 +221,6 @@ export class AnalysisMode extends BaseMode {
   }
 
   /**
-   * Update cursor style for drag operations
-   * @param {string} style - A CSS cursor value, as resolved by `utils/cursors.js`
-   */
-  updateCursorStyle(style) {
-    if (this.instance.ui.svg) {
-      this.instance.ui.svg.style.cursor = style
-    }
-  }
-
-  /**
    * Get guidance content for analysis mode
    * @returns {Object} Structured guidance content
    */

--- a/src/modes/harmonics/HarmonicsMode.js
+++ b/src/modes/harmonics/HarmonicsMode.js
@@ -127,16 +127,6 @@ export class HarmonicsMode extends BaseMode {
   }
 
   /**
-   * Update cursor style for drag operations
-   * @param {string} style - A CSS cursor value, as resolved by `utils/cursors.js`
-   */
-  updateCursorStyle(style) {
-    if (this.instance.ui.svg) {
-      this.instance.ui.svg.style.cursor = style
-    }
-  }
-
-  /**
    * Color palette for harmonic sets
    * @type {string[]}
    */

--- a/src/modes/pan/PanMode.js
+++ b/src/modes/pan/PanMode.js
@@ -27,7 +27,7 @@ export class PanMode extends BaseMode {
       onDragMove: (_target, _position, _startPosition, event) => this.onPanMove(event),
       onDragEnd: () => this.onPanEnd(),
       onDragCancel: () => this.onPanEnd(),
-      updateCursor: (style) => this.applyCursor(style),
+      updateCursor: (style) => this.updateCursorStyle(style),
       // A pan keeps the hand, rather than the hollow brackets feature drags use:
       // there is no target under the pointer for it to obscure.
       cursorFor: (kind, phase) => {
@@ -55,16 +55,6 @@ export class PanMode extends BaseMode {
    */
   idleCursor() {
     return this.instance.state.zoom.level > 1.0 ? PAN_IDLE_CURSOR : IDLE_CURSOR
-  }
-
-  /**
-   * Apply a cursor style to the SVG.
-   * @param {string} style - Cursor style
-   */
-  applyCursor(style) {
-    if (this.instance.ui.svg) {
-      this.instance.ui.svg.style.cursor = style
-    }
   }
 
   /**
@@ -102,7 +92,7 @@ export class PanMode extends BaseMode {
    * Restore the resting cursor when the pan finishes.
    */
   onPanEnd() {
-    this.applyCursor(this.idleCursor())
+    this.updateCursorStyle(this.idleCursor())
   }
 
   /**
@@ -111,7 +101,7 @@ export class PanMode extends BaseMode {
   activate() {
     // Set cursor to grab if zoomed
     if (this.instance.state.zoom.level > 1.0) {
-      this.applyCursor(PAN_IDLE_CURSOR)
+      this.updateCursorStyle(PAN_IDLE_CURSOR)
     }
 
     // Reset any existing drag state
@@ -124,7 +114,7 @@ export class PanMode extends BaseMode {
   deactivate() {
     // Clear drag state, then reset the cursor
     this.dragHandler.reset()
-    this.applyCursor(IDLE_CURSOR)
+    this.updateCursorStyle(IDLE_CURSOR)
   }
 
   /**

--- a/src/utils/tolerance.js
+++ b/src/utils/tolerance.js
@@ -19,30 +19,35 @@
 /**
  * The tunable constants behind `calculateDataTolerance`.
  * @typedef {Object} ToleranceConfig
- * @property {number} pixelRadius - Drag/click radius in SVG coordinate space
- * @property {DataTolerance} minDataTolerance - Floor, so high zoom does not make interactions hair-trigger
- * @property {DataTolerance} maxDataTolerance - Ceiling, so low zoom does not make them insensitive
+ * @property {number} pixelRadius - Drag/click radius, in rendered image pixels
+ * @property {DataTolerance} fallbackDataTolerance - Used only when the viewport
+ *   is missing or degenerate and no pixel-derived value can be computed
  */
 
 /**
- * Default tolerance configuration
- * @type {Object}
+ * Default tolerance configuration.
+ *
+ * `pixelRadius` is the whole policy: a feature is grabbable within 8 rendered
+ * pixels of its position, on either axis, at any zoom and for any data range.
+ *
+ * There are deliberately no absolute data-space clamps. There used to be
+ * (`maxDataTolerance: { time: 0.5, freq: 50 }`), and because a gram's data
+ * range per pixel varies enormously between configs, that ceiling silently
+ * shrank the hotspot to a fraction of its intended size on ordinary material:
+ * on a 237px-tall gram spanning 60s, 0.5s is under 2px, so the grab band down
+ * the time axis was *narrower than the marker glyph drawn on it* (issue: a
+ * Doppler marker that could not be picked up). A ceiling expressed in seconds
+ * and hertz cannot express "8 pixels"; the pixel radius already does.
+ * @type {ToleranceConfig}
  */
-/** @type {ToleranceConfig} */
 const DEFAULT_TOLERANCE = {
-  // Pixel tolerance for drag/click detection (in SVG coordinate space)
+  // Hit radius in rendered image pixels, applied to both axes
   pixelRadius: 8,
-  
-  // Minimum data space tolerance (prevents overly sensitive interactions at high zoom)
-  minDataTolerance: {
-    time: 0.01,  // 0.01 seconds minimum
-    freq: 1.0    // 1 Hz minimum
-  },
-  
-  // Maximum data space tolerance (prevents insensitive interactions at low zoom)
-  maxDataTolerance: {
-    time: 0.5,   // 0.5 seconds maximum
-    freq: 50.0   // 50 Hz maximum
+
+  // Only reached when the viewport cannot be read at all
+  fallbackDataTolerance: {
+    time: 0.01,
+    freq: 1.0
   }
 }
 
@@ -55,12 +60,11 @@ const DEFAULT_TOLERANCE = {
  */
 function calculateDataTolerance(viewport, spectrogramImage, customTolerance = {}) {
   const config = { ...DEFAULT_TOLERANCE, ...customTolerance }
-  
+
   if (!viewport || !spectrogramImage) {
-    // Fallback to minimum tolerance if viewport/image unavailable
-    return config.minDataTolerance
+    return config.fallbackDataTolerance
   }
-  
+
   const { config: dataConfig, imageDetails, zoom } = viewport
   const { naturalWidth, naturalHeight } = imageDetails
   // Base render size (defaults to natural; grows when expanded)
@@ -68,34 +72,21 @@ function calculateDataTolerance(viewport, spectrogramImage, customTolerance = {}
   const renderHeight = imageDetails.renderHeight || naturalHeight
 
   if (!dataConfig || !renderWidth || !renderHeight) {
-    return config.minDataTolerance
+    return config.fallbackDataTolerance
   }
 
   // Calculate pixel-to-data conversion factors
   const timeRange = dataConfig.timeMax - dataConfig.timeMin
   const freqRange = dataConfig.freqMax - dataConfig.freqMin
 
-  // Account for zoom level - higher zoom means smaller pixel tolerance in data space
+  // Zooming in draws the same data over more pixels, so the same on-screen
+  // radius covers proportionally less data. Dividing by the zoom level is what
+  // keeps the grab radius a constant *visual* size at every zoom.
   const effectiveZoom = zoom?.level || 1.0
 
-  // Convert pixel tolerance to data space (relative to the rendered image size)
-  const timeToleranceFromPixels = (config.pixelRadius / renderHeight) * timeRange / effectiveZoom
-  const freqToleranceFromPixels = (config.pixelRadius / renderWidth) * freqRange / effectiveZoom
-  
-  // Apply min/max constraints
-  const timeTolerance = Math.max(
-    config.minDataTolerance.time,
-    Math.min(config.maxDataTolerance.time, timeToleranceFromPixels)
-  )
-  
-  const freqTolerance = Math.max(
-    config.minDataTolerance.freq,
-    Math.min(config.maxDataTolerance.freq, freqToleranceFromPixels)
-  )
-  
   return {
-    time: timeTolerance,
-    freq: freqTolerance
+    time: (config.pixelRadius / renderHeight) * timeRange / effectiveZoom,
+    freq: (config.pixelRadius / renderWidth) * freqRange / effectiveZoom
   }
 }
 
@@ -164,7 +155,10 @@ export function findClosestTarget(position, targets, tolerance) {
 
 
 /**
- * Get uniform tolerance calculation for all modes
+ * Get uniform tolerance calculation for all modes.
+ *
+ * Every mode's hit test goes through here, so "how close counts as on it" is
+ * one answer rather than four.
  * @param {Viewport} viewport - Viewport configuration
  * @param {HTMLElement|SVGImageElement} spectrogramImage - Spectrogram image element
  * @returns {DataTolerance} Tolerance object with time and freq properties

--- a/tests/cursor-hover.spec.js
+++ b/tests/cursor-hover.spec.js
@@ -18,6 +18,10 @@ const BRACKET_CURSOR = /^url\("data:image\/svg\+xml/
 
 /**
  * Read the cursor style currently applied to the component's SVG.
+ *
+ * The SVG root is deliberately the only element checked: `cursor` is resolved
+ * on whatever the pointer hits, and features are drawn over the image, so the
+ * root is the one place a value reaches every one of them by inheritance.
  * @param {import('./helpers/gram-frame-page.js').default} gramFramePage - Page object
  * @returns {Promise<string>} The inline cursor style
  */
@@ -86,6 +90,34 @@ test.describe('Cursor over a draggable feature', () => {
     const overSet = await svgCursor(gramFramePage)
     expect(overSet).toMatch(BRACKET_CURSOR)
     expect(overSet).not.toContain('grab')
+  })
+
+  test('a doppler marker takes the hollow cursor', async ({ gramFramePage }) => {
+    await gramFramePage.clickMode('Doppler')
+    await gramFramePage.waitForImageDimensions()
+
+    // Drag out a curve, which places f+ and f- at the drag's two ends.
+    await gramFramePage.startDragSVG(200, 100)
+    await gramFramePage.endDragSVG(300, 200)
+    await gramFramePage.waitForState((state) => !!(state.doppler.fPlus && state.doppler.fMinus))
+
+    // Off the markers: the resting crosshair.
+    await gramFramePage.moveMouseToSpectrogram(450, 250)
+    expect(await svgCursor(gramFramePage)).toBe('crosshair')
+
+    // Dead centre of a marker's own glyph. This is what regressed: doppler was
+    // the one mode still styling the `<image>` rather than the SVG root, so the
+    // marker — sitting on top of the image — kept the SVG's crosshair.
+    const marker = gramFramePage.page.locator('.gram-frame-doppler-fMinus')
+    const box = await marker.boundingBox()
+    await gramFramePage.page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+
+    const overMarker = await svgCursor(gramFramePage)
+    expect(overMarker).toMatch(BRACKET_CURSOR)
+    expect(overMarker).not.toContain('grab')
+
+    await gramFramePage.moveMouseToSpectrogram(450, 250)
+    expect(await svgCursor(gramFramePage)).toBe('crosshair')
   })
 
   test('panning keeps the hand — there is no feature under it to hide', async ({ gramFramePage }) => {

--- a/tests/doppler-hotspot.spec.js
+++ b/tests/doppler-hotspot.spec.js
@@ -1,0 +1,129 @@
+import { test, expect } from './helpers/fixtures.js'
+
+/**
+ * @fileoverview E2E tests for the grab region ("hotspot") of a Doppler marker.
+ *
+ * A marker that is drawn is a marker that can be picked up: anywhere on an
+ * f+/f- dot must start a drag. The hit test used to run against a tolerance
+ * clamped in seconds (0.5s), which on the debug gram — 237px tall over 60s —
+ * is under 2px. The grab band down the time axis was therefore *narrower than
+ * the 8px dot drawn on it*: the analyst could be dead centre on a marker,
+ * 3px above its middle, and the mousedown would resolve to nothing at all.
+ *
+ * Debug config spans freq 0-100 Hz over time 0-60 s.
+ */
+
+/**
+ * Place an f+/f- pair by dragging, and return the f- dot's on-screen box.
+ * @param {import('./helpers/gram-frame-page.js').default} gfp - Page helper
+ * @returns {Promise<{x: number, y: number, width: number, height: number}>} The dot's client rect
+ */
+async function drawCurveAndLocateMarker(gfp) {
+  await gfp.clickMode('Doppler')
+  await gfp.waitForImageDimensions()
+  // Keep the whole component on screen: a drag towards a point outside the
+  // window leaves the SVG, which cancels the placement for unrelated reasons.
+  await gfp.svg.scrollIntoViewIfNeeded()
+
+  await gfp.startDragSVG(200, 100)
+  await gfp.endDragSVG(300, 200)
+  await gfp.waitForState((state) => !!(state.doppler.fPlus && state.doppler.fMinus))
+
+  const box = await gfp.page.locator('.gram-frame-doppler-fMinus').boundingBox()
+  expect(box).not.toBeNull()
+  return box
+}
+
+/**
+ * Press at a client point and report whether it started a marker drag.
+ * @param {import('./helpers/gram-frame-page.js').default} gfp - Page helper
+ * @param {number} x - Client X
+ * @param {number} y - Client Y
+ * @returns {Promise<{active: boolean, kind: string|null}>} The drag projection at mousedown
+ */
+async function pressAt(gfp, x, y) {
+  await gfp.page.mouse.move(x, y)
+  await gfp.page.mouse.down()
+  const state = await gfp.getState()
+  await gfp.page.mouse.up()
+  return { active: !!state.drag.active, kind: state.drag.kind }
+}
+
+test.describe('Doppler marker hotspot', () => {
+  test('every pixel of the drawn dot grabs the marker', async ({ gramFramePage }) => {
+    const box = await drawCurveAndLocateMarker(gramFramePage)
+
+    const cx = box.x + box.width / 2
+    const cy = box.y + box.height / 2
+    // Half a pixel inside each edge, so the probe is unambiguously on the glyph.
+    const dx = box.width / 2 - 0.5
+    const dy = box.height / 2 - 0.5
+
+    /** @type {Array<[string, number, number]>} */
+    const probes = [
+      ['centre', 0, 0],
+      ['top', 0, -dy],
+      ['bottom', 0, dy],
+      ['left', -dx, 0],
+      ['right', dx, 0]
+    ]
+
+    for (const [where, offsetX, offsetY] of probes) {
+      const drag = await pressAt(gramFramePage, cx + offsetX, cy + offsetY)
+      expect(drag, `pressing the ${where} of the marker should grab it`).toEqual({
+        active: true,
+        kind: 'move'
+      })
+    }
+  })
+
+  test('the grab region reaches the full 8px radius on both axes', async ({ gramFramePage }) => {
+    const box = await drawCurveAndLocateMarker(gramFramePage)
+    const cx = box.x + box.width / 2
+    const cy = box.y + box.height / 2
+
+    // The documented radius is 8 rendered pixels. Probe just inside it on the
+    // time axis, which is the axis the old seconds-based ceiling collapsed.
+    expect(await pressAt(gramFramePage, cx, cy - 7)).toEqual({ active: true, kind: 'move' })
+    expect(await pressAt(gramFramePage, cx, cy + 7)).toEqual({ active: true, kind: 'move' })
+    expect(await pressAt(gramFramePage, cx - 7, cy)).toEqual({ active: true, kind: 'move' })
+    expect(await pressAt(gramFramePage, cx + 7, cy)).toEqual({ active: true, kind: 'move' })
+  })
+
+  test('a press well clear of every marker grabs nothing', async ({ gramFramePage }) => {
+    const box = await drawCurveAndLocateMarker(gramFramePage)
+    const cx = box.x + box.width / 2
+    const cy = box.y + box.height / 2
+
+    // Far enough out that no marker's region reaches, so the widened tolerance
+    // has not simply made the whole gram grabbable.
+    const drag = await pressAt(gramFramePage, cx + 60, cy + 40)
+    expect(drag.active).toBe(false)
+  })
+
+  test('dragging a marker moves it, and moves only it', async ({ gramFramePage }) => {
+    const box = await drawCurveAndLocateMarker(gramFramePage)
+
+    const before = await gramFramePage.getState()
+    const cx = box.x + box.width / 2
+    const cy = box.y + box.height / 2
+
+    await gramFramePage.page.mouse.move(cx, cy)
+    await gramFramePage.page.mouse.down()
+    await gramFramePage.page.mouse.move(cx + 40, cy - 20, { steps: 5 })
+    await gramFramePage.page.mouse.up()
+
+    const after = await gramFramePage.getState()
+
+    // f- followed the pointer: right is up in frequency, up is later in time.
+    expect(after.doppler.fMinus.freq).toBeGreaterThan(before.doppler.fMinus.freq)
+    expect(after.doppler.fMinus.time).toBeGreaterThan(before.doppler.fMinus.time)
+
+    // f+ stayed put, and f₀ is not dragged along with its neighbours.
+    expect(after.doppler.fPlus).toEqual(before.doppler.fPlus)
+    expect(after.doppler.fZero).toEqual(before.doppler.fZero)
+
+    // The drag ended cleanly rather than leaving the marker chasing the cursor.
+    expect(after.drag.active).toBe(false)
+  })
+})

--- a/tests/doppler-mode.spec.js
+++ b/tests/doppler-mode.spec.js
@@ -1,825 +1,414 @@
 import { test, expect } from './helpers/fixtures.js'
-import { 
-  expectValidMetadata, 
+import {
+  expectValidMetadata,
   expectValidMode,
   expectValidConfig,
-  expectValidImageDetails 
+  expectValidImageDetails
 } from './helpers/state-assertions.js'
 
 /**
- * @fileoverview Comprehensive E2E tests for Doppler Mode functionality
- * Tests Doppler marker placement, dragging, speed calculations, and UI interactions
+ * @fileoverview E2E tests for Doppler mode: marker placement, dragging, speed
+ * calculation, persistence across modes and reset.
+ *
+ * Every interaction here is positioned from the drawn gram's own bounding box.
+ * These tests used to drive `page.mouse` at absolute page coordinates like
+ * (200, 150), which on the debug page sit some 390px *above* the component —
+ * no marker was ever placed, and each assertion was wrapped in an
+ * `if (state.doppler.fPlus)` or bailed out with an early `return`, so the whole
+ * suite passed while exercising nothing. Assertions are unconditional now: if a
+ * placement stops working, these fail.
+ *
+ * Debug config spans freq 0-100 Hz across the image and time 0-60 s bottom-up.
  */
 
+const FREQ_SPAN = 100
+const TIME_SPAN = 60
+
 /**
- * Doppler Mode test suite
- * @description Tests Doppler marker placement, dragging, speed calculations, and UI interactions
+ * The drawn gram's rectangle in client coordinates.
+ *
+ * Scrolls the component fully into view first. The debug page puts the gram low
+ * enough that its bottom edge can sit below the viewport, and a drag towards a
+ * point outside the window leaves the SVG — which correctly cancels the drag,
+ * but for reasons that have nothing to do with what is being tested.
+ * @param {import('./helpers/gram-frame-page.js').default} gfp - Page helper
+ * @returns {Promise<{x: number, y: number, width: number, height: number}>} Client rect
  */
-test.describe('Doppler Mode - Comprehensive E2E Tests', () => {
-  /**
-   * Setup before each test - switch to Doppler mode
-   * @param {TestParams} params - Test parameters
-   * @param {import('./helpers/gram-frame-page.js').default} params.gramFramePage - GramFrame page object
-   * @returns {Promise<void>}
-   */
+async function gramRect(gfp) {
+  await gfp.svg.scrollIntoViewIfNeeded()
+  const box = await gfp.page.locator('.gram-frame-spectrogram-image').boundingBox()
+  expect(box).not.toBeNull()
+  return box
+}
+
+/**
+ * A client point at a fraction across and down the drawn gram.
+ * @param {{x: number, y: number, width: number, height: number}} rect - Gram rect
+ * @param {number} fx - Fraction across (0 = left edge, 1 = right edge)
+ * @param {number} fy - Fraction down (0 = top edge, 1 = bottom edge)
+ * @returns {{x: number, y: number}} Client coordinates
+ */
+function pointAt(rect, fx, fy) {
+  return { x: rect.x + rect.width * fx, y: rect.y + rect.height * fy }
+}
+
+/**
+ * The data coordinates a gram fraction corresponds to, for expected values.
+ * @param {number} fx - Fraction across
+ * @param {number} fy - Fraction down
+ * @returns {{freq: number, time: number}} Data coordinates
+ */
+function dataAt(fx, fy) {
+  return { freq: FREQ_SPAN * fx, time: TIME_SPAN * (1 - fy) }
+}
+
+/**
+ * Drag out a Doppler curve between two fractions of the gram, and wait for the
+ * placement to land.
+ * @param {import('./helpers/gram-frame-page.js').default} gfp - Page helper
+ * @param {[number, number]} from - Start fraction [across, down]
+ * @param {[number, number]} to - End fraction [across, down]
+ * @returns {Promise<import('../src/types.js').GramFrameState>} State after placement
+ */
+async function placeCurve(gfp, from, to) {
+  const rect = await gramRect(gfp)
+  const start = pointAt(rect, from[0], from[1])
+  const end = pointAt(rect, to[0], to[1])
+
+  await gfp.page.mouse.move(start.x, start.y)
+  await gfp.page.mouse.down()
+  await gfp.page.mouse.move(end.x, end.y, { steps: 5 })
+  await gfp.page.mouse.up()
+
+  await gfp.waitForState((state) => !!(state.doppler.fPlus && state.doppler.fMinus && state.doppler.fZero))
+  return gfp.getState()
+}
+
+/**
+ * Drag a rendered Doppler marker by a client-pixel offset.
+ * @param {import('./helpers/gram-frame-page.js').default} gfp - Page helper
+ * @param {'fPlus'|'fMinus'|'crosshair'} marker - Which marker's element to grab
+ * @param {number} dx - Horizontal offset in client px
+ * @param {number} dy - Vertical offset in client px
+ * @returns {Promise<void>}
+ */
+async function dragMarker(gfp, marker, dx, dy) {
+  const box = await gfp.page.locator(`.gram-frame-doppler-${marker}`).first().boundingBox()
+  expect(box, `the ${marker} marker should be rendered`).not.toBeNull()
+
+  const cx = box.x + box.width / 2
+  const cy = box.y + box.height / 2
+
+  await gfp.page.mouse.move(cx, cy)
+  await gfp.page.mouse.down()
+  await gfp.page.mouse.move(cx + dx, cy + dy, { steps: 5 })
+  await gfp.page.mouse.up()
+}
+
+test.describe('Doppler Mode', () => {
   test.beforeEach(async ({ gramFramePage }) => {
-    
-    // Switch to Doppler mode
     await gramFramePage.clickMode('Doppler')
-    
-    // Verify we're in doppler mode
-    /** @type {import('../src/types.js').GramFrameState} */
+    await gramFramePage.waitForImageDimensions()
+
     const state = await gramFramePage.getState()
     expectValidMode(state, 'doppler')
   })
 
-  /**
-   * Doppler marker placement test suite
-   */
-  test.describe('Doppler Marker Placement', () => {
-    /**
-     * Test creation of f+ and f- markers with click and drag
-     * @param {TestParams} params - Test parameters
-     * @param {import('./helpers/gram-frame-page.js').default} params.gramFramePage - GramFrame page object
-     * @returns {Promise<void>}
-     */
-    test('should create f+ and f- markers with click and drag', async ({ gramFramePage }) => {
-      /** @type {number} */
-      const startX = 200
-      /** @type {number} */
-      const startY = 150
-      /** @type {number} */
-      const endX = 300
-      /** @type {number} */
-      const endY = 200
-      
-      // Click and drag to create Doppler markers
-      await gramFramePage.page.mouse.move(startX, startY)
-      await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(endX, endY)
-      await gramFramePage.page.mouse.up()
-      
-      // Verify Doppler markers were created
-      /** @type {import('../src/types.js').GramFrameState} */
-      const state = await gramFramePage.getState()
-      expect(state.doppler).toBeDefined()
-      
-      // Check if markers were created
-      if (state.doppler.fPlus && state.doppler.fMinus) {
-        // Verify marker properties
-        expect(state.doppler.fPlus).toHaveProperty('time')
-        expect(state.doppler.fPlus).toHaveProperty('frequency')
-        expect(state.doppler.fMinus).toHaveProperty('time')
-        expect(state.doppler.fMinus).toHaveProperty('frequency')
-        
-        expect(state.doppler.fPlus.time).toBeGreaterThan(0)
-        expect(state.doppler.fPlus.freq).toBeGreaterThan(0)
-        expect(state.doppler.fMinus.time).toBeGreaterThan(0)
-        expect(state.doppler.fMinus.freq).toBeGreaterThan(0)
-      } else {
-        // If no markers created, at least verify doppler state exists
-        expect(state.doppler).toHaveProperty('fPlus')
-        expect(state.doppler).toHaveProperty('fMinus')
-      }
-    })
-    
-    /**
-     * Test automatic calculation of f₀ midpoint marker
-     * @param {TestParams} params - Test parameters
-     * @param {import('./helpers/gram-frame-page.js').default} params.gramFramePage - GramFrame page object
-     * @returns {Promise<void>}
-     */
-    test('should automatically calculate f₀ midpoint marker', async ({ gramFramePage }) => {
-      // Create f+ and f- markers
-      await gramFramePage.page.mouse.move(200, 100)
-      await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(300, 200)
-      await gramFramePage.page.mouse.up()
-      
-      // Verify f₀ was automatically calculated (if markers were created)
-      /** @type {import('../src/types.js').GramFrameState} */
-      const state = await gramFramePage.getState()
-      
-      if (state.doppler.fPlus && state.doppler.fMinus && state.doppler.fZero) {
-        expect(state.doppler.fZero).toHaveProperty('time')
-        expect(state.doppler.fZero).toHaveProperty('frequency')
-        
-        // f₀ should be approximately between f+ and f-
-        /** @type {number} */
-        const fPlusFreq = state.doppler.fPlus.freq
-        /** @type {number} */
-        const fMinusFreq = state.doppler.fMinus.freq
-        /** @type {number} */
-        const fZeroFreq = state.doppler.fZero.freq
-        
-        /** @type {number} */
-        const minFreq = Math.min(fPlusFreq, fMinusFreq)
-        /** @type {number} */
-        const maxFreq = Math.max(fPlusFreq, fMinusFreq)
-        
-        expect(fZeroFreq).toBeGreaterThanOrEqual(minFreq - 10) // Small tolerance
-        expect(fZeroFreq).toBeLessThanOrEqual(maxFreq + 10)
-      } else {
-        // If markers weren't created, verify state structure exists
-        expect(state.doppler).toHaveProperty('fZero')
-      }
-    })
-    
-  })
+  test.describe('Marker Placement', () => {
+    test('a drag places f+ and f- at its two ends', async ({ gramFramePage }) => {
+      // Start high on the gram (later in time), finish low (earlier).
+      const state = await placeCurve(gramFramePage, [0.3, 0.2], [0.6, 0.7])
 
-  /**
-   * Doppler marker dragging test suite
-   */
-  test.describe('Doppler Marker Dragging', () => {
-    /**
-     * Test dragging f₀ marker independently
-     * @param {TestParams} params - Test parameters
-     * @param {import('./helpers/gram-frame-page.js').default} params.gramFramePage - GramFrame page object
-     * @returns {Promise<void>}
-     */
-    test('should allow dragging f₀ marker independently', async ({ gramFramePage }) => {
-      // Create initial Doppler markers
-      await gramFramePage.page.mouse.move(200, 150)
-      await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(300, 200)
-      await gramFramePage.page.mouse.up()
-      
-      /** @type {import('../src/types.js').GramFrameState} */
-      let state = await gramFramePage.getState()
-      
-      // Skip test if markers weren't created
-      if (!state.doppler.fZero) {
-        return
-      }
-      
-      // Calculate approximate f₀ position for dragging
-      /** @type {number} */
-      const fZeroX = (200 + 300) / 2 // Approximate midpoint
-      /** @type {number} */
-      const fZeroY = (150 + 200) / 2
-      
-      // Drag f₀ marker to new position
-      await gramFramePage.page.mouse.move(fZeroX, fZeroY)
-      await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(fZeroX + 50, fZeroY + 25)
-      await gramFramePage.page.mouse.up()
-      
-      // Verify f₀ marker was moved or drag was attempted
-      state = await gramFramePage.getState()
-      if (state.doppler.fZero) {
-        expect(state.doppler.fZero.time).toBeDefined()
-      }
+      const expectedHigh = dataAt(0.3, 0.2)
+      const expectedLow = dataAt(0.6, 0.7)
+
+      // f+ is defined as the later marker, whichever end of the drag it was.
+      expect(state.doppler.fPlus.time).toBeGreaterThan(state.doppler.fMinus.time)
+
+      expect(state.doppler.fPlus.time).toBeCloseTo(expectedHigh.time, 0)
+      expect(state.doppler.fPlus.freq).toBeCloseTo(expectedHigh.freq, 0)
+      expect(state.doppler.fMinus.time).toBeCloseTo(expectedLow.time, 0)
+      expect(state.doppler.fMinus.freq).toBeCloseTo(expectedLow.freq, 0)
     })
-    
-    /**
-     * Test cursor style updates when hovering over markers
-     * @param {TestParams} params - Test parameters
-     * @param {import('./helpers/gram-frame-page.js').default} params.gramFramePage - GramFrame page object
-     * @returns {Promise<void>}
-     */
-    test('should update cursor style when hovering over markers', async ({ gramFramePage }) => {
-      // Create Doppler markers
-      await gramFramePage.page.mouse.move(200, 150)
-      await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(300, 200)
-      await gramFramePage.page.mouse.up()
-      
-      // Hover over f+ marker position
-      await gramFramePage.page.mouse.move(200, 150)
-      
-      // Check cursor style (should indicate draggable)
-      /** @type {string | null} */
-      const cursor = await gramFramePage.page.evaluate(() => {
-        const svg = document.querySelector('.gram-frame-svg')
-        return svg ? window.getComputedStyle(svg).cursor : null
-      })
-      
-      // Cursor may or may not change depending on marker existence
-      if (cursor) {
-        expect(typeof cursor).toBe('string')
-      }
+
+    test('a drag placed the other way round still orders f+ after f-', async ({ gramFramePage }) => {
+      // Same two points, dragged bottom-to-top: the roles must not swap.
+      const state = await placeCurve(gramFramePage, [0.6, 0.7], [0.3, 0.2])
+
+      expect(state.doppler.fPlus.time).toBeGreaterThan(state.doppler.fMinus.time)
+      expect(state.doppler.fPlus.freq).toBeCloseTo(dataAt(0.3, 0.2).freq, 0)
+      expect(state.doppler.fMinus.freq).toBeCloseTo(dataAt(0.6, 0.7).freq, 0)
+    })
+
+    test('f₀ is derived as the midpoint of f+ and f-', async ({ gramFramePage }) => {
+      const { doppler } = await placeCurve(gramFramePage, [0.3, 0.2], [0.6, 0.7])
+
+      expect(doppler.fZero.time).toBeCloseTo((doppler.fPlus.time + doppler.fMinus.time) / 2, 6)
+      expect(doppler.fZero.freq).toBeCloseTo((doppler.fPlus.freq + doppler.fMinus.freq) / 2, 6)
+    })
+
+    test('placement leaves no half-finished geometry behind', async ({ gramFramePage }) => {
+      const state = await placeCurve(gramFramePage, [0.3, 0.2], [0.6, 0.7])
+
+      expect(state.doppler.tempFirst).toBeNull()
+      expect(state.doppler.previewEnd).toBeNull()
+      expect(state.drag.active).toBe(false)
     })
   })
 
-  /**
-   * Speed calculation workflow test suite
-   */
-  test.describe('Speed Calculation Workflow', () => {
-    /**
-     * Test Doppler speed calculation from f+ and f- markers
-     * @param {TestParams} params - Test parameters
-     * @param {import('./helpers/gram-frame-page.js').default} params.gramFramePage - GramFrame page object
-     * @returns {Promise<void>}
-     */
-    test('should calculate Doppler speed from f+ and f- markers', async ({ gramFramePage }) => {
-      // Create Doppler markers with known frequency difference
-      await gramFramePage.page.mouse.move(200, 100) // Higher frequency
-      await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(300, 200) // Lower frequency
-      await gramFramePage.page.mouse.up()
-      
-      // Verify speed calculation is performed
-      /** @type {import('../src/types.js').GramFrameState} */
+  test.describe('Marker Dragging', () => {
+    // The cursor affordance over a marker is covered in cursor-hover.spec.js,
+    // and the size of the region that grabs one in doppler-hotspot.spec.js.
+
+    test('dragging f+ moves f+ and leaves f- alone', async ({ gramFramePage }) => {
+      const before = await placeCurve(gramFramePage, [0.3, 0.2], [0.6, 0.7])
+
+      await dragMarker(gramFramePage, 'fPlus', 40, 20)
+      const after = await gramFramePage.getState()
+
+      expect(after.doppler.fPlus.freq).toBeGreaterThan(before.doppler.fPlus.freq)
+      expect(after.doppler.fPlus.time).toBeLessThan(before.doppler.fPlus.time)
+      expect(after.doppler.fMinus).toEqual(before.doppler.fMinus)
+    })
+
+    test('dragging f- moves f- and leaves f+ alone', async ({ gramFramePage }) => {
+      const before = await placeCurve(gramFramePage, [0.3, 0.2], [0.6, 0.7])
+
+      await dragMarker(gramFramePage, 'fMinus', -40, 20)
+      const after = await gramFramePage.getState()
+
+      expect(after.doppler.fMinus.freq).toBeLessThan(before.doppler.fMinus.freq)
+      expect(after.doppler.fMinus.time).toBeLessThan(before.doppler.fMinus.time)
+      expect(after.doppler.fPlus).toEqual(before.doppler.fPlus)
+    })
+
+    test('f₀ drags independently of the markers it was derived from', async ({ gramFramePage }) => {
+      const before = await placeCurve(gramFramePage, [0.25, 0.2], [0.75, 0.8])
+
+      // f₀ sits at the curve's midpoint, well clear of both ends here.
+      await dragMarker(gramFramePage, 'crosshair', 30, 0)
+      const after = await gramFramePage.getState()
+
+      expect(after.doppler.fZero.freq).toBeGreaterThan(before.doppler.fZero.freq)
+      expect(after.doppler.fPlus).toEqual(before.doppler.fPlus)
+      expect(after.doppler.fMinus).toEqual(before.doppler.fMinus)
+    })
+
+    test('a completed drag leaves the engine idle', async ({ gramFramePage }) => {
+      await placeCurve(gramFramePage, [0.3, 0.2], [0.6, 0.7])
+      await dragMarker(gramFramePage, 'fPlus', 20, 10)
+
       const state = await gramFramePage.getState()
-      
-      // Skip if markers weren't created
-      if (!state.doppler.fPlus || !state.doppler.fMinus) {
-        return
-      }
-      
-      // Check if speed calculation fields exist
-      if (state.doppler.calculatedSpeed !== undefined) {
-        expect(state.doppler.calculatedSpeed).toBeGreaterThanOrEqual(0)
-      }
-      
-      // Verify frequency difference is calculated
-      /** @type {number} */
-      const freqDiff = Math.abs(state.doppler.fPlus.freq - state.doppler.fMinus.freq)
-      expect(freqDiff).toBeGreaterThanOrEqual(0)
-    })
-    
-    /**
-     * Test speed calculation updates when dragging markers
-     * @param {TestParams} params - Test parameters
-     * @param {import('./helpers/gram-frame-page.js').default} params.gramFramePage - GramFrame page object
-     * @returns {Promise<void>}
-     */
-    test('should update speed calculation when dragging markers', async ({ gramFramePage }) => {
-      // Create initial markers
-      await gramFramePage.page.mouse.move(200, 150)
-      await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(300, 200)
-      await gramFramePage.page.mouse.up()
-      
-      // Get initial calculation
-      /** @type {import('../src/types.js').GramFrameState} */
-      let state = await gramFramePage.getState()
-      
-      // Skip if markers weren't created
-      if (!state.doppler.fPlus || !state.doppler.fMinus) {
-        return
-      }
-      
-      // Drag one marker to change frequency difference
-      await gramFramePage.page.mouse.move(200, 150)
-      await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(200, 100) // Move to higher frequency
-      await gramFramePage.page.mouse.up()
-      
-      // Verify calculation updated or drag was attempted
-      state = await gramFramePage.getState()
-      if (state.doppler.fPlus && state.doppler.fMinus) {
-        /** @type {number} */
-        const newFreqDiff = Math.abs(state.doppler.fPlus.freq - state.doppler.fMinus.freq)
-        // Frequency difference may or may not have changed
-        expect(newFreqDiff).toBeGreaterThanOrEqual(0)
-      }
-    })
-    
-    /**
-     * Test handling of zero frequency difference gracefully
-     * @param {TestParams} params - Test parameters
-     * @param {import('./helpers/gram-frame-page.js').default} params.gramFramePage - GramFrame page object
-     * @returns {Promise<void>}
-     */
-    test('should handle zero frequency difference gracefully', async ({ gramFramePage }) => {
-      // Create markers at same frequency (vertically aligned)
-      await gramFramePage.page.mouse.move(200, 150)
-      await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(300, 150) // Same frequency, different time
-      await gramFramePage.page.mouse.up()
-      
-      // Verify system handles zero frequency difference
-      /** @type {import('../src/types.js').GramFrameState} */
-      const state = await gramFramePage.getState()
-      
-      // Skip if markers weren't created
-      if (!state.doppler.fPlus || !state.doppler.fMinus) {
-        return
-      }
-      
-      if (state.doppler.calculatedSpeed !== undefined) {
-        // Speed should be zero or very close to zero
-        expect(state.doppler.calculatedSpeed).toBeLessThanOrEqual(1)
-      }
-      
-      // Should not cause errors
-      expect(state.doppler.fPlus).toBeDefined()
-      expect(state.doppler.fMinus).toBeDefined()
-    })
-  })
-
-  /**
-   * Bearing input interactions test suite
-   */
-  test.describe('Bearing Input Interactions', () => {
-  })
-
-  /**
-   * Time selection and display test suite
-   */
-  test.describe('Time Selection and Display', () => {
-    /**
-     * Test display of time values for f+ and f- markers
-     * @param {TestParams} params - Test parameters
-     * @param {import('./helpers/gram-frame-page.js').default} params.gramFramePage - GramFrame page object
-     * @returns {Promise<void>}
-     */
-    test('should display time values for f+ and f- markers', async ({ gramFramePage }) => {
-      // Create Doppler markers
-      await gramFramePage.page.mouse.move(200, 150)
-      await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(350, 200)
-      await gramFramePage.page.mouse.up()
-      
-      // Verify time values are calculated
-      /** @type {import('../src/types.js').GramFrameState} */
-      const state = await gramFramePage.getState()
-      
-      // Skip if markers weren't created
-      if (!state.doppler.fPlus || !state.doppler.fMinus) {
-        return
-      }
-      
-      expect(state.doppler.fPlus.time).toBeGreaterThan(0)
-      expect(state.doppler.fMinus.time).toBeGreaterThan(0)
-      
-      // Times should be different (unless vertically aligned)
-      /** @type {number} */
-      const timeDiff = Math.abs(state.doppler.fPlus.time - state.doppler.fMinus.time)
-      expect(timeDiff).toBeGreaterThanOrEqual(0)
-    })
-    
-    /**
-     * Test handling of time-based calculations correctly
-     * @param {TestParams} params - Test parameters
-     * @param {import('./helpers/gram-frame-page.js').default} params.gramFramePage - GramFrame page object
-     * @returns {Promise<void>}
-     */
-    test('should handle time-based calculations correctly', async ({ gramFramePage }) => {
-      // Create markers with significant time difference
-      await gramFramePage.page.mouse.move(150, 150) // Earlier time
-      await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(400, 200) // Later time
-      await gramFramePage.page.mouse.up()
-      
-      /** @type {import('../src/types.js').GramFrameState} */
-      const state = await gramFramePage.getState()
-      
-      // Skip if markers weren't created
-      if (!state.doppler.fPlus || !state.doppler.fMinus) {
-        return
-      }
-      
-      /** @type {number} */
-      const timeDiff = Math.abs(state.doppler.fPlus.time - state.doppler.fMinus.time)
-      
-      // Verify time difference was captured
-      expect(timeDiff).toBeGreaterThanOrEqual(0)
-      
-      // Time values should be within reasonable range
-      expect(state.doppler.fPlus.time).toBeGreaterThanOrEqual(state.config.timeMin)
-      expect(state.doppler.fPlus.time).toBeLessThanOrEqual(state.config.timeMax)
-      expect(state.doppler.fMinus.time).toBeGreaterThanOrEqual(state.config.timeMin)
-      expect(state.doppler.fMinus.time).toBeLessThanOrEqual(state.config.timeMax)
-    })
-  })
-
-  /**
-   * UI display and calculation results test suite
-   */
-  test.describe('UI Display and Calculation Results', () => {
-    
-    /**
-     * Test real-time display updates during dragging
-     * @param {TestParams} params - Test parameters
-     * @param {import('./helpers/gram-frame-page.js').default} params.gramFramePage - GramFrame page object
-     * @returns {Promise<void>}
-     */
-    test('should update display in real-time during dragging', async ({ gramFramePage }) => {
-      // Create initial markers
-      await gramFramePage.page.mouse.move(200, 150)
-      await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(300, 200)
-      await gramFramePage.page.mouse.up()
-      
-      try {
-        /** @type {import('@playwright/test').Locator} */
-        const resultsDisplay = gramFramePage.page.locator('.gram-frame-doppler-results, .doppler-speed-display')
-        await resultsDisplay.waitFor({ timeout: 1000 })
-        
-        /** @type {string | null} */
-        const initialText = await resultsDisplay.textContent()
-        
-        // Drag marker to change calculation
-        await gramFramePage.page.mouse.move(200, 150)
-        await gramFramePage.page.mouse.down()
-        await gramFramePage.page.mouse.move(200, 100) // Change frequency
-        await gramFramePage.page.mouse.up()
-        
-        // Verify display updated
-        await expect(resultsDisplay).not.toHaveText(initialText ?? '')
-      } catch (_error) {
-        console.log('Real-time display update not testable')
-      }
-    })
-  })
-
-  /**
-   * Cross-mode functionality test suite
-   */
-  test.describe('Cross-Mode Functionality', () => {
-    /**
-     * Test maintaining Doppler markers when switching modes
-     * @param {TestParams} params - Test parameters
-     * @param {import('./helpers/gram-frame-page.js').default} params.gramFramePage - GramFrame page object
-     * @returns {Promise<void>}
-     */
-    test('should maintain Doppler markers when switching modes', async ({ gramFramePage }) => {
-      // Create Doppler markers
-      await gramFramePage.page.mouse.move(200, 150)
-      await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(300, 200)
-      await gramFramePage.page.mouse.up()
-      
-      /** @type {import('../src/types.js').GramFrameState} */
-      let state = await gramFramePage.getState()
-      /** @type {import('../src/types.js').DopplerState} */
-      const originalDopplerState = { ...state.doppler }
-      
-      // Switch to Cross Cursor mode
-      await gramFramePage.clickMode('Cross Cursor')
-      
-      // Verify Doppler state persists (if markers were created)
-      state = await gramFramePage.getState()
-      if (originalDopplerState.fPlus && originalDopplerState.fMinus) {
-        expect(state.doppler.fPlus).toEqual(originalDopplerState.fPlus)
-        expect(state.doppler.fMinus).toEqual(originalDopplerState.fMinus)
-        if (originalDopplerState.fZero) {
-          expect(state.doppler.fZero).toEqual(originalDopplerState.fZero)
-        }
-      }
-      
-      // Switch back to Doppler mode
-      await gramFramePage.clickMode('Doppler')
-      
-      // Verify markers are still functional
-      state = await gramFramePage.getState()
-      if (originalDopplerState.fPlus) {
-        expect(state.doppler.fPlus).toEqual(originalDopplerState.fPlus)
-      }
-      
-      // Check for Doppler markers in SVG (may not exist)
-      try {
-        /** @type {import('@playwright/test').Locator} */
-        const dopplerMarkers = gramFramePage.page.locator('.gram-frame-doppler-marker')
-        /** @type {number} */
-        const count = await dopplerMarkers.count()
-        if (count > 0) {
-          expect(count).toBeGreaterThan(0)
-        }
-      } catch (_error) {
-        // Markers may not be visible
-      }
-    })
-    
-    /**
-     * Test coexistence with Cross Cursor markers
-     * @param {TestParams} params - Test parameters
-     * @param {import('./helpers/gram-frame-page.js').default} params.gramFramePage - GramFrame page object
-     * @returns {Promise<void>}
-     */
-    test('should coexist with Cross Cursor markers', async ({ gramFramePage }) => {
-      // Switch to Cross Cursor mode and create markers
-      await gramFramePage.clickMode('Cross Cursor')
-      await gramFramePage.clickSpectrogram(150, 100)
-      
-      // Switch back to Doppler mode
-      await gramFramePage.clickMode('Doppler')
-      
-      // Create Doppler markers
-      await gramFramePage.page.mouse.move(200, 150)
-      await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(300, 200)
-      await gramFramePage.page.mouse.up()
-      
-      // Verify both types of markers coexist
-      /** @type {import('../src/types.js').GramFrameState} */
-      const state = await gramFramePage.getState()
-      expect(state.analysis?.markers).toHaveLength(1)
-      
-      // Check if Doppler markers were created
-      if (state.doppler.fPlus && state.doppler.fMinus) {
-        expect(state.doppler.fPlus).toBeDefined()
-        expect(state.doppler.fMinus).toBeDefined()
-      }
-      
-      // Check for markers in SVG (may not exist)
-      try {
-        /** @type {import('@playwright/test').Locator} */
-        const analysisMarkers = gramFramePage.page.locator('.gram-frame-analysis-marker')
-        await expect(analysisMarkers).toHaveCount(1)
-        
-        /** @type {import('@playwright/test').Locator} */
-        const dopplerMarkers = gramFramePage.page.locator('.gram-frame-doppler-marker')
-        /** @type {number} */
-        const dopplerCount = await dopplerMarkers.count()
-        if (dopplerCount > 0) {
-          expect(dopplerCount).toBeGreaterThan(0)
-        }
-      } catch (_error) {
-        // Some markers may not be visible
-      }
-    })
-  })
-
-  /**
-   * Reset and clear functionality test suite
-   */
-  test.describe('Reset and Clear Functionality', () => {
-    /**
-     * Test resetting markers via right-click
-     * @param {TestParams} params - Test parameters
-     * @param {import('./helpers/gram-frame-page.js').default} params.gramFramePage - GramFrame page object
-     * @returns {Promise<void>}
-     */
-    test('should reset markers via right-click', async ({ gramFramePage }) => {
-      // Create Doppler markers
-      await gramFramePage.page.mouse.move(200, 150)
-      await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(300, 200)
-      await gramFramePage.page.mouse.up()
-      
-      // Check if markers were created
-      /** @type {import('../src/types.js').GramFrameState} */
-      let state = await gramFramePage.getState()
-      /** @type {boolean} */
-      const hasMarkers = state.doppler.fPlus && state.doppler.fMinus
-      
-      if (!hasMarkers) {
-        return // Skip test if no markers were created
-      }
-      
-      expect(state.doppler.fPlus).toBeDefined()
-      expect(state.doppler.fMinus).toBeDefined()
-      
-      // Right-click to reset (if implemented)
-      await gramFramePage.page.mouse.click(250, 175, { button: 'right' })
-      
-      // The context-menu handler runs synchronously, so the click resolving is
-      // itself the signal that any reset has already happened.
-      // Check if markers were reset
-      state = await gramFramePage.getState()
-      // Note: This test assumes right-click reset is implemented
-      // If not implemented, markers will still exist
-    })
-  })
-
-  /**
-   * Edge cases and error handling test suite
-   */
-  test.describe('Edge Cases and Error Handling', () => {
-    /**
-     * Test marker placement at spectrogram boundaries
-     * @param {TestParams} params - Test parameters
-     * @param {import('./helpers/gram-frame-page.js').default} params.gramFramePage - GramFrame page object
-     * @returns {Promise<void>}
-     */
-    test('should handle marker placement at spectrogram boundaries', async ({ gramFramePage }) => {
-      /** @type {import('@playwright/test').BoundingBox | null} */
-      const svgBox = await gramFramePage.svg.boundingBox()
-      expect(svgBox).toBeTruthy()
-      
-      if (svgBox) {
-        // Test boundary positions (accounting for axes margins)
-        await gramFramePage.page.mouse.move(65, 50) // Near left edge
-        await gramFramePage.page.mouse.down()
-        await gramFramePage.page.mouse.move(svgBox.width - 10, svgBox.height - 55) // Near right-bottom
-        await gramFramePage.page.mouse.up()
-        
-        // Check if markers were created successfully
-        /** @type {import('../src/types.js').GramFrameState} */
-        const state = await gramFramePage.getState()
-        
-        if (state.doppler.fPlus && state.doppler.fMinus) {
-          expect(state.doppler.fPlus).toBeDefined()
-          expect(state.doppler.fMinus).toBeDefined()
-          
-          // Coordinates should be within valid ranges
-          expect(state.doppler.fPlus.time).toBeGreaterThanOrEqual(state.config.timeMin)
-          expect(state.doppler.fPlus.time).toBeLessThanOrEqual(state.config.timeMax)
-          expect(state.doppler.fMinus.time).toBeGreaterThanOrEqual(state.config.timeMin)
-          expect(state.doppler.fMinus.time).toBeLessThanOrEqual(state.config.timeMax)
-        }
-      }
-    })
-    
-    /**
-     * Test handling rapid marker creation and dragging
-     * @param {TestParams} params - Test parameters
-     * @param {import('./helpers/gram-frame-page.js').default} params.gramFramePage - GramFrame page object
-     * @returns {Promise<void>}
-     */
-    test('should handle rapid marker creation and dragging', async ({ gramFramePage }) => {
-      // Rapidly create and modify Doppler markers
-      await gramFramePage.page.mouse.move(200, 150)
-      await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(250, 180)
-      await gramFramePage.page.mouse.move(300, 200)
-      await gramFramePage.page.mouse.up()
-
-      // Immediately start dragging
-      await gramFramePage.page.mouse.move(200, 150)
-      await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(180, 130)
-      await gramFramePage.page.mouse.up()
-      
-      // Verify final state is consistent
-      /** @type {import('../src/types.js').GramFrameState} */
-      const state = await gramFramePage.getState()
-      
-      // Check marker state (may or may not exist)
-      if (state.doppler.fPlus && state.doppler.fMinus) {
-        expect(state.doppler.fPlus).toBeDefined()
-        expect(state.doppler.fMinus).toBeDefined()
-        if (state.doppler.fZero) {
-          expect(state.doppler.fZero).toBeDefined()
-        }
-      }
-      
-      // Verify drag states are clean. Drag bookkeeping is now the engine's
-      // single read-only projection (spec 166, FR-004).
       expect(state.drag.active).toBe(false)
       expect(state.drag.kind).toBeNull()
     })
-    
-    /**
-     * Test state consistency during complex operations
-     * @param {TestParams} params - Test parameters
-     * @param {import('./helpers/gram-frame-page.js').default} params.gramFramePage - GramFrame page object
-     * @returns {Promise<void>}
-     */
-    test('should maintain state consistency during complex operations', async ({ gramFramePage }) => {
-      // Perform complex sequence of operations
-      await gramFramePage.page.mouse.move(200, 150)
-      await gramFramePage.page.mouse.down() // Start creating markers
-      await gramFramePage.clickMode('Cross Cursor') // Switch mode mid-operation
-      await gramFramePage.clickMode('Doppler') // Switch back
-      await gramFramePage.page.mouse.move(300, 200) // Continue operation
-      await gramFramePage.page.mouse.up() // Complete operation
-      
-      // Verify final state is consistent
-      /** @type {import('../src/types.js').GramFrameState} */
+  })
+
+  test.describe('Speed Calculation', () => {
+    test('speed follows the Doppler formula over f+, f- and f₀', async ({ gramFramePage }) => {
+      const { doppler } = await placeCurve(gramFramePage, [0.3, 0.2], [0.7, 0.8])
+
+      // v = (c / f₀) × Δf, with c = 1481 m/s and Δf = (f+ − f−) / 2.
+      const expected = Math.abs((1481 / doppler.fZero.freq) * ((doppler.fPlus.freq - doppler.fMinus.freq) / 2))
+
+      expect(doppler.speed).toBeCloseTo(expected, 6)
+    })
+
+    test('dragging a marker recomputes the speed', async ({ gramFramePage }) => {
+      const before = await placeCurve(gramFramePage, [0.3, 0.2], [0.7, 0.8])
+      expect(before.doppler.speed).toBeGreaterThan(0)
+
+      // Widen the frequency gap: a bigger Δf over the same f₀ means more speed.
+      await dragMarker(gramFramePage, 'fPlus', -60, 0)
+      const after = await gramFramePage.getState()
+
+      expect(after.doppler.fPlus.freq).toBeLessThan(before.doppler.fPlus.freq)
+      expect(after.doppler.speed).not.toBeCloseTo(before.doppler.speed, 3)
+      const expected = Math.abs(
+        (1481 / after.doppler.fZero.freq) * ((after.doppler.fPlus.freq - after.doppler.fMinus.freq) / 2)
+      )
+      expect(after.doppler.speed).toBeCloseTo(expected, 6)
+    })
+
+    test('markers at the same frequency give a speed of zero', async ({ gramFramePage }) => {
+      // Vertically aligned: same frequency, different times.
+      const { doppler } = await placeCurve(gramFramePage, [0.5, 0.25], [0.5, 0.75])
+
+      expect(doppler.fPlus.freq).toBeCloseTo(doppler.fMinus.freq, 3)
+      expect(doppler.speed).toBeCloseTo(0, 3)
+    })
+
+    test('the speed LED shows the calculated value', async ({ gramFramePage }) => {
+      const { doppler } = await placeCurve(gramFramePage, [0.3, 0.2], [0.7, 0.8])
+
+      const led = await gramFramePage.getLEDValue('Doppler\u00a0Speed (kts)')
+      expect(led).toMatch(/\d/)
+      // The LED reads in knots; state carries m/s.
+      const shown = parseFloat(led.replace(/[^\d.-]/g, ''))
+      expect(shown).toBeCloseTo(doppler.speed * 1.94384, 0)
+    })
+  })
+
+  test.describe('Coordinates', () => {
+    test('marker positions land inside the configured ranges', async ({ gramFramePage }) => {
+      const state = await placeCurve(gramFramePage, [0.2, 0.15], [0.8, 0.85])
+
+      for (const marker of [state.doppler.fPlus, state.doppler.fMinus, state.doppler.fZero]) {
+        expect(marker.time).toBeGreaterThanOrEqual(state.config.timeMin)
+        expect(marker.time).toBeLessThanOrEqual(state.config.timeMax)
+        expect(marker.freq).toBeGreaterThanOrEqual(state.config.freqMin)
+        expect(marker.freq).toBeLessThanOrEqual(state.config.freqMax)
+      }
+    })
+
+    test('markers placed at the gram edges stay in range', async ({ gramFramePage }) => {
+      // Two pixels inside opposite corners — the extremes a press can still
+      // resolve to data coordinates at all.
+      const rect = await gramRect(gramFramePage)
+      const inset = 2
+      await gramFramePage.page.mouse.move(rect.x + inset, rect.y + inset)
+      await gramFramePage.page.mouse.down()
+      await gramFramePage.page.mouse.move(
+        rect.x + rect.width - inset,
+        rect.y + rect.height - inset,
+        { steps: 5 }
+      )
+      await gramFramePage.page.mouse.up()
+      await gramFramePage.waitForState((s) => !!(s.doppler.fPlus && s.doppler.fMinus))
+
+      const state = await gramFramePage.getState()
+      for (const marker of [state.doppler.fPlus, state.doppler.fMinus, state.doppler.fZero]) {
+        expect(marker.time).toBeGreaterThanOrEqual(state.config.timeMin)
+        expect(marker.time).toBeLessThanOrEqual(state.config.timeMax)
+        expect(marker.freq).toBeGreaterThanOrEqual(state.config.freqMin)
+        expect(marker.freq).toBeLessThanOrEqual(state.config.freqMax)
+      }
+    })
+
+    test('a drag of barely any distance still places both markers', async ({ gramFramePage }) => {
+      const rect = await gramRect(gramFramePage)
+      const start = pointAt(rect, 0.5, 0.5)
+
+      await gramFramePage.page.mouse.move(start.x, start.y)
+      await gramFramePage.page.mouse.down()
+      await gramFramePage.page.mouse.move(start.x + 1, start.y + 1)
+      await gramFramePage.page.mouse.up()
+
+      const state = await gramFramePage.getState()
+      expect(state.doppler.fPlus).not.toBeNull()
+      expect(state.doppler.fMinus).not.toBeNull()
+      expect(Math.abs(state.doppler.fPlus.freq - state.doppler.fMinus.freq)).toBeLessThan(1)
+    })
+  })
+
+  test.describe('Cross-Mode Behaviour', () => {
+    test('markers survive a round trip through another mode', async ({ gramFramePage }) => {
+      const before = await placeCurve(gramFramePage, [0.3, 0.2], [0.6, 0.7])
+
+      await gramFramePage.clickMode('Cross Cursor')
+      const away = await gramFramePage.getState()
+      expect(away.doppler.fPlus).toEqual(before.doppler.fPlus)
+      expect(away.doppler.fMinus).toEqual(before.doppler.fMinus)
+      expect(away.doppler.fZero).toEqual(before.doppler.fZero)
+
+      await gramFramePage.clickMode('Doppler')
+      const back = await gramFramePage.getState()
+      expect(back.doppler.fPlus).toEqual(before.doppler.fPlus)
+      expect(back.doppler.fMinus).toEqual(before.doppler.fMinus)
+
+      // And the curve is drawn again rather than merely remembered.
+      await expect(gramFramePage.page.locator('.gram-frame-doppler-fPlus')).toHaveCount(1)
+    })
+
+    test('a doppler curve coexists with cross-cursor markers', async ({ gramFramePage }) => {
+      await gramFramePage.clickMode('Cross Cursor')
+      await gramFramePage.clickSpectrogram(150, 100)
+      await gramFramePage.waitForMarkerCount(1)
+
+      await gramFramePage.clickMode('Doppler')
+      const state = await placeCurve(gramFramePage, [0.4, 0.3], [0.7, 0.7])
+
+      expect(state.analysis.markers).toHaveLength(1)
+      expect(state.doppler.fPlus).not.toBeNull()
+      expect(state.doppler.fMinus).not.toBeNull()
+      await expect(gramFramePage.page.locator('.gram-frame-doppler-fPlus')).toHaveCount(1)
+    })
+  })
+
+  test.describe('Reset', () => {
+    test('right-click clears every marker and the speed', async ({ gramFramePage }) => {
+      await placeCurve(gramFramePage, [0.3, 0.2], [0.6, 0.7])
+
+      const rect = await gramRect(gramFramePage)
+      const centre = pointAt(rect, 0.45, 0.45)
+      await gramFramePage.page.mouse.click(centre.x, centre.y, { button: 'right' })
+
+      const state = await gramFramePage.getState()
+      expect(state.doppler.fPlus).toBeNull()
+      expect(state.doppler.fMinus).toBeNull()
+      expect(state.doppler.fZero).toBeNull()
+      expect(state.doppler.speed).toBeNull()
+      await expect(gramFramePage.page.locator('.gram-frame-doppler-fPlus')).toHaveCount(0)
+    })
+
+    test('a fresh curve can be drawn after a reset', async ({ gramFramePage }) => {
+      await placeCurve(gramFramePage, [0.3, 0.2], [0.6, 0.7])
+
+      const rect = await gramRect(gramFramePage)
+      const centre = pointAt(rect, 0.45, 0.45)
+      await gramFramePage.page.mouse.click(centre.x, centre.y, { button: 'right' })
+      await gramFramePage.waitForState((state) => state.doppler.fPlus === null)
+
+      const state = await placeCurve(gramFramePage, [0.2, 0.3], [0.5, 0.6])
+      expect(state.doppler.fPlus).not.toBeNull()
+      expect(state.doppler.speed).toBeGreaterThan(0)
+    })
+  })
+
+  test.describe('Edge Cases', () => {
+    test('placing then immediately dragging keeps the state consistent', async ({ gramFramePage }) => {
+      await placeCurve(gramFramePage, [0.3, 0.2], [0.6, 0.7])
+      await dragMarker(gramFramePage, 'fPlus', -20, -20)
+
+      const state = await gramFramePage.getState()
+      expect(state.doppler.fPlus).not.toBeNull()
+      expect(state.doppler.fMinus).not.toBeNull()
+      expect(state.doppler.fZero).not.toBeNull()
+      expect(state.drag.active).toBe(false)
+      expect(state.drag.kind).toBeNull()
+    })
+
+    test('releasing outside the gram cancels rather than stranding the drag', async ({ gramFramePage }) => {
+      const before = await placeCurve(gramFramePage, [0.3, 0.2], [0.6, 0.7])
+
+      const box = await gramFramePage.page.locator('.gram-frame-doppler-fPlus').boundingBox()
+      await gramFramePage.page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+      await gramFramePage.page.mouse.down()
+      // Out over the axis margin, where there are no data coordinates.
+      await gramFramePage.page.mouse.move(box.x + box.width / 2, before.margins.top - 40, { steps: 5 })
+      await gramFramePage.page.mouse.up()
+
+      const state = await gramFramePage.getState()
+      expect(state.drag.active).toBe(false)
+      expect(state.doppler.fPlus).not.toBeNull()
+    })
+
+    test('the component stays coherent through a mode switch', async ({ gramFramePage }) => {
+      await placeCurve(gramFramePage, [0.3, 0.2], [0.6, 0.7])
+
+      await gramFramePage.clickMode('Cross Cursor')
+      await gramFramePage.clickMode('Doppler')
+
       const state = await gramFramePage.getState()
       expectValidMetadata(state)
       expectValidMode(state, 'doppler')
       expectValidConfig(state)
       expectValidImageDetails(state)
-      
-      // Doppler state should be consistent despite mode switching
+
       expect(state.drag.active).toBe(false)
       expect(state.drag.kind).toBeNull()
-    })
-    
-    /**
-     * Test handling overlapping marker positions
-     * @param {TestParams} params - Test parameters
-     * @param {import('./helpers/gram-frame-page.js').default} params.gramFramePage - GramFrame page object
-     * @returns {Promise<void>}
-     */
-    test('should handle overlapping marker positions', async ({ gramFramePage }) => {
-      // Create markers at same position
-      await gramFramePage.page.mouse.move(200, 150)
-      await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(201, 151) // Minimal movement
-      await gramFramePage.page.mouse.up()
-      
-      // Verify system handles overlapping positions gracefully
-      /** @type {import('../src/types.js').GramFrameState} */
-      const state = await gramFramePage.getState()
-      
-      if (state.doppler.fPlus && state.doppler.fMinus) {
-        // Should have valid but potentially similar positions
-        expect(state.doppler.fPlus).toHaveProperty('time')
-        expect(state.doppler.fPlus).toHaveProperty('frequency')
-        expect(state.doppler.fMinus).toHaveProperty('time')
-        expect(state.doppler.fMinus).toHaveProperty('frequency')
-        
-        // Frequency difference should be minimal
-        /** @type {number} */
-        const freqDiff = Math.abs(state.doppler.fPlus.freq - state.doppler.fMinus.freq)
-        expect(freqDiff).toBeLessThan(100) // Small difference for overlapping positions
-      }
-    })
-  })
-
-  /**
-   * Coordinate system integration test suite
-   */
-  test.describe('Coordinate System Integration', () => {
-    /**
-     * Test accurate conversion of marker positions to frequency/time
-     * @param {TestParams} params - Test parameters
-     * @param {import('./helpers/gram-frame-page.js').default} params.gramFramePage - GramFrame page object
-     * @returns {Promise<void>}
-     */
-    test('should accurately convert marker positions to frequency/time', async ({ gramFramePage }) => {
-      // Create markers at known positions
-      /** @type {number} */
-      const startX = 200
-      /** @type {number} */
-      const startY = 150
-      /** @type {number} */
-      const endX = 300
-      /** @type {number} */
-      const endY = 250
-      
-      await gramFramePage.page.mouse.move(startX, startY)
-      await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(endX, endY)
-      await gramFramePage.page.mouse.up()
-      
-      /** @type {import('../src/types.js').GramFrameState} */
-      const state = await gramFramePage.getState()
-      
-      // Skip if markers weren't created
-      if (!state.doppler.fPlus || !state.doppler.fMinus) {
-        return
-      }
-      
-      // Verify coordinates are within expected ranges
-      expect(state.doppler.fPlus.time).toBeGreaterThanOrEqual(state.config.timeMin)
-      expect(state.doppler.fPlus.time).toBeLessThanOrEqual(state.config.timeMax)
-      expect(state.doppler.fPlus.freq).toBeGreaterThanOrEqual(state.config.freqMin)
-      expect(state.doppler.fPlus.freq).toBeLessThanOrEqual(state.config.freqMax)
-      
-      expect(state.doppler.fMinus.time).toBeGreaterThanOrEqual(state.config.timeMin)
-      expect(state.doppler.fMinus.time).toBeLessThanOrEqual(state.config.timeMax)
-      expect(state.doppler.fMinus.freq).toBeGreaterThanOrEqual(state.config.freqMin)
-      expect(state.doppler.fMinus.freq).toBeLessThanOrEqual(state.config.freqMax)
-    })
-  })
-
-  test.describe('Issue #136 - Doppler marker dragging', () => {
-    test('should properly detect and allow dragging of doppler markers after placement', async ({ gramFramePage }) => {
-      // Create initial doppler curve using mouse API (like other tests)
-      await gramFramePage.page.mouse.move(400, 200)
-      await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(500, 300)
-      await gramFramePage.page.mouse.up()
-      
-      // Verify markers were created
-      let state = await gramFramePage.getState()
-      
-      // Skip test if markers weren't created (separate issue)
-      if (!state.doppler.fPlus || !state.doppler.fMinus || !state.doppler.fZero) {
-        console.log('Doppler markers not created - skipping drag test')
-        return
-      }
-      
-      const originalFPlusFreq = state.doppler.fPlus.freq
-      const originalFMinusFreq = state.doppler.fMinus.freq
-      
-      // Try to drag the f+ marker to a new position  
-      // First, click on the approximate location of f+ marker
-      await gramFramePage.page.mouse.move(400, 200)
-      await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(420, 180) // Move to new position
-      await gramFramePage.page.mouse.up()
-      
-      // Check if the marker position actually changed
-      state = await gramFramePage.getState()
-      const fPlusChanged = state.doppler.fPlus.freq !== originalFPlusFreq
-      
-      // Try dragging f- marker as well
-      await gramFramePage.page.mouse.move(500, 300)
-      await gramFramePage.page.mouse.down()
-      await gramFramePage.page.mouse.move(480, 320)
-      await gramFramePage.page.mouse.up()
-      
-      const finalState = await gramFramePage.getState()
-      const fMinusChanged = finalState.doppler.fMinus.freq !== originalFMinusFreq
-      
-      // Verify that markers can actually be dragged (Issue #136)
-      // The test should demonstrate that dragging works properly
-      console.log('F+ changed:', fPlusChanged, 'F- changed:', fMinusChanged)
-      console.log('Original f+ freq:', originalFPlusFreq, 'New f+ freq:', state.doppler.fPlus.freq)
-      console.log('Original f- freq:', originalFMinusFreq, 'New f- freq:', finalState.doppler.fMinus.freq)
-      
-      // This test confirms that doppler marker dragging is working correctly
-      // If this test passes consistently, then Issue #136 has been resolved
-      expect(fPlusChanged || fMinusChanged).toBe(true)
-      
-      // Ensure markers are still within bounds
-      expect(finalState.doppler.fPlus.time).toBeGreaterThanOrEqual(finalState.config.timeMin)
-      expect(finalState.doppler.fPlus.time).toBeLessThanOrEqual(finalState.config.timeMax)
-      expect(finalState.doppler.fPlus.freq).toBeGreaterThanOrEqual(finalState.config.freqMin)
-      expect(finalState.doppler.fPlus.freq).toBeLessThanOrEqual(finalState.config.freqMax)
-      
-      expect(finalState.doppler.fMinus.time).toBeGreaterThanOrEqual(finalState.config.timeMin)
-      expect(finalState.doppler.fMinus.time).toBeLessThanOrEqual(finalState.config.timeMax)
-      expect(finalState.doppler.fMinus.freq).toBeGreaterThanOrEqual(finalState.config.freqMin)
-      expect(finalState.doppler.fMinus.freq).toBeLessThanOrEqual(finalState.config.freqMax)
+      expect(state.doppler.tempFirst).toBeNull()
+      expect(state.doppler.previewEnd).toBeNull()
     })
   })
 })

--- a/tests/unit/tolerance.test.js
+++ b/tests/unit/tolerance.test.js
@@ -9,10 +9,10 @@ import {
 /**
  * @fileoverview Unit tests for the shared hit-test tolerances. Pins the three
  * geometric contracts (box test, circle test, closest-within-circle) and the
- * zoom-aware data-space tolerance derivation with its min/max clamps.
+ * zoom-aware data-space tolerance derivation.
  */
 
-/** A tolerance of 0.5s × 50Hz, matching the documented ceiling values */
+/** An arbitrary tolerance of 0.5s × 50Hz, for the pure geometric tests */
 const TOL = { time: 0.5, freq: 50 }
 
 describe('isWithinDataTolerance (box test)', () => {
@@ -66,8 +66,7 @@ describe('findClosestTarget', () => {
 
 describe('getUniformTolerance', () => {
   /**
-   * Build a viewport whose 8px hit radius lands strictly between the
-   * documented floors (0.01s / 1Hz) and ceilings (0.5s / 50Hz):
+   * Build a viewport of a known size and span:
    * time: (8 / 1000px) × 30s = 0.24s, freq: (8 / 800px) × 2000Hz = 20Hz.
    * @param {number} zoomLevel - Zoom level for the viewport
    * @returns {any} Viewport for getUniformTolerance
@@ -82,6 +81,24 @@ describe('getUniformTolerance', () => {
 
   const image = /** @type {any} */ ({})
 
+  /**
+   * Convert a viewport's tolerance back into the rendered pixel radius it
+   * represents on each axis. This is the contract the constant states: eight
+   * pixels, whatever the gram's span or the zoom level.
+   * @param {any} viewport - Viewport to measure
+   * @returns {{time: number, freq: number}} Radius in rendered pixels per axis
+   */
+  function pixelRadiusOf(viewport) {
+    const { config, imageDetails, zoom } = viewport
+    const tolerance = getUniformTolerance(viewport, image)
+    const height = imageDetails.renderHeight || imageDetails.naturalHeight
+    const width = imageDetails.renderWidth || imageDetails.naturalWidth
+    return {
+      time: tolerance.time / (config.timeMax - config.timeMin) * height * zoom.level,
+      freq: tolerance.freq / (config.freqMax - config.freqMin) * width * zoom.level
+    }
+  }
+
   test('derives data-space tolerance from the rendered size at zoom 1', () => {
     expect(getUniformTolerance(makeViewport(1), image)).toEqual({ time: 0.24, freq: 20 })
   })
@@ -90,20 +107,45 @@ describe('getUniformTolerance', () => {
     expect(getUniformTolerance(makeViewport(2), image)).toEqual({ time: 0.12, freq: 10 })
   })
 
-  test('extreme zoom clamps to the floor instead of going hair-trigger', () => {
-    expect(getUniformTolerance(makeViewport(1000), image)).toEqual({ time: 0.01, freq: 1 })
+  test('the grab radius stays 8 rendered pixels at every zoom level', () => {
+    for (const level of [0.5, 1, 2, 10, 1000]) {
+      const radius = pixelRadiusOf(makeViewport(level))
+      expect(radius.time).toBeCloseTo(8, 6)
+      expect(radius.freq).toBeCloseTo(8, 6)
+    }
   })
 
-  test('a tiny render of a huge range clamps to the ceiling', () => {
+  test('a tiny render of a huge range still grabs across 8 pixels', () => {
+    // Formerly clamped to a 0.5s / 50Hz ceiling, which on this viewport is
+    // 0.08px of time — a hotspot far narrower than any glyph drawn on it.
     const viewport = {
       config: { timeMin: 0, timeMax: 600, freqMin: 0, freqMax: 100000 },
       imageDetails: { naturalWidth: 100, naturalHeight: 100, renderWidth: 100, renderHeight: 100 },
       zoom: { level: 1 }
     }
-    expect(getUniformTolerance(viewport, image)).toEqual({ time: 0.5, freq: 50 })
+    expect(getUniformTolerance(viewport, image)).toEqual({ time: 48, freq: 8000 })
+    const radius = pixelRadiusOf(viewport)
+    expect(radius.time).toBeCloseTo(8, 6)
+    expect(radius.freq).toBeCloseTo(8, 6)
   })
 
-  test('missing viewport falls back to the floor tolerance', () => {
+  test('the grab radius does not depend on how much data a gram spans', () => {
+    // The bug this replaced: two grams of the same pixel size, differing only
+    // in the span they cover, had wildly different grab regions on screen.
+    const narrow = {
+      config: { timeMin: 0, timeMax: 10, freqMin: 0, freqMax: 100 },
+      imageDetails: { naturalWidth: 902, naturalHeight: 237, renderWidth: 902, renderHeight: 237 },
+      zoom: { level: 1 }
+    }
+    const wide = {
+      ...narrow,
+      config: { timeMin: 0, timeMax: 600, freqMin: 0, freqMax: 20000 }
+    }
+    expect(pixelRadiusOf(narrow).time).toBeCloseTo(pixelRadiusOf(wide).time, 6)
+    expect(pixelRadiusOf(narrow).freq).toBeCloseTo(pixelRadiusOf(wide).freq, 6)
+  })
+
+  test('missing viewport falls back to a nominal tolerance', () => {
     expect(getUniformTolerance(/** @type {any} */ (null), image)).toEqual({ time: 0.01, freq: 1.0 })
   })
 


### PR DESCRIPTION
Reported from v0.1.16: in Doppler mode, hovering a marker never switched to the "target" bracket cursor, and the markers could not be dragged. Code inspection found two independent causes, both confirmed by instrumented headless runs.

## 1. The cursor was applied to an element the pointer never hits

`DopplerMode` was the only mode that had not overridden `BaseMode.updateCursorStyle`, which wrote the style to `instance.ui.spectrogramImage` — the SVG `<image>`. Analysis, Harmonics and Pan each had their own copy writing to `instance.ui.svg`.

`cursor` resolves on whatever element the pointer actually hits, and features are drawn *over* the image as siblings of it. Over a doppler marker the hit element was the marker circle (or the curve's vertical extension line stacked on top of it), which inherits `cursor: crosshair` from `.gram-frame-svg`. The bracket cursor was computed and applied correctly every time — just on an element that was never under the pointer:

```
hover ON gram-frame-doppler-fPlus  svg="crosshair"  img="url(data:image/svg+xml,...brackets...)"
```

**Fix:** `BaseMode.updateCursorStyle` now writes to the SVG root, where every descendant inherits it. The three duplicate overrides are deleted; `PanMode.applyCursor` was a fourth copy under another name and now uses the inherited method too.

Also added `pointer-events: none` to `.gram-frame-doppler-extension`. The extensions are drawn after the f+/f- dots, so they sat on top of the very markers being aimed at. Doppler hit-testing is done in data space, so nothing needed them to be targets.

## 2. The grab region was smaller than the drawn marker

`getUniformTolerance` derived an 8px hit radius and then clamped it to absolute data-space ceilings (`time: 0.5s`, `freq: 50Hz`). A ceiling in seconds cannot express "8 pixels": on the debug gram (237px tall, 0–60s) 0.5s is **1.97px**, and on `pub10-gram1` (0–40s) 2.96px. The marker circle is `r=4`, so the grab band down the time axis was *narrower than the dot drawn on it*.

Measured on `fMinus` before the fix:

```
dy=0..3  drag starts        dx=0..8   drag starts
dy=4+    nothing happens    dx=12+    nothing happens
```

Dead centre on the dot, 4px above its middle, `findDopplerMarkerAtPosition` returned null and `startDrag` returned false — the "can't drag to change the curve" symptom.

**Fix:** both clamps removed. The tolerance is now exactly `pixelRadius` (8) rendered pixels per axis, at every zoom and every gram span, which is what the constant always claimed. This affects every mode's hit test, since they all share `getUniformTolerance` — analysis markers had the same flattened ellipse.

This is **BH-22** in `docs/Bug-Hunt-2026-08.md`, previously logged as Plausible and left open pending a fixture. The field report is that fixture; the doc is updated to Confirmed/fixed.

## Tests

`tests/doppler-mode.spec.js` drove `page.mouse` at absolute page coordinates like `(200, 150)`, which on the debug page sit ~390px **above** the component. No marker was ever placed, so every assertion sat behind an `if (state.doppler.fPlus)` or bailed out with an early `return` — 825 lines of green that exercised nothing. It even contained a test named *"should update cursor style when hovering over markers"* whose only assertion was `expect(typeof cursor).toBe('string')`, and an Issue #136 drag test that returned early before its one real assertion.

- **Rewritten** `tests/doppler-mode.spec.js` (22 tests) against the gram's own bounding box, with unconditional assertions: placement and f+/f- ordering, f₀ midpoint derivation, independent dragging of each marker, the speed formula and LED, coordinate ranges, cross-mode persistence, right-click reset, and drag-state cleanliness.
- **New** `tests/doppler-hotspot.spec.js` — every pixel of a drawn marker grabs it, the radius reaches 8px on both axes, a press well clear grabs nothing, and a drag moves only its own marker.
- **New** doppler case in `tests/cursor-hover.spec.js` — the mode that was missing from the four it covers.
- `tests/unit/tolerance.test.js` now pins the contract as a pixel radius: constant across zoom levels and across gram spans.

Both new specs were verified to **fail** against the unfixed code before being kept.

Full suite: 308 Playwright + 125 Vitest passing; `yarn typecheck`, `yarn lint` and `yarn hygiene` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AGc1ES6P2QiHERsG4ocAp

---
_Generated by [Claude Code](https://claude.ai/code/session_014AGc1ES6P2QiHERsG4ocAp)_