### PR TITLE
Add Sidebands mode (issue #241)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ curl -d "status here" ntfy.sh/iancc2025
 - **Main Class**: `GramFrame` in `src/main.js` - Central component managing all functionality
 - **Entry Point**: `src/index.js` - Main module export and global registration
 - **State Management**: `src/core/state.js` - Centralized state with listener pattern
-- **Mode System**: Modular architecture with four modes — Pan (default), Analysis, Harmonics and Doppler
+- **Mode System**: Modular architecture with five modes — Pan (default), Analysis, Harmonics, Sidebands and Doppler
 - **Feature Rendering**: `src/core/FeatureRenderer.js` - Cross-mode feature coordination
 - **Mode Factory**: `src/modes/ModeFactory.js` - Centralized mode instantiation
 
@@ -92,19 +92,27 @@ Every path below exists; keep this list in step with `src/` when adding modules.
   - `BaseMode.js` - Abstract base class for all modes
   - `ModeFactory.js` - Mode instantiation factory
   - `analysis/AnalysisMode.js` - Analysis mode with marker persistence
-  - `harmonics/HarmonicsMode.js` - Harmonics calculation mode
+  - `harmonics/HarmonicsMode.js` - Harmonics calculation mode (a `PinSetMode`)
   - `harmonics/ManualHarmonicModal.js` - Manual harmonic-spacing dialog
+  - `sideband/SidebandMode.js` - Sidebands mode: a pin set whose origin the
+    analyst places (a `PinSetMode`)
   - `doppler/DopplerMode.js` - Doppler speed calculation mode
   - `pan/PanMode.js` - Pan mode (the default mode)
   - `capabilities.js` - Duck-typed mode capabilities (`PersistentFeatureProvider`,
-    `PanelOwner`) and their predicates. How `FeatureRenderer` and `MainUI` find
+    `PanelOwner`, `PinSetOwner`) and their predicates. How `FeatureRenderer` and `MainUI` find
     what a mode can do without naming it (ADR-017)
   - `shared/BaseDragHandler.js` - The shared drag engine: every pointer drag (move, create, place, pan) and the single `state.drag` projection
+  - `shared/PinSetMode.js` - The shared pin-set mode: pin geometry, the
+    label/symbol stack, hit testing, rendering, drag wiring and set
+    add/update/remove for Harmonics and Sidebands. A subclass supplies only
+    where its sets live and what frequency a member index maps to
 - `src/components/` - UI component modules:
   - `UIComponents.js` - LED displays, colour picker and layout helpers
   - `MainUI.js` - Unified layout and persistent panels
   - `ModeButtons.js` - Mode switching interface
   - `HarmonicPanel.js` - Harmonics display panel
+  - `SidebandPanel.js` - Sidebands display panel (shares the right-hand column
+    with the harmonics panel, one shown at a time)
   - `DiffingTable.js` - Shared row-diffing table behind the markers table and harmonics panel
   - `ColorPicker.js` - Colour selection component
   - `SymbolPicker.js` - Symbol selection component
@@ -198,7 +206,7 @@ There is no visual/screenshot regression testing — see
 ## Important Implementation Notes
 
 ### Architecture
-- **Modular Mode System**: Each mode (Pan, Analysis, Harmonics, Doppler) extends BaseMode
+- **Modular Mode System**: Each mode (Pan, Analysis, Harmonics, Sidebands, Doppler) extends BaseMode
 - **Feature Persistence**: FeatureRenderer coordinates cross-mode feature visibility
 - **Factory Pattern**: ModeFactory centralizes mode instantiation and error handling
 - **Separation of Concerns**: Clear separation between rendering, state, events, and UI
@@ -257,6 +265,8 @@ There is no visual/screenshot regression testing — see
 - **Analysis Mode**: Persistent draggable markers with cross-mode visibility and optional
   haloed text labels (upper-right of a crosshair, centred above a shaped symbol)
 - **Harmonics Mode**: Real-time harmonic calculation and display
+- **Sidebands Mode**: A pin set with a user-placed origin — the fundamental —
+  with members spread each side of it and labelled by signed offset
 - **Doppler Mode**: Speed calculation from f+/f-/f₀ markers
 
 ## Active Technologies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,8 +111,8 @@ Every path below exists; keep this list in step with `src/` when adding modules.
   - `MainUI.js` - Unified layout and persistent panels
   - `ModeButtons.js` - Mode switching interface
   - `HarmonicPanel.js` - Harmonics display panel
-  - `SidebandPanel.js` - Sidebands display panel (shares the right-hand column
-    with the harmonics panel, one shown at a time)
+  - `SidebandPanel.js` - Sidebands display panel (its own column beside the
+    harmonics panel; both are always visible)
   - `DiffingTable.js` - Shared row-diffing table behind the markers table and harmonics panel
   - `ColorPicker.js` - Colour selection component
   - `SymbolPicker.js` - Symbol selection component

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This component provides an interactive overlay for sonar spectrogram images, ena
 
 ## Key Features
 
-- Modes: Pan (default), Analysis, Harmonics, Doppler
+- Modes: Pan (default), Analysis, Harmonics, Sidebands, Doppler
 - Harmonic line overlays with frequency labels
 - Retro-style LED readouts for measurement
 - Drag-to-place cursor system with unlimited cursors
@@ -24,7 +24,7 @@ This component provides an interactive overlay for sonar spectrogram images, ena
 
 ## Annotation Persistence
 
-Annotations (analysis markers, harmonic sets, and Doppler curves) are saved to
+Annotations (analysis markers, harmonic sets, sideband sets, and Doppler curves) are saved to
 browser storage automatically. The storage backend depends on whether the page
 is detected as a **trainer** or **student** context:
 

--- a/debug-trainer.html
+++ b/debug-trainer.html
@@ -40,7 +40,7 @@
     
     .component-container {
       flex-basis: calc(75% - 10px);
-      min-width: 1020px;
+      min-width: 1200px;
     }
     
     .diagnostics-panel {

--- a/debug.html
+++ b/debug.html
@@ -40,7 +40,7 @@
     
     .component-container {
       flex-basis: calc(75% - 10px);
-      min-width: 1020px;
+      min-width: 1200px;
     }
     
     .diagnostics-panel {

--- a/docs/Data-and-State-Guide.md
+++ b/docs/Data-and-State-Guide.md
@@ -52,13 +52,14 @@ All runtime data for a GramFrame instance lives in a single `state` object. See 
     kind: null,               // 'move' | 'create' | 'place' | 'pan'
     mode: null,               // Mode that owns the drag; null for the central pan
     targetId: null,           // Dragged feature's id; null for a pan
-    targetType: null,         // 'marker' | 'harmonicSet' | 'dopplerMarker' | null
+    targetType: null,         // 'marker' | 'harmonicSet' | 'sidebandSet' | 'dopplerMarker' | null
     startPosition: null       // Where the drag began, in data coordinates
   },
 
   // Mode-specific state (merged from each mode's getInitialState())
   analysis: { markers: [...], ... },
   harmonics: { harmonicSets: [...], ... },
+  sidebands: { sidebandSets: [...] },
   doppler: { fPlus, fMinus, fZero, ... },
   // ...
 }

--- a/docs/Gram-Modes.md
+++ b/docs/Gram-Modes.md
@@ -1,15 +1,15 @@
 # Gram Component Interaction Modes
 
-GramFrame has **four** interaction modes: **Pan**, **Cross Cursor** (the
-analysis mode), **Harmonics** and **Doppler**. This document describes what each
-one does for an analyst; for how they are built see
+GramFrame has **five** interaction modes: **Pan**, **Cross Cursor** (the
+analysis mode), **Harmonics**, **Sidebands** and **Doppler**. This document
+describes what each one does for an analyst; for how they are built see
 [Tech-Architecture.md](Tech-Architecture.md).
 
 Behaviour common to every mode:
 
 - The time/frequency readouts follow the cursor regardless of the active mode.
-- Markers, harmonic sets and doppler curves stay visible in all modes once
-  placed — only the mode that *creates* them changes.
+- Markers, harmonic sets, sideband sets and doppler curves stay visible in all
+  modes once placed — only the mode that *creates* them changes.
 - Ctrl+wheel zooms about the pointer, wheel scrolls along frequency when zoomed
   in, and a middle-button drag pans — in every mode.
 - Switching mode clears the current selection, so the colour/symbol controls
@@ -87,6 +87,35 @@ multiples of a spacing.
   the unlabelled harmonics still show against the data.
 - Sets are listed in the harmonics panel; selecting a row enables arrow-key
   adjustment and in-place restyling, as for markers.
+
+---
+
+## 📻 Sidebands Mode
+
+### Purpose
+
+Reveal a modulated tonal: a carrier with equally-spaced sidebands either side of
+it, such as a shaft rate modulating a blade tone. It is Harmonics mode with the
+origin freed — the analyst places the fundamental rather than counting up from
+0 Hz.
+
+### Behaviour
+
+- Click to set the **fundamental** at that frequency. About eight sidebands
+  appear, equally spaced either side of it: an equal count each side when the
+  fundamental sits mid-axis, and more on the roomier side when it does not.
+- The initial spacing is only a starting point — hold the drag on and keep
+  moving, or drag again, to match the spacing to the data underneath.
+- Drag the **0** line to move the fundamental; drag any other line to set the
+  spacing, which holds the line you grabbed under the cursor. Dragging
+  vertically moves the set's anchor time, as in Harmonics mode.
+- Each sideband is labelled by its signed offset from the fundamental — `0`,
+  `+1`, `-1` and so on — and is drawn with the same pins, symbols, colours and
+  **Tall Pins** toggle as a harmonic set. Dense sets are sampled the same way.
+- Sets are listed in the **Sidebands** panel, which shares the right-hand column
+  with the harmonics panel: the column shows the sidebands table while this mode
+  is active and the harmonics table otherwise. Selecting a row enables arrow-key
+  spacing adjustment and in-place restyling, as for harmonic sets.
 
 ---
 

--- a/docs/Gram-Modes.md
+++ b/docs/Gram-Modes.md
@@ -112,10 +112,10 @@ origin freed — the analyst places the fundamental rather than counting up from
 - Each sideband is labelled by its signed offset from the fundamental — `0`,
   `+1`, `-1` and so on — and is drawn with the same pins, symbols, colours and
   **Tall Pins** toggle as a harmonic set. Dense sets are sampled the same way.
-- Sets are listed in the **Sidebands** panel, which shares the right-hand column
-  with the harmonics panel: the column shows the sidebands table while this mode
-  is active and the harmonics table otherwise. Selecting a row enables arrow-key
-  spacing adjustment and in-place restyling, as for harmonic sets.
+- Sets are listed in the **Sidebands** panel, which sits beside the harmonics
+  panel and is visible in every mode, as the markers and harmonics tables are.
+  Selecting a row enables arrow-key spacing adjustment and in-place restyling,
+  as for harmonic sets.
 
 ---
 

--- a/docs/HTML-Integration-Guide.md
+++ b/docs/HTML-Integration-Guide.md
@@ -122,7 +122,7 @@ State is deep-copied before being passed to listeners, so you cannot accidentall
 
 ## Annotation Persistence (Trainer vs. Student)
 
-GramFrame can persist annotations (analysis markers, harmonic sets, doppler
+GramFrame can persist annotations (analysis markers, harmonic sets, sideband sets, doppler
 curves) in browser storage. The storage backend depends on whether the page is
 detected as a **trainer** page or a **student** page:
 

--- a/hygiene-baseline.json
+++ b/hygiene-baseline.json
@@ -1,10 +1,10 @@
 {
   "_comment": "Debt ratchet baselines (specs/164-quality-ratchets). `yarn hygiene` fails any change that raises a count above its baseline. When your change lowers a count, lower the baseline here in the same PR so the improvement is locked in.",
-  "_comment_sc004_exceptions": "spec 167 SC-004 asks that no source module exceed ~350 lines except by documented exception. It is a review heuristic, not a gate \u2014 nothing here enforces it. Modules over the line that no story in spec 167 touched, with why: HarmonicsMode.js (1054), DopplerMode.js (685) and AnalysisMode.js (640) are the three feature modes, flagged as candidates for a later phase; keyboardControl.js (565) and events.js (395) are input handling; GramFrameAPI.js (399) is the public surface plus its failure handling; types.js (583) is exempt as declarations. main.js is over the line too, and is the one module here that a later phase should split. table.js came down from 713 to 151 and is scaffold-only.",
+  "_comment_sc004_exceptions": "spec 167 SC-004 asks that no source module exceed ~350 lines except by documented exception. It is a review heuristic, not a gate \u2014 nothing here enforces it. Modules over the line that no story in spec 167 touched, with why: DopplerMode.js (685) and AnalysisMode.js (640) are feature modes, flagged as candidates for a later phase; PinSetMode.js (995) is the shared pin-set mode Harmonics and Sidebands are built from \u2014 extracting it took HarmonicsMode.js from 1054 to 373 and let Sidebands (issue #241) land in ~310; keyboardControl.js (565) and events.js (395) are input handling; GramFrameAPI.js (399) is the public surface plus its failure handling; types.js (583) is exempt as declarations. main.js is over the line too, and is the one module here that a later phase should split. table.js came down from 713 to 151 and is scaffold-only.",
   "circularDependencies": 0,
   "unusedExportModules": 5,
   "waitForTimeoutOccurrences": 1,
   "_comment_instanceSurface": "specs/167-structural-refactor Story 5. instanceStateReachIns counts lines containing `instance.state` under src/; instanceFields counts class-field declarations between `export class GramFrame` and its constructor in src/main.js.",
-  "instanceStateReachIns": 170,
+  "instanceStateReachIns": 160,
   "instanceFields": 11
 }

--- a/src/components/ColorPicker.js
+++ b/src/components/ColorPicker.js
@@ -130,7 +130,8 @@ export function createColorPicker(instance) {
   // gram.
   symbolRow.appendChild(createLargeSymbolToggle(instance))
 
-  // --- Harmonics band: the pin toggle is the one harmonics-only control ---
+  // --- Pin band: the pin toggle is the one control that applies to pin sets
+  // (harmonic and sideband) rather than to every feature ---
   const divider = document.createElement('div')
   divider.className = 'gram-frame-style-divider'
   container.appendChild(divider)
@@ -144,7 +145,7 @@ export function createColorPicker(instance) {
   harmonicsRow.className = 'gram-frame-style-row'
   harmonicsGroup.appendChild(harmonicsRow)
 
-  harmonicsRow.appendChild(createGroupLabel('Harmonics'))
+  harmonicsRow.appendChild(createGroupLabel('Pin sets'))
   harmonicsRow.appendChild(createPinToggle(instance))
 
   // Add click handler for color selection

--- a/src/components/MainUI.js
+++ b/src/components/MainUI.js
@@ -2,7 +2,7 @@
  * MainUI module for GramFrame
  * 
  * This module handles the creation and management of the main UI layout
- * including the unified 3-column layout, LED displays, and container setup.
+ * including the unified 4-column layout, LED displays, and container setup.
  */
 
 /// <reference path="../types.js" />
@@ -17,7 +17,8 @@ import {
 import { formatTime } from '../utils/timeFormatter.js'
 
 /**
- * Create unified 3-column layout for readouts.
+ * Create the unified layout for readouts: the left readout column plus the
+ * three persistent feature tables (markers, harmonics, sidebands).
  *
  * Returns the handles rather than writing them onto the instance, so the
  * constructor is the one place they are adopted (spec 167, FR-009).
@@ -106,8 +107,21 @@ export function createUnifiedLayout(instance) {
   const markersContainer = createMarkersContainer()
   middleColumn.appendChild(markersContainer)
   
-  // Right Column (175px) - Harmonics sets table. Narrowed from 200px to fund
-  // the markers column's Label column (feature 231); its four columns still fit.
+  // Right Column (175px) - the pin-set table: Harmonics, or Sidebands while
+  // that mode is active. Narrowed from 200px to fund the markers column's Label
+  // column (feature 231); its four columns still fit.
+  //
+  // Sidebands share this column rather than taking a fourth of their own, and
+  // take turns in it rather than splitting it (issue #241). Both alternatives
+  // were measured at a 1280px viewport, where the control row's width is
+  // already fully spoken for:
+  //   - a fourth fixed column squeezes the guidance column to its 150px
+  //     minimum, where the text wraps to roughly twice the height and pushes
+  //     the whole row — and the spectrogram under it — ~80px down the page;
+  //   - splitting this column in two leaves each table ~45px of body, which is
+  //     less than one row: the sticky header covers whatever you scroll to.
+  // Swapping costs neither. The two tables are mode-specific in a way the
+  // markers table is not: a sideband set is managed from Sidebands mode.
   const rightColumn = /** @type {HTMLDivElement} */ (createFlexColumn('gram-frame-right-column'))
   rightColumn.style.flex = '0 0 175px'
   rightColumn.style.minWidth = '175px'
@@ -116,7 +130,11 @@ export function createUnifiedLayout(instance) {
   // Create harmonics container in right column
   const harmonicsContainer = createHarmonicsContainer()
   rightColumn.appendChild(harmonicsContainer)
-  
+
+  // Sideband sets, in the same column, shown while Sidebands mode is active
+  const sidebandsContainer = createSidebandsContainer()
+  rightColumn.appendChild(sidebandsContainer)
+
   // Assemble the unified layout
   unifiedLayoutContainer.appendChild(leftColumn)
   unifiedLayoutContainer.appendChild(middleColumn)
@@ -132,6 +150,7 @@ export function createUnifiedLayout(instance) {
     controlsColumn,
     markersContainer,
     harmonicsContainer,
+    sidebandsContainer,
     timeLED,
     freqLED,
     speedLED,
@@ -140,16 +159,42 @@ export function createUnifiedLayout(instance) {
 }
 
 /**
+ * Create the sidebands container for sidebands mode.
+ *
+ * The same header-plus-table structure as the markers panel (no action slot —
+ * sidebands have no "+ Manual" equivalent), so all three panels carry their
+ * rule, spacing and heading position from the one `gram-frame-panel-header`
+ * rule rather than from per-panel inline styles. It shares the right column
+ * with the harmonics panel, one shown at a time — see the note there — so it is
+ * `flex: 1` like its counterpart and fills the column when it is the one shown.
+ * @returns {HTMLDivElement} The sidebands container
+ */
+function createSidebandsContainer() {
+  const sidebandsContainer = document.createElement('div')
+  sidebandsContainer.className = 'gram-frame-sidebands-persistent-container'
+
+  const header = document.createElement('div')
+  header.className = 'gram-frame-panel-header'
+
+  const label = document.createElement('h4')
+  label.textContent = 'Sidebands'
+  header.appendChild(label)
+  sidebandsContainer.appendChild(header)
+
+  return sidebandsContainer
+}
+
+/**
  * Create markers container for analysis mode
  * @returns {HTMLDivElement} The markers container
  */
 function createMarkersContainer() {
+  // Layout comes from the shared `*-persistent-container` CSS rule, not from
+  // inline styles: they duplicated it exactly, and an inline `display` cannot be
+  // overridden by the stylesheet — which is how the sidebands panel takes its
+  // turn in the right column.
   const markersContainer = document.createElement('div')
   markersContainer.className = 'gram-frame-markers-persistent-container'
-  markersContainer.style.flex = '1'
-  markersContainer.style.display = 'flex'
-  markersContainer.style.flexDirection = 'column'
-  markersContainer.style.minHeight = '0'
   
   // Same header row as the harmonics panel, minus the action slot: both panels
   // then carry their rule, their spacing and their heading position from one
@@ -172,10 +217,6 @@ function createMarkersContainer() {
 function createHarmonicsContainer() {
   const harmonicsContainer = document.createElement('div')
   harmonicsContainer.className = 'gram-frame-harmonics-persistent-container'
-  harmonicsContainer.style.flex = '1'
-  harmonicsContainer.style.display = 'flex'
-  harmonicsContainer.style.flexDirection = 'column'
-  harmonicsContainer.style.minHeight = '0'
   
   // Create header container with title and button area
   const harmonicsHeader = document.createElement('div')

--- a/src/components/MainUI.js
+++ b/src/components/MainUI.js
@@ -39,7 +39,15 @@ export function createUnifiedLayout(instance) {
   // (shrink:1, min-width:0) so a narrow host stays clip-free instead of cutting
   // off the tables.
   const leftColumn = /** @type {HTMLDivElement} */ (createFullFlexLayout('gram-frame-left-column', '4px'))
-  leftColumn.style.flex = '0 1 750px'
+  // Grows into whatever the tables leave, but never past its 750px basis, so
+  // the spare width of a wide host reaches the guidance column instead of
+  // pooling at the right-hand edge — while the tables still stay grouped
+  // alongside rather than being pushed away (issue #241). Growing matters now
+  // that the guidance panel is absolutely positioned: it contributes no
+  // intrinsic width of its own, so without this the left column sat at the sum
+  // of its minimums whatever room was going spare.
+  leftColumn.style.flex = '1 1 750px'
+  leftColumn.style.maxWidth = '750px'
   leftColumn.style.width = 'auto'
   leftColumn.style.minWidth = '0'
   leftColumn.style.flexDirection = 'row'
@@ -49,10 +57,10 @@ export function createUnifiedLayout(instance) {
   modeColumn.style.flex = '0 0 130px'
   modeColumn.style.width = '130px'
   
-  // Column 2: Guidance panel  
+  // Column 2: Guidance panel. Its minimum width lives in CSS beside the rest of
+  // the column's styling — an inline one here silently outranked it.
   const guidanceColumn = /** @type {HTMLDivElement} */ (createFlexColumn('gram-frame-guidance-column', '8px'))
   guidanceColumn.style.flex = '1'
-  guidanceColumn.style.minWidth = '150px'
   
   // Column 3: Controls (time/freq displays, speed, color selector)
   const controlsColumn = /** @type {HTMLDivElement} */ (createFlexColumn('gram-frame-controls-column', '1px'))
@@ -107,44 +115,36 @@ export function createUnifiedLayout(instance) {
   const markersContainer = createMarkersContainer()
   middleColumn.appendChild(markersContainer)
   
-  // Right Column (175px) - the pin-set table: Harmonics, or Sidebands while
-  // that mode is active. Narrowed from 200px to fund the markers column's Label
-  // column (feature 231); its four columns still fit.
+  // Right column - Harmonics sets table, and beside it the Sidebands table.
+  // Both are always visible: a pin set of either kind is managed from its own
+  // table whatever mode is active, exactly as the markers table is (issue #241).
   //
-  // Sidebands share this column rather than taking a fourth of their own, and
-  // take turns in it rather than splitting it (issue #241). Both alternatives
-  // were measured at a 1280px viewport, where the control row's width is
-  // already fully spoken for:
-  //   - a fourth fixed column squeezes the guidance column to its 150px
-  //     minimum, where the text wraps to roughly twice the height and pushes
-  //     the whole row — and the spectrogram under it — ~80px down the page;
-  //   - splitting this column in two leaves each table ~45px of body, which is
-  //     less than one row: the sticky header covers whatever you scroll to.
-  // Swapping costs neither. The two tables are mode-specific in a way the
-  // markers table is not: a sideband set is managed from Sidebands mode.
+  // Both are 175px, the width the harmonics table has always had, so the pair
+  // reads as a pair. The row is that much wider for it: where a host cannot give
+  // it the room, the guidance column takes the squeeze and its panel scrolls
+  // rather than the row growing taller and pushing the gram down the page — see
+  // the note on `.gram-frame-guidance` in gramframe.css. Widths live in CSS with
+  // the rest of each column's styling.
   const rightColumn = /** @type {HTMLDivElement} */ (createFlexColumn('gram-frame-right-column'))
-  rightColumn.style.flex = '0 0 175px'
-  rightColumn.style.minWidth = '175px'
-  rightColumn.style.width = '175px'
-  
-  // Create harmonics container in right column
   const harmonicsContainer = createHarmonicsContainer()
   rightColumn.appendChild(harmonicsContainer)
 
-  // Sideband sets, in the same column, shown while Sidebands mode is active
+  const sidebandsColumn = /** @type {HTMLDivElement} */ (createFlexColumn('gram-frame-sidebands-column'))
   const sidebandsContainer = createSidebandsContainer()
-  rightColumn.appendChild(sidebandsContainer)
+  sidebandsColumn.appendChild(sidebandsContainer)
 
   // Assemble the unified layout
   unifiedLayoutContainer.appendChild(leftColumn)
   unifiedLayoutContainer.appendChild(middleColumn)
   unifiedLayoutContainer.appendChild(rightColumn)
-  
+  unifiedLayoutContainer.appendChild(sidebandsColumn)
+
   return {
     unifiedLayoutContainer,
     leftColumn,
     middleColumn,
     rightColumn,
+    sidebandsColumn,
     modeColumn,
     guidanceColumn,
     controlsColumn,

--- a/src/components/ModeButtons.js
+++ b/src/components/ModeButtons.js
@@ -25,7 +25,7 @@ export function createModeSwitchingUI(modeCell, state, modeSwitchCallback, modes
   
   // Create mode buttons
   /** @type {ModeType[]} */
-  const modeTypes = ['pan', 'analysis', 'harmonics', 'doppler']
+  const modeTypes = ['pan', 'analysis', 'harmonics', 'sideband', 'doppler']
   /** @type {Object<string, HTMLButtonElement>} */
   const modeButtons = {}
   /** @type {Object<string, HTMLButtonElement[]>} */

--- a/src/components/PinToggle.js
+++ b/src/components/PinToggle.js
@@ -1,20 +1,21 @@
 /**
- * Harmonic-pin visibility toggle for GramFrame overlays.
+ * Pin visibility toggle for GramFrame overlays.
  *
- * A checkbox in the style panel's Harmonics band (see ColorPicker.js) that
- * controls whether a harmonic set draws its full-height vertical pin lines.
- * Pins are the only style in that panel harmonic sets alone understand, which is
- * why the band is fenced off below a rule. With the toggle off, a set renders as
- * its symbols and numbers over short mini-pins — the style experienced analysts
- * use to stack many harmonic sets over dense data without the lines swamping it.
+ * A checkbox in the style panel's Pin sets band (see ColorPicker.js) that
+ * controls whether a pin set — a harmonic set, or a sideband set (issue #241) —
+ * draws its full-height vertical pin lines. Pins are the only style in that
+ * panel that pin sets alone understand, which is why the band is fenced off
+ * below a rule. With the toggle off, a set renders as its symbols and numbers
+ * over short mini-pins — the style experienced analysts use to stack many sets
+ * over dense data without the lines swamping it.
  *
  * It is labelled "Tall Pins" rather than "Pin" because a pin-less set still
  * draws mini-pins (issue #232): the choice is between tall pins and short ones,
  * not between pins and none.
  *
- * When a harmonic set is selected, toggling restyles that set in place;
- * otherwise the choice is written to `state.showHarmonicPin` and applied to the
- * next created set. The preference is on at the start of each browser session
+ * When a pin set is selected, toggling restyles that set in place; otherwise
+ * the choice is written to `state.showHarmonicPin` and applied to the next
+ * created set. The preference is on at the start of each browser session
  * and remembered (sessionStorage) for the rest of it.
  *
  * The toggle has no meaning for analysis markers (they have no pin), so it is
@@ -27,7 +28,7 @@ import { savePinPreference } from '../core/storage.js'
 import { showStorageWarning, clearStorageWarning } from './StorageWarning.js'
 
 /**
- * Create the harmonic-pin toggle row.
+ * Create the pin toggle row.
  * @param {GramFrame} instance - GramFrame instance
  * @returns {HTMLLabelElement} The toggle row element
  */
@@ -36,13 +37,13 @@ export function createPinToggle(instance) {
 
   const row = document.createElement('label')
   row.className = 'gram-frame-pin-toggle'
-  row.title = 'Draw harmonic sets with full-height pin lines instead of mini-pins'
+  row.title = 'Draw harmonic and sideband sets with full-height pin lines instead of mini-pins'
 
   const checkbox = document.createElement('input')
   checkbox.type = 'checkbox'
   checkbox.className = 'gram-frame-pin-toggle-input'
   checkbox.checked = state.showHarmonicPin !== false
-  checkbox.setAttribute('aria-label', 'Show tall harmonic pins')
+  checkbox.setAttribute('aria-label', 'Show tall pins')
 
   const text = document.createElement('span')
   text.className = 'gram-frame-pin-toggle-label'
@@ -53,9 +54,9 @@ export function createPinToggle(instance) {
 
   checkbox.addEventListener('change', () => {
     const showPin = checkbox.checked
-    // Route to the selected harmonic set when one is selected (restyle in
-    // place), otherwise set the style for the next created set and remember it
-    // for the rest of the session.
+    // Route to the selected pin set — harmonic or sideband — when one is
+    // selected (restyle in place), otherwise set the style for the next created
+    // set and remember it for the rest of the session.
     if (!instance.interaction.applyPinToSelectedFeature || !instance.interaction.applyPinToSelectedFeature(showPin)) {
       state.showHarmonicPin = showPin
       // The choice applies immediately either way; the warning only says it
@@ -80,8 +81,8 @@ export function createPinToggle(instance) {
       checkbox.disabled = !enabled
       row.classList.toggle('gram-frame-pin-toggle-disabled', !enabled)
       row.title = enabled
-        ? 'Draw harmonic sets with full-height pin lines instead of mini-pins'
-        : 'Tall pins apply to harmonic sets only'
+        ? 'Draw harmonic and sideband sets with full-height pin lines instead of mini-pins'
+        : 'Tall pins apply to harmonic and sideband sets only'
     }
   }
 

--- a/src/components/SidebandPanel.js
+++ b/src/components/SidebandPanel.js
@@ -1,0 +1,123 @@
+/**
+ * Sideband Management Panel Component (issue #241)
+ *
+ * The sidebands table, built on the shared {@link createDiffingTable} engine —
+ * the same one behind the markers table and the harmonics panel. What lives
+ * here is what makes this the *sidebands* panel: its columns (the fundamental
+ * and the spacing), its cell formatting, and what selecting or deleting a
+ * sideband set means.
+ */
+
+/// <reference path="../types.js" />
+
+import { createColorIndicator } from '../rendering/symbols.js'
+import { createDiffingTable } from './DiffingTable.js'
+
+/**
+ * The diffing table backing each panel element, so the
+ * `updateSidebandPanelContent(panel, instance)` signature works for every
+ * caller without them holding the table handle.
+ * @type {WeakMap<HTMLElement, {update: function(any[]): void, destroy: function(): void, element: HTMLTableElement}>}
+ */
+const panelTables = new WeakMap()
+
+/**
+ * Build the colour cell's contents: the set's symbol drawn in its colour (or a
+ * plain filled rectangle for the symbol-less `cross` style), inside the tinted
+ * wrapper the harmonics panel uses.
+ * @param {SidebandSet} sidebandSet - The sideband set data
+ * @returns {HTMLDivElement} The colour cell content
+ */
+function createColorCellContent(sidebandSet) {
+  const colorDiv = document.createElement('div')
+  colorDiv.className = 'gram-frame-sideband-color'
+  colorDiv.style.color = sidebandSet.color
+  colorDiv.appendChild(createColorIndicator(sidebandSet.symbol, sidebandSet.color))
+  return colorDiv
+}
+
+/**
+ * Build a sideband row's delete button, matching the harmonics panel's markup.
+ * @param {SidebandSet} sidebandSet - The sideband set data
+ * @returns {HTMLButtonElement} The delete button
+ */
+function createSidebandDeleteButton(sidebandSet) {
+  const button = document.createElement('button')
+  button.className = 'gram-frame-sideband-delete'
+  button.setAttribute('data-sideband-id', sidebandSet.id)
+  button.title = 'Delete sideband set'
+  button.textContent = '\u00d7'
+  return button
+}
+
+/**
+ * Create the sideband management panel.
+ *
+ * Mounted inside a `gram-frame-table-area` wrapper, exactly as the markers and
+ * harmonics tables are: the wrapper takes whatever vertical space the column
+ * has and the panel fills it, so however many sets exist the panel scrolls
+ * instead of growing the page layout.
+ *
+ * @param {HTMLElement} container - Container element to append the panel to
+ * @param {GramFrame} instance - GramFrame instance
+ * @returns {HTMLElement} The created panel element
+ */
+export function createSidebandPanel(container, instance) {
+  const table = createDiffingTable(container, {
+    columns: [
+      { label: '', width: '15%' },
+      { label: 'Freq (Hz)', width: '35%', cellClassName: 'gram-frame-sideband-freq' },
+      { label: 'Spacing (Hz)', width: '35%', cellClassName: 'gram-frame-sideband-spacing' },
+      { label: '', width: '15%' }
+    ],
+    rowAttribute: 'data-sideband-id',
+    rowClassName: 'gram-frame-sideband-row',
+    rowKey: (sidebandSet) => sidebandSet.id,
+    cells: (sidebandSet) => [
+      createColorCellContent(sidebandSet),
+      sidebandSet.fundamentalFreq.toFixed(2),
+      sidebandSet.spacing.toFixed(2),
+      createSidebandDeleteButton(sidebandSet)
+    ],
+    deleteSelector: '.gram-frame-sideband-delete',
+    onSelect: (sidebandSetId, _sidebandSet, index) => {
+      // Toggle selection
+      if (instance.state.selection.selectedType === 'sidebandSet' &&
+          instance.state.selection.selectedId === sidebandSetId) {
+        instance.interaction.clearSelection()
+      } else {
+        instance.interaction.setSelection('sidebandSet', sidebandSetId, index)
+      }
+    },
+    onDelete: (sidebandSetId) => instance.interaction.removeSidebandSet(sidebandSetId),
+    isSelected: (sidebandSetId) => (
+      instance.state.selection.selectedType === 'sidebandSet' &&
+      instance.state.selection.selectedId === sidebandSetId
+    )
+  })
+
+  const panel = /** @type {HTMLElement} */ (table.element.parentElement)
+  // Named so the mode can re-resolve its own panel from the container after a
+  // mode switch has rebuilt its UI references.
+  panel.classList.add('gram-frame-sideband-panel')
+  panelTables.set(panel, table)
+  return panel
+}
+
+/**
+ * Update sideband panel content
+ * @param {HTMLElement} panel - Panel element
+ * @param {GramFrame} instance - GramFrame instance
+ */
+export function updateSidebandPanelContent(panel, instance) {
+  if (!panel) {
+    return
+  }
+
+  const table = panelTables.get(panel)
+  if (!table) {
+    return
+  }
+
+  table.update(instance.state.sidebands.sidebandSets)
+}

--- a/src/core/initialization/EventBindings.js
+++ b/src/core/initialization/EventBindings.js
@@ -9,7 +9,7 @@
 /// <reference path="../../types.js" />
 
 import { setupEventListeners, setupResizeObserver } from '../events.js'
-import { initializeKeyboardControl, setSelection, clearSelection, updateSelectionVisuals, removeHarmonicSet, applyColorToSelectedFeature, applySymbolToSelectedFeature, applyPinToSelectedFeature, applyLargeSymbolsToSelectedFeature } from '../keyboardControl.js'
+import { initializeKeyboardControl, setSelection, clearSelection, updateSelectionVisuals, removeHarmonicSet, removeSidebandSet, applyColorToSelectedFeature, applySymbolToSelectedFeature, applyPinToSelectedFeature, applyLargeSymbolsToSelectedFeature } from '../keyboardControl.js'
 
 /**
  * Set up all event listeners for the GramFrame instance.
@@ -30,6 +30,7 @@ export function setupAllEventListeners(instance) {
   // rather than appearing on the instance from inside a helper (FR-009).
   return {
     removeHarmonicSet: (/** @type {string} */ id) => removeHarmonicSet(instance, id),
+    removeSidebandSet: (/** @type {string} */ id) => removeSidebandSet(instance, id),
     setSelection: (/** @type {string} */ type, /** @type {string} */ id, /** @type {number} */ index) =>
       setSelection(instance, type, id, index),
     clearSelection: () => clearSelection(instance),

--- a/src/core/initialization/ModeInitialization.js
+++ b/src/core/initialization/ModeInitialization.js
@@ -38,21 +38,23 @@ export function initializeModeInfrastructure(instance) {
  * Mount each panel-owning mode's UI and pick the starting mode.
  *
  * The per-mode container is why this names modes rather than using a
- * capability: analysis and harmonics mount into *different* columns, which no
- * capability expresses. Recorded as a documented exception in ADR-017.
+ * capability: each panel-owning mode mounts into a *different* column, which no
+ * capability expresses. Recorded as a documented exception in ADR-017. The
+ * caller supplies the mapping, so adding a panel-owning mode is one entry in
+ * that map rather than another parameter here.
  * @param {GramFrame} instance - GramFrame instance
  * @param {Object<string, BaseMode>} modes - Constructed modes
- * @param {HTMLDivElement} markersContainer - Middle column, for the markers table
- * @param {HTMLDivElement} harmonicsContainer - Right column, for the harmonics panel
+ * @param {Object<string, HTMLDivElement>} panelContainers - Column each panel-owning mode mounts into, by mode name
  * @param {HTMLDivElement} guidancePanel - Panel the starting mode's guidance is written into
  * @returns {BaseMode} The starting mode
  */
-export function setupModeUI(instance, modes, markersContainer, harmonicsContainer, guidancePanel) {
-  // Analysis markers in middle column (always visible)
-  modes['analysis'].createUI(markersContainer)
-
-  // Harmonics sets in right column (always visible)
-  modes['harmonics'].createUI(harmonicsContainer)
+export function setupModeUI(instance, modes, panelContainers, guidancePanel) {
+  // Every panel-owning mode's table is always visible, whatever mode is active
+  Object.entries(panelContainers).forEach(([modeName, container]) => {
+    if (modes[modeName]) {
+      modes[modeName].createUI(container)
+    }
+  })
 
   // Set initial mode from state (pan by default)
   const currentMode = modes[instance.state.mode] || modes['pan']

--- a/src/core/keyboardControl.js
+++ b/src/core/keyboardControl.js
@@ -9,8 +9,7 @@
 
 import { dispatch, markAnnotationsChanged } from './state.js'
 import { dataToSVG, svgToImage, imageToData, clampToImage } from '../utils/coordinates.js'
-import { updateHarmonicPanelContent } from '../components/HarmonicPanel.js'
-import { isPanelOwner } from '../modes/capabilities.js'
+import { isPanelOwner, findPinSetOwner } from '../modes/capabilities.js'
 import { DEFAULT_SYMBOL } from '../rendering/symbols.js'
 import { registerInstance, unregisterInstance, getFocusedInstance, focusNextInstance, focusPreviousInstance, setFocusedInstance, getRegisteredInstanceCount, clearFocusedInstance, isNodeInsideAnyInstance } from './FocusManager.js'
 import { cancelActiveDrag } from '../modes/shared/BaseDragHandler.js'
@@ -171,8 +170,13 @@ function handleGlobalKeyboardEvent(event) {
   // Apply movement based on selected item type
   if (selection.selectedType === 'marker') {
     moveSelectedMarker(focusedInstance, selection.selectedId, movement)
-  } else if (selection.selectedType === 'harmonicSet') {
-    moveSelectedHarmonicSet(focusedInstance, selection.selectedId, movement)
+  } else {
+    // Every other selectable feature is a pin set — a harmonic set or a
+    // sideband set — and the owning mode is found by capability, not by name.
+    const owner = findPinSetOwner(focusedInstance, selection.selectedType)
+    if (owner) {
+      moveSelectedPinSet(focusedInstance, owner, selection.selectedId, movement)
+    }
   }
 }
 
@@ -263,25 +267,25 @@ function moveSelectedMarker(instance, markerId, movement) {
 }
 
 /**
- * Move a selected harmonic set by pixel increments  
+ * Move a selected pin set (harmonic or sideband) by pixel increments.
+ *
+ * Horizontal movement adjusts what the owning mode says an arrow key changes —
+ * the spacing, for both of today's pin-set modes. Vertical movement moves the
+ * set's anchor time, which is the same for every pin set and so lives here.
  * @param {GramFrame} instance - GramFrame instance
- * @param {string} harmonicSetId - ID of harmonic set to move
+ * @param {import('../modes/capabilities.js').PinSetOwner} owner - Mode owning the set
+ * @param {string} setId - ID of the set to move
  * @param {MovementVector} movement - Movement vector {dx, dy}
  */
-function moveSelectedHarmonicSet(instance, harmonicSetId, movement) {
-  const harmonics = instance.state.harmonics
-  if (!harmonics || !harmonics.harmonicSets) {
+function moveSelectedPinSet(instance, owner, setId, movement) {
+  const set = owner.sets.find(candidate => candidate.id === setId)
+  if (!set) {
     return
   }
-  
-  const harmonicSet = harmonics.harmonicSets.find(h => h.id === harmonicSetId)
-  if (!harmonicSet) {
-    return
-  }
-  
-  /** @type {Partial<HarmonicSet>} */
-  const updates = {}
-  
+
+  /** @type {Partial<PinSet>} */
+  let updates = {}
+
   // Both branches go through the canonical coordinate module, so the movement
   // is in rendered pixels at any zoom level (FR-002, FR-003).
   const { timeMin, timeMax } = instance.state.config
@@ -299,7 +303,7 @@ function moveSelectedHarmonicSet(instance, harmonicSetId, movement) {
     return imageToData(imagePoint.x, imagePoint.y, viewport)
   }
 
-  // For horizontal movement (frequency/spacing adjustment)
+  // For horizontal movement (frequency adjustment)
   if (movement.dx !== 0) {
     // Measure what one keypress is worth in frequency rather than re-deriving
     // it: take a reference point and the same point moved by the increment.
@@ -311,15 +315,13 @@ function moveSelectedHarmonicSet(instance, harmonicSetId, movement) {
     const before = svgPointToData(reference.x, reference.y)
     const after = svgPointToData(reference.x + movement.dx, reference.y)
 
-    // Positive dx increases spacing, negative dx decreases spacing
-    const spacingChange = after.freq - before.freq
-    updates.spacing = Math.max(1.0, harmonicSet.spacing + spacingChange)
+    updates = { ...updates, ...owner.nudgeFreqUpdates(set, after.freq - before.freq) }
   }
 
   // For vertical movement (time/anchor position adjustment)
   if (movement.dy !== 0) {
     const anchorSVG = dataToSVG(
-      { freq: instance.state.config.freqMin, time: harmonicSet.anchorTime },
+      { freq: instance.state.config.freqMin, time: set.anchorTime },
       viewport,
       image
     )
@@ -328,30 +330,12 @@ function moveSelectedHarmonicSet(instance, harmonicSetId, movement) {
     // Clamp to valid time range
     updates.anchorTime = Math.max(timeMin, Math.min(timeMax, moved.time))
   }
-  
-  // Apply updates directly to the harmonic set
+
   if (Object.keys(updates).length > 0) {
-    const setIndex = harmonics.harmonicSets.findIndex(set => set.id === harmonicSetId)
-    if (setIndex !== -1) {
-      Object.assign(harmonics.harmonicSets[setIndex], updates)
-      markAnnotationsChanged(instance)
-      
-      // Update visual elements if harmonic panel exists. This uses the static
-      // import at the top of the file: the dynamic import that used to be here
-      // cited circular dependencies, but the same module is already imported
-      // statically and called synchronously elsewhere in this file — so it only
-      // delayed the panel update by a microtask and swallowed any error.
-      if (instance.ui.harmonicPanel) {
-        updateHarmonicPanelContent(instance.ui.harmonicPanel, instance)
-      }
-      
-      // Trigger re-render of persistent features to show updated harmonic set
-      if (instance.featureRenderer) {
-        instance.featureRenderer.renderAllPersistentFeatures()
-      }
-      
-      dispatch(instance)
-    }
+    // The mode applies the update, marks the annotation change, refreshes its
+    // table and re-renders. This function used to do all four by hand against
+    // `state.harmonics` (spec 167, FR-006).
+    owner.updateSet(setId, updates)
   }
 }
 
@@ -359,7 +343,7 @@ function moveSelectedHarmonicSet(instance, harmonicSetId, movement) {
 /**
  * Set selection state for an item
  * @param {GramFrame} instance - GramFrame instance
- * @param {string} type - Type of item ('marker' | 'harmonicSet')
+ * @param {string} type - Type of item ('marker' | 'harmonicSet' | 'sidebandSet')
  * @param {string} id - ID of selected item
  * @param {number} index - Index in table for display purposes
  */
@@ -409,7 +393,7 @@ export function clearSelection(instance) {
 /**
  * Resolve the currently selected feature (marker or harmonic set).
  * @param {GramFrame} instance - GramFrame instance
- * @returns {{type: 'marker'|'harmonicSet', feature: AnalysisMarker|HarmonicSet}|null} Selected feature or null
+ * @returns {{type: SelectedFeatureType, feature: AnalysisMarker|PinSet}|null} Selected feature or null
  */
 function getSelectedFeature(instance) {
   const sel = instance.state.selection
@@ -423,12 +407,10 @@ function getSelectedFeature(instance) {
       : null
     return feature ? { type: 'marker', feature } : null
   }
-  if (sel.selectedType === 'harmonicSet') {
-    const harmonics = instance.state.harmonics
-    const feature = harmonics && harmonics.harmonicSets
-      ? harmonics.harmonicSets.find(h => h.id === sel.selectedId)
-      : null
-    return feature ? { type: 'harmonicSet', feature } : null
+  const owner = findPinSetOwner(instance, sel.selectedType)
+  if (owner) {
+    const feature = owner.sets.find(set => set.id === sel.selectedId)
+    return feature ? { type: owner.selectionType, feature } : null
   }
   return null
 }
@@ -450,15 +432,16 @@ function getSelectedFeature(instance) {
 export function getActiveStyle(instance) {
   const selected = getSelectedFeature(instance)
   if (selected) {
-    const isHarmonicSet = selected.type === 'harmonicSet'
+    // Markers have no pin; every pin set (harmonic or sideband) does.
+    const isPinSet = selected.type !== 'marker'
     return {
       color: selected.feature.color,
       symbol: /** @type {SymbolType} */ (selected.feature.symbol || DEFAULT_SYMBOL),
-      // A harmonic set without an explicit `showPin` (legacy/restored) is pinned.
-      showPin: isHarmonicSet
-        ? /** @type {HarmonicSet} */ (selected.feature).showPin !== false
+      // A pin set without an explicit `showPin` (legacy/restored) is pinned.
+      showPin: isPinSet
+        ? /** @type {PinSet} */ (selected.feature).showPin !== false
         : instance.state.showHarmonicPin !== false,
-      pinApplies: isHarmonicSet,
+      pinApplies: isPinSet,
       largeSymbols: !!selected.feature.largeSymbols
     }
   }
@@ -476,15 +459,13 @@ export function getActiveStyle(instance) {
  * Re-render the overlay and the affected feature's table after a restyle, then
  * notify listeners (which also triggers persistence).
  * @param {GramFrame} instance - GramFrame instance
- * @param {'marker'|'harmonicSet'} type - Which feature type changed
+ * @param {SelectedFeatureType} _type - Which feature type changed
  */
-function refreshFeatureVisuals(instance, type) {
+function refreshFeatureVisuals(instance, _type) {
   if (instance.featureRenderer) {
     instance.featureRenderer.renderAllPersistentFeatures()
   }
-  if (type === 'marker' || type === 'harmonicSet') {
-    refreshPanels(instance)
-  }
+  refreshPanels(instance)
   dispatch(instance)
 }
 
@@ -525,20 +506,21 @@ export function applySymbolToSelectedFeature(instance, symbol) {
 }
 
 /**
- * Show or hide the vertical pin lines of the currently selected harmonic set,
- * updating the overlay and table instantly. No-op (returns false) when nothing
- * is selected or when the selection is a marker, which has no pin — the caller
- * then treats the change as setting the session default instead.
+ * Show or hide the vertical pin lines of the currently selected pin set —
+ * harmonic or sideband — updating the overlay and table instantly. No-op
+ * (returns false) when nothing is selected or when the selection is a marker,
+ * which has no pin — the caller then treats the change as setting the session
+ * default instead.
  * @param {GramFrame} instance - GramFrame instance
  * @param {boolean} showPin - Whether the set should draw its pin lines
  * @returns {boolean} True if a harmonic set was restyled
  */
 export function applyPinToSelectedFeature(instance, showPin) {
   const selected = getSelectedFeature(instance)
-  if (!selected || selected.type !== 'harmonicSet') {
+  if (!selected || selected.type === 'marker') {
     return false
   }
-  /** @type {HarmonicSet} */ (selected.feature).showPin = !!showPin
+  /** @type {PinSet} */ (selected.feature).showPin = !!showPin
   // `showPin` is a persisted field, so this restyle must reach storage like its
   // colour/symbol siblings — without the mark, a pin toggle survived only until
   // the next reload (H1).
@@ -569,35 +551,40 @@ export function applyLargeSymbolsToSelectedFeature(instance, large) {
 }
 
 /**
- * Remove a harmonic set by ID
+ * Remove a harmonic set by ID.
+ *
+ * A thin alias for {@link removePinSet}: the name is the one the public
+ * `instance.interaction` surface and the harmonics panel already use.
  * @param {GramFrame} instance - GramFrame instance
  * @param {string} id - Harmonic set ID to remove
  */
 export function removeHarmonicSet(instance, id) {
-  const { harmonics, selection } = instance.state
-  const setIndex = harmonics.harmonicSets.findIndex(set => set.id === id)
-  if (setIndex !== -1) {
-    // Clear selection if removing the selected harmonic set
-    if (selection.selectedType === 'harmonicSet' && selection.selectedId === id) {
-      clearSelection(instance)
-    }
-    
-    harmonics.harmonicSets.splice(setIndex, 1)
-    // Deleting a set is an annotation mutation: masked today by the signature's
-    // set-count field, but the mark is the contract (BH-24).
-    markAnnotationsChanged(instance)
+  removePinSet(instance, 'harmonicSet', id)
+}
 
-    // Update visual elements
-    if (instance.ui.harmonicPanel) {
-      updateHarmonicPanelContent(instance.ui.harmonicPanel, instance)
-    }
-    
-    // Trigger re-render of persistent features to remove the harmonic set
-    if (instance.featureRenderer) {
-      instance.featureRenderer.renderAllPersistentFeatures()
-    }
-    
-    dispatch(instance)
+/**
+ * Remove a sideband set by ID (issue #241).
+ * @param {GramFrame} instance - GramFrame instance
+ * @param {string} id - Sideband set ID to remove
+ */
+export function removeSidebandSet(instance, id) {
+  removePinSet(instance, 'sidebandSet', id)
+}
+
+/**
+ * Delete one of a pin-set mode's sets, through the mode that owns it.
+ *
+ * The removal itself — clearing the selection, splicing the set out, marking
+ * the annotation change, refreshing the table and re-rendering — belongs to the
+ * mode, and used to be written a second time here against `state.harmonics`.
+ * @param {GramFrame} instance - GramFrame instance
+ * @param {SelectedFeatureType} selectionType - Which family the id belongs to
+ * @param {string} id - Set ID to remove
+ */
+function removePinSet(instance, selectionType, id) {
+  const owner = findPinSetOwner(instance, selectionType)
+  if (owner) {
+    owner.removeSet(id)
   }
 }
 

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -16,16 +16,16 @@ import { getVersion } from '../utils/version.js'
  * to {@link createInitialState}, composed by `ModeFactory.getModeInitialStates()`,
  * which is what breaks the state ⇄ modes cycle (spec 167, FR-002, ADR-014).
  *
- * Typed as `GramFrameState` minus the three mode slices, because that is
+ * Typed as `GramFrameState` minus the four mode slices, because that is
  * exactly what it is: the mode keys are no longer written here, so claiming
  * them would be a lie tsc happens not to check.
- * @type {Omit<GramFrameState, 'analysis'|'harmonics'|'doppler'>}
+ * @type {Omit<GramFrameState, 'analysis'|'harmonics'|'sidebands'|'doppler'>}
  */
 const initialState = {
   version: getVersion(),
   timestamp: new Date().toISOString(),
   instanceId: '',
-  mode: 'pan', // 'analysis', 'harmonics', 'doppler', 'pan' — start in pan so a click doesn't immediately place a marker
+  mode: 'pan', // 'analysis', 'harmonics', 'sideband', 'doppler', 'pan' — start in pan so a click doesn't immediately place a marker
   previousMode: null, // Previous mode for switching back
   rate: 1,
   selectedColor: '#ff6b6b', // Currently selected color for new features across all modes
@@ -185,7 +185,7 @@ function deliverToListeners(state, listeners) {
  * The storage listener saves on a change to this counter (plus a few cheap
  * identity fields) rather than by re-serialising every annotation on every
  * notification. Call it from any path that adds, removes, moves or restyles a
- * marker, harmonic set or doppler marker.
+ * marker, harmonic set, sideband set or doppler marker.
  * @param {GramFrame} instance - GramFrame instance
  */
 export function markAnnotationsChanged(instance) {

--- a/src/core/storage.js
+++ b/src/core/storage.js
@@ -1,8 +1,8 @@
 /**
  * Browser Storage Adapter for GramFrame
  *
- * Persists user annotations (analysis markers, harmonic sets, doppler curves)
- * in browser storage. Trainers get localStorage (permanent); students get
+ * Persists user annotations (analysis markers, harmonic sets, sideband sets,
+ * doppler curves) in browser storage. Trainers get localStorage (permanent); students get
  * sessionStorage (cleared on browser close).
  *
  * Student persistence is additionally capped at 24 hours (feature 157): on
@@ -227,8 +227,9 @@ export function savePinPreference(showPin) {
 export function hasPersistableAnnotations(state) {
   const hasMarkers = !!(state.analysis && state.analysis.markers && state.analysis.markers.length > 0)
   const hasHarmonics = !!(state.harmonics && state.harmonics.harmonicSets && state.harmonics.harmonicSets.length > 0)
+  const hasSidebands = !!(state.sidebands && state.sidebands.sidebandSets && state.sidebands.sidebandSets.length > 0)
   const hasDoppler = !!(state.doppler && (state.doppler.fPlus !== null || state.doppler.fMinus !== null || state.doppler.fZero !== null))
-  return hasMarkers || hasHarmonics || hasDoppler
+  return hasMarkers || hasHarmonics || hasSidebands || hasDoppler
 }
 
 /**
@@ -314,6 +315,22 @@ export function sanitizeStoredAnnotations(data) {
     dropped++ // harmonicSets present but not an array
   }
 
+  /** @type {StoredSidebandSet[]} */
+  let sidebandSets = []
+  if (data && data.sidebands && Array.isArray(data.sidebands.sidebandSets)) {
+    sidebandSets = data.sidebands.sidebandSets.filter((/** @type {any} */ sb) => {
+      const valid = !!sb && isNonEmptyString(sb.id) && isNonEmptyString(sb.color) &&
+        isFiniteNumber(sb.anchorTime) && isFiniteNumber(sb.fundamentalFreq) &&
+        // Strictly positive, for the same reason a harmonic set's is: a spacing
+        // of zero makes the sideband index range infinite.
+        isFiniteNumber(sb.spacing) && sb.spacing > 0
+      if (!valid) dropped++
+      return valid
+    })
+  } else if (data && data.sidebands && data.sidebands.sidebandSets != null) {
+    dropped++ // sidebandSets present but not an array
+  }
+
   const rawDoppler = (data && data.doppler) || {}
   /** @type {StoredDopplerData} */
   const doppler = { fPlus: null, fMinus: null, fZero: null, color: null }
@@ -333,6 +350,7 @@ export function sanitizeStoredAnnotations(data) {
     gram: data && data.gram,
     analysis: { markers },
     harmonics: { harmonicSets },
+    sidebands: { sidebandSets },
     doppler
   }
   return { annotations, dropped }
@@ -452,6 +470,21 @@ export function saveAnnotations(state, instanceIndex, context) {
           // bump SCHEMA_VERSION. Records written before it simply lack the key
           // and restore as `true` (pin shown), matching their original look.
           showPin: hs.showPin !== false
+        }))
+      },
+      // `sidebands` is an ADDITIVE section (issue #241). It MUST NOT trigger a
+      // SCHEMA_VERSION bump: the strict version guard in loadAnnotations would
+      // otherwise discard every pre-existing v1 record. Records written before
+      // sidebands existed simply lack the key and restore with none.
+      sidebands: {
+        sidebandSets: (state.sidebands && state.sidebands.sidebandSets || []).map(sb => ({
+          id: sb.id,
+          color: sb.color,
+          anchorTime: sb.anchorTime,
+          fundamentalFreq: sb.fundamentalFreq,
+          spacing: sb.spacing,
+          symbol: sb.symbol || 'cross',
+          showPin: sb.showPin !== false
         }))
       },
       doppler: {

--- a/src/gramframe.css
+++ b/src/gramframe.css
@@ -929,10 +929,19 @@ table.gram-frame-table {
   justify-content: flex-start;
 }
 
+/*
+ * The mode buttons, stacked one per row.
+ *
+ * The gap and the button paddings below were tightened when Sidebands became a
+ * fifth mode (issue #241): at the old sizes a fifth row made the whole control
+ * panel ~40px taller in every mode whose guidance text is short, which pushed
+ * the spectrogram itself that far down the page. Five rows now occupy what four
+ * did, so adding the mode cost the gram no vertical space.
+ */
 .gram-frame-modes {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 4px;
   justify-content: center;
   align-items: stretch;
   flex: 0 0 auto;
@@ -994,7 +1003,7 @@ table.gram-frame-table {
 
 /* Military-style metal buttons */
 .gram-frame-mode-btn {
-  padding: 8px 6px;
+  padding: 5px 6px;
   background: linear-gradient(180deg, #6a6a6a 0%, #4a4a4a 50%, #2a2a2a 100%);
   color: #ddd;
   border: 2px solid #555;
@@ -1014,7 +1023,7 @@ table.gram-frame-table {
 }
 
 .gram-frame-command-btn {
-  padding: 8px 10px;
+  padding: 6px 8px;
   background: linear-gradient(180deg, #5a5a5a 0%, #3a3a3a 50%, #1a1a1a 100%);
   color: #ddd;
   border: 2px solid #444;
@@ -1025,7 +1034,7 @@ table.gram-frame-table {
   line-height: 1;
   flex: 0 0 auto;
   min-width: 32px;
-  height: 36px;
+  height: 32px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1224,7 +1233,9 @@ table.gram-frame-table {
 
 
 .gram-frame-harmonic-line,
-.gram-frame-harmonic-mini-pin {
+.gram-frame-harmonic-mini-pin,
+.gram-frame-sideband-line,
+.gram-frame-sideband-mini-pin {
   stroke-width: 2;
   fill: none;
   pointer-events: none;
@@ -1232,7 +1243,8 @@ table.gram-frame-table {
 }
 
 
-.gram-frame-harmonic-number {
+.gram-frame-harmonic-number,
+.gram-frame-sideband-number {
   font-family: Arial, sans-serif;
   font-size: 12px;
   font-weight: bold;
@@ -1292,12 +1304,15 @@ table.gram-frame-table {
 /* Legacy harmonic panel styles - now using unified table structure */
 
 .gram-frame-harmonic-spacing,
-.gram-frame-harmonic-rate {
+.gram-frame-harmonic-rate,
+.gram-frame-sideband-freq,
+.gram-frame-sideband-spacing {
   font-size: 14px;
   font-weight: bold;
 }
 
-.gram-frame-harmonic-color {
+.gram-frame-harmonic-color,
+.gram-frame-sideband-color {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1309,7 +1324,8 @@ table.gram-frame-table {
   display: block;
 }
 
-.gram-frame-harmonic-delete {
+.gram-frame-harmonic-delete,
+.gram-frame-sideband-delete {
   background: linear-gradient(180deg, #6a4a4a 0%, #4a2a2a 50%, #2a1a1a 100%);
   color: #ff6666;
   border: 1px solid #555;
@@ -1326,12 +1342,14 @@ table.gram-frame-table {
   transition: all 0.1s ease;
 }
 
-.gram-frame-harmonic-delete:hover {
+.gram-frame-harmonic-delete:hover,
+.gram-frame-sideband-delete:hover {
   background: linear-gradient(180deg, #8a5a5a 0%, #6a3a3a 50%, #4a2a2a 100%);
   border-color: #777;
 }
 
-.gram-frame-harmonic-delete:active {
+.gram-frame-harmonic-delete:active,
+.gram-frame-sideband-delete:active {
   transform: translateY(1px);
 }
 
@@ -1660,11 +1678,34 @@ table.gram-frame-table {
 }
 
 .gram-frame-markers-persistent-container,
-.gram-frame-harmonics-persistent-container {
+.gram-frame-harmonics-persistent-container,
+.gram-frame-sidebands-persistent-container {
   display: flex;
   flex-direction: column;
   flex: 1;
   min-height: 0;
+}
+
+/*
+ * The right column carries one pin-set table at a time: the harmonics table,
+ * except while Sidebands mode is active (issue #241). Both panels are always in
+ * the DOM — each mode keeps its table up to date whatever mode is active — and
+ * this only chooses which of the two the column shows. See the note in
+ * components/MainUI.js for why they take turns rather than sharing the column.
+ *
+ * Driven entirely by the `gram-frame-<mode>-mode` class the component keeps on
+ * its container, so nothing has to be toggled from JavaScript on every switch.
+ */
+.gram-frame-sidebands-persistent-container {
+  display: none;
+}
+
+.gram-frame-sideband-mode .gram-frame-sidebands-persistent-container {
+  display: flex;
+}
+
+.gram-frame-sideband-mode .gram-frame-harmonics-persistent-container {
+  display: none;
 }
 
 /*
@@ -1691,7 +1732,8 @@ table.gram-frame-table {
 }
 
 .gram-frame-markers-persistent-container h4,
-.gram-frame-harmonics-persistent-container h4 {
+.gram-frame-harmonics-persistent-container h4,
+.gram-frame-sidebands-persistent-container h4 {
   margin: 0;
   padding: 0;
   border: 0;

--- a/src/gramframe.css
+++ b/src/gramframe.css
@@ -959,8 +959,34 @@ table.gram-frame-table {
 /* Simplified left panel - no sub-columns needed */
 
 /* Guidance panel */
+/*
+ * The guidance panel fills its column and scrolls, rather than growing the
+ * control row to fit its text.
+ *
+ * Same mechanism as the tables beside it (an absolutely positioned child of a
+ * relative column), and for the same reason: the guidance column is what gives
+ * way when a host is too narrow for the whole row, and the narrower it gets the
+ * taller its text wraps. Letting that set the row height pushed the row — and
+ * the spectrogram under it — down the page, by as much as 80px on a 1280px host
+ * once a fourth table joined the row (issue #241).
+ *
+ * The row is now as tall as the readouts and the mode buttons need and no
+ * taller, in every mode. Two things follow: the gram sits at a constant height
+ * instead of moving as the analyst switches mode, and a host too narrow for the
+ * full guidance text costs reading length here rather than gram height.
+ */
+.gram-frame-guidance-column {
+  position: relative;
+}
+
 .gram-frame-guidance {
-  flex: 1;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  overflow-y: auto;
+  box-sizing: border-box;
   padding: 8px 12px;
   background: linear-gradient(135deg, #1a1a1a 0%, #000 50%, #0a0a0a 100%);
   border: 2px solid #333;
@@ -1654,8 +1680,19 @@ table.gram-frame-table {
   box-shadow: inset 0 1px 3px rgba(0,0,0,0.3);
 }
 
-/* Harmonics column. 200 → 175px; see the markers-column note above. */
-.gram-frame-right-column {
+/*
+ * The two pin-set tables: harmonics (200 → 175px when the markers column gained
+ * its Label column — see the markers-column note above), and sidebands beside
+ * it. Both are always visible (issue #241).
+ *
+ * 175px each — the width the harmonics table has always had — so the two read as
+ * a matched pair. Together with the markers table and the readouts beside them,
+ * the control row now wants ~1090px; a host narrower than that squeezes the
+ * guidance column, which scrolls rather than growing the row taller (see the
+ * note on `.gram-frame-guidance`).
+ */
+.gram-frame-right-column,
+.gram-frame-sidebands-column {
   display: flex;
   flex-direction: column;
   flex: 0 0 175px;
@@ -1684,28 +1721,6 @@ table.gram-frame-table {
   flex-direction: column;
   flex: 1;
   min-height: 0;
-}
-
-/*
- * The right column carries one pin-set table at a time: the harmonics table,
- * except while Sidebands mode is active (issue #241). Both panels are always in
- * the DOM — each mode keeps its table up to date whatever mode is active — and
- * this only chooses which of the two the column shows. See the note in
- * components/MainUI.js for why they take turns rather than sharing the column.
- *
- * Driven entirely by the `gram-frame-<mode>-mode` class the component keeps on
- * its container, so nothing has to be toggled from JavaScript on every switch.
- */
-.gram-frame-sidebands-persistent-container {
-  display: none;
-}
-
-.gram-frame-sideband-mode .gram-frame-sidebands-persistent-container {
-  display: flex;
-}
-
-.gram-frame-sideband-mode .gram-frame-harmonics-persistent-container {
-  display: none;
 }
 
 /*
@@ -1760,7 +1775,8 @@ table.gram-frame-table {
   
   .gram-frame-left-column,
   .gram-frame-middle-column,
-  .gram-frame-right-column {
+  .gram-frame-right-column,
+  .gram-frame-sidebands-column {
     flex: 0 0 auto;
     min-height: 200px;
   }

--- a/src/main.js
+++ b/src/main.js
@@ -105,6 +105,7 @@ export class GramFrame {
     applyPinToSelectedFeature: () => false,
     applyLargeSymbolsToSelectedFeature: () => false,
     removeHarmonicSet: () => {},
+    removeSidebandSet: () => {},
     // Replaced by the colour picker when it mounts; a no-op until then, so a
     // caller arriving early does nothing rather than throwing.
     syncStyleControls: () => {},
@@ -212,6 +213,7 @@ export class GramFrame {
       modeColumn: layout.modeColumn,
       markersContainer: layout.markersContainer,
       harmonicsContainer: layout.harmonicsContainer,
+      sidebandsContainer: layout.sidebandsContainer,
       timeLED: layout.timeLED,
       freqLED: layout.freqLED,
       speedLED: layout.speedLED,
@@ -220,10 +222,12 @@ export class GramFrame {
       modeButtons: initialModeUI.modeButtons,
       commandButtons: initialModeUI.commandButtons,
       guidancePanel: initialModeUI.guidancePanel,
-      // Mounted later, or not at all: the harmonics panel arrives with that
-      // mode's UI, the expand toggle only for a landscape image, and nothing
-      // assigns the mode/rate LEDs at all — every read of them is guarded.
+      // Mounted later, or not at all: the harmonics and sidebands panels
+      // arrive with their modes' UI, the expand toggle only for a landscape
+      // image, and nothing assigns the mode/rate LEDs at all — every read of
+      // them is guarded.
       harmonicPanel: null,
+      sidebandPanel: null,
       expandToggleButton: null,
       modeLED: null,
       rateLED: null
@@ -234,7 +238,11 @@ export class GramFrame {
     const { modes, featureRenderer } = initializeModeInfrastructure(this)
     this.modes = modes
     this.featureRenderer = featureRenderer
-    this.currentMode = setupModeUI(this, modes, layout.markersContainer, layout.harmonicsContainer, initialModeUI.guidancePanel)
+    this.currentMode = setupModeUI(this, modes, {
+      analysis: layout.markersContainer,
+      harmonics: layout.harmonicsContainer,
+      sideband: layout.sidebandsContainer
+    }, initialModeUI.guidancePanel)
 
     const modeUI = updateModeUIWithCommands(
       this, initialModeUI, modes, this.currentMode, layout.modeColumn, layout.guidanceColumn
@@ -246,6 +254,7 @@ export class GramFrame {
 
     const controls = setupAllEventListeners(this)
     this.interaction.removeHarmonicSet = controls.removeHarmonicSet
+    this.interaction.removeSidebandSet = controls.removeSidebandSet
     this.interaction.setSelection = controls.setSelection
     this.interaction.clearSelection = controls.clearSelection
     this.interaction.updateSelectionVisuals = controls.updateSelectionVisuals
@@ -264,8 +273,8 @@ export class GramFrame {
     // Restore saved annotations before first render
     this._restoreAnnotations()
 
-    // Reflect restored annotations in the persistent control panels (markers
-    // and harmonics tables) and in the SVG overlays. Without this, reloaded
+    // Reflect restored annotations in the persistent control panels (the
+    // markers, harmonics and sidebands tables) and in the SVG overlays. Without this, reloaded
     // annotations render over the spectrogram but leave the panel tables empty.
     updatePersistentPanels(this)
     if (this.featureRenderer) {
@@ -357,6 +366,7 @@ export class GramFrame {
     const fresh = createInitialState(ModeFactory.getModeInitialStates())
     this.state.analysis = fresh.analysis
     this.state.harmonics = fresh.harmonics
+    this.state.sidebands = fresh.sidebands
     this.state.doppler = fresh.doppler
     this.state.cursors = fresh.cursors
 
@@ -377,7 +387,7 @@ export class GramFrame {
       this.currentMode.activate()
     }
 
-    // Refresh the persistent markers and harmonics tables (always visible,
+    // Refresh the persistent markers, harmonics and sidebands tables (always visible,
     // regardless of the active mode) so cleared annotations also disappear
     // from the tables above the spectrogram, not just the SVG overlay
     updatePersistentPanels(this)
@@ -439,6 +449,16 @@ export class GramFrame {
       }))
     }
 
+    // Merge sideband sets (issue #241). Records written before sidebands
+    // existed simply lack the key and restore as none.
+    if (saved.sidebands && Array.isArray(saved.sidebands.sidebandSets)) {
+      this.state.sidebands.sidebandSets = saved.sidebands.sidebandSets.map(sb => ({
+        ...sb,
+        symbol: sb.symbol || 'cross',
+        showPin: sb.showPin !== false
+      }))
+    }
+
     // Merge doppler state
     if (saved.doppler) {
       this.state.doppler.fPlus = saved.doppler.fPlus || null
@@ -484,6 +504,7 @@ export class GramFrame {
         state.annotationRevision || 0,
         state.analysis && state.analysis.markers ? state.analysis.markers.length : 0,
         state.harmonics && state.harmonics.harmonicSets ? state.harmonics.harmonicSets.length : 0,
+        state.sidebands && state.sidebands.sidebandSets ? state.sidebands.sidebandSets.length : 0,
         doppler.fPlus ? `${doppler.fPlus.time}:${doppler.fPlus.freq}` : '-',
         doppler.fMinus ? `${doppler.fMinus.time}:${doppler.fMinus.freq}` : '-',
         doppler.fZero ? `${doppler.fZero.time}:${doppler.fZero.freq}` : '-',
@@ -624,11 +645,15 @@ export class GramFrame {
       })
     }
     
-    // Update container class for mode-specific styling
+    // Update container class for mode-specific styling. Every registered mode's
+    // class is removed rather than a hand-kept list of three: the old list had
+    // silently gone stale (pan and doppler were added and never removed, so
+    // their classes accumulated), and the sidebands panel's visibility now
+    // depends on the class being accurate.
     if (this.ui.container) {
-      // Remove all mode classes
-      this.ui.container.classList.remove('gram-frame-analysis-mode', 'gram-frame-harmonics-mode')
-      // Add current mode class
+      ModeFactory.getAvailableModes().forEach(modeName => {
+        this.ui.container.classList.remove(`gram-frame-${modeName}-mode`)
+      })
       this.ui.container.classList.add(`gram-frame-${mode}-mode`)
     }
     

--- a/src/modes/ModeFactory.js
+++ b/src/modes/ModeFactory.js
@@ -1,5 +1,6 @@
 import { AnalysisMode } from './analysis/AnalysisMode.js'
 import { HarmonicsMode } from './harmonics/HarmonicsMode.js'
+import { SidebandMode } from './sideband/SidebandMode.js'
 import { DopplerMode } from './doppler/DopplerMode.js'
 import { PanMode } from './pan/PanMode.js'
 import { looksLikeMissingApiError } from '../core/browserCompatibility.js'
@@ -30,6 +31,9 @@ export class ModeFactory {
         
         case 'harmonics':
           return new HarmonicsMode(instance)
+
+        case 'sideband':
+          return new SidebandMode(instance)
         
         case 'doppler':
           return new DopplerMode(instance)
@@ -38,7 +42,7 @@ export class ModeFactory {
           return new PanMode(instance)
         
         default:
-          throw new Error(`Invalid mode name: ${modeName}. Valid modes are: analysis, harmonics, doppler, pan`)
+          throw new Error(`Invalid mode name: ${modeName}. Valid modes are: analysis, harmonics, sideband, doppler, pan`)
       }
     } catch (error) {
       console.error(`CRITICAL ERROR: Failed to create mode "${modeName}":`, error)
@@ -78,13 +82,14 @@ export class ModeFactory {
    * rather than importing the mode classes itself, which is what breaks the
    * state ⇄ modes cycle (spec 167, FR-002, ADR-014).
    *
-   * Merge order is fixed and explicit: analysis, harmonics, doppler, pan.
+   * Merge order is fixed and explicit: analysis, harmonics, sideband, doppler, pan.
    * @returns {Partial<GramFrameState>} Merged mode slices
    */
   static getModeInitialStates() {
     const slices = Object.assign({},
       AnalysisMode.getInitialState(),
       HarmonicsMode.getInitialState(),
+      SidebandMode.getInitialState(),
       DopplerMode.getInitialState(),
       PanMode.getInitialState()
     )
@@ -97,7 +102,7 @@ export class ModeFactory {
    * @returns {ModeType[]} Array of mode names
    */
   static getAvailableModes() {
-    return ['analysis', 'harmonics', 'doppler', 'pan']
+    return ['analysis', 'harmonics', 'sideband', 'doppler', 'pan']
   }
 
   /**

--- a/src/modes/capabilities.js
+++ b/src/modes/capabilities.js
@@ -38,6 +38,56 @@
  */
 
 /**
+ * A mode that owns a family of pin sets — equally-spaced vertical pins the
+ * analyst can select, nudge with the arrow keys, restyle and delete.
+ *
+ * Implemented by Harmonics and Sidebands, both through `PinSetMode`. The
+ * capability is what lets the keyboard/selection layer find "the mode that owns
+ * a `harmonicSet`/`sidebandSet`" without naming either of them — it used to
+ * read `state.harmonics.harmonicSets` directly and had no way to grow.
+ * @typedef {Object} PinSetOwner
+ * @property {SelectedFeatureType} selectionType - What `state.selection.selectedType` reads while one of this mode's sets is selected
+ * @property {PinSet[]} sets - This mode's sets, live
+ * @property {function(string, Partial<PinSet>): void} updateSet - Apply updates to one set by id, re-rendering and notifying
+ * @property {function(string): void} removeSet - Delete one set by id
+ * @property {function(PinSet, number): Partial<PinSet>} nudgeFreqUpdates - What a horizontal keyboard nudge changes
+ */
+
+/**
+ * Whether a mode owns a family of pin sets.
+ *
+ * Not exported: unlike the other two predicates, every caller wants the *one*
+ * owner of a selection type rather than the whole filtered list, so
+ * {@link findPinSetOwner} is the seam and this is its implementation detail.
+ * @template T
+ * @param {T} mode - Mode instance
+ * @returns {mode is T & PinSetOwner} True if the mode implements PinSetOwner
+ */
+function isPinSetOwner(mode) {
+  const candidate = /** @type {Partial<PinSetOwner>} */ (mode)
+  return typeof candidate?.updateSet === 'function'
+      && typeof candidate?.removeSet === 'function'
+      && typeof candidate?.nudgeFreqUpdates === 'function'
+      && Array.isArray(candidate?.sets)
+}
+
+/**
+ * The mode owning a given selection type, if any.
+ * @param {GramFrame} instance - GramFrame instance
+ * @param {string|null} selectionType - A `state.selection.selectedType` value
+ * @returns {PinSetOwner|null} The owning mode, or null
+ */
+export function findPinSetOwner(instance, selectionType) {
+  if (!selectionType) {
+    return null
+  }
+  const owner = Object.values(instance.modes || {})
+    .filter(isPinSetOwner)
+    .find(mode => mode.selectionType === selectionType)
+  return owner || null
+}
+
+/**
  * Whether a mode provides persistent features.
  *
  * A type guard, not a boolean check: the point of a capability is that the

--- a/src/modes/harmonics/HarmonicsMode.js
+++ b/src/modes/harmonics/HarmonicsMode.js
@@ -1,206 +1,172 @@
-import { BaseMode } from '../BaseMode.js'
-// SVG utilities removed - no display element
+import { PinSetMode, MIN_PIN_SPACING } from '../shared/PinSetMode.js'
 import { updateHarmonicPanelContent, createHarmonicPanel } from '../../components/HarmonicPanel.js'
 import { showManualHarmonicModal } from './ManualHarmonicModal.js'
-import { dispatch, markAnnotationsChanged } from '../../core/state.js'
-import { dataToSVG, getImageBounds } from '../../utils/coordinates.js'
-import { BaseDragHandler } from '../shared/BaseDragHandler.js'
-import { getUniformTolerance } from '../../utils/tolerance.js'
-import { sampledHarmonics } from '../../utils/harmonicSampling.js'
-import { createSymbolMark, resolveSymbolScale } from '../../rendering/symbols.js'
-import { applyTextHalo } from '../../utils/svg.js'
-import { calculateVisibleDataRange, getRenderDimensions } from '../../utils/coordinates.js'
 
 /**
- * Harmonics mode implementation
- * Handles harmonic set creation, dragging, and rendering
+ * Harmonics mode implementation.
+ *
+ * A harmonic set is a {@link PinSetMode} set whose origin is fixed at 0 Hz:
+ * member `n` sits at `n × spacing`, and only members `n >= 1` exist. Everything
+ * else — the pin geometry, the label/symbol stack, the hit test, the render
+ * loop and the drag wiring — is the shared pin-set machinery, which Sidebands
+ * mode (issue #241) drives with a different origin.
  */
-export class HarmonicsMode extends BaseMode {
+export class HarmonicsMode extends PinSetMode {
   /**
-   * Initialize HarmonicsMode with drag handler
+   * Initialize HarmonicsMode
    * @param {GramFrame} instance - GramFrame instance
    */
   constructor(instance) {
-    super(instance)
-    
-    // One handler for both harmonic drags: moving an existing set (`move`) and
-    // creating one by dragging (`create`). They differ only in how the target
-    // is resolved — a create mints its set on mousedown — and share every
-    // subsequent step (spec 166, FR-004).
-    this.dragHandler = new BaseDragHandler(instance, {
-      // A feature drag always carries a data position. Only the pan drag passes
-      // null, and it runs on its own handler in `core/events.js`.
-      resolveTarget: (position) => this.resolveHarmonicDrag(/** @type {DataCoordinates} */ (position)),
-      // Hover only ever *finds* — resolveHarmonicDrag mints a new set when the
-      // cursor is over empty gram, which is right for a mousedown and wrong for
-      // a hover (a hover that creates features floods the gram with sets).
-      resolveHoverTarget: (position) => this.findHarmonicSetTarget(/** @type {DataCoordinates} */ (position)),
-      onDragStart: (target, position) => this.onHarmonicSetDragStart(target, /** @type {DataCoordinates} */ (position)),
-      onDragMove: (target, currentPos, startPos) => this.onHarmonicSetDragUpdate(target, /** @type {DataCoordinates} */ (currentPos), /** @type {DataCoordinates} */ (startPos)),
-      onDragEnd: (target, position) => this.onHarmonicSetDragEnd(target, position),
-      onDragCancel: (target) => this.onHarmonicSetDragEnd(target, null),
-      updateCursor: (style) => this.updateCursorStyle(style)
-    }, 'harmonics')
+    super(instance, 'harmonics')
   }
 
   /**
-   * Find harmonic set target for drag handler
-   * @param {DataCoordinates} position - Position to check
-   * @returns {DragTarget|null} Drag target if found, null otherwise
+   * The harmonic sets, live.
+   * @returns {PinSet[]} This mode's sets
    */
-  findHarmonicSetTarget(position) {
-    const harmonicSet = this.findHarmonicSetAt(position)
-    if (harmonicSet) {
-      return {
-        kind: 'move',
-        id: harmonicSet.id,
-        type: 'harmonicSet',
-        position: position,
-        data: {
-          harmonicSet: harmonicSet,
-          clickedHarmonicNumber: this.findClickedHarmonicNumber(harmonicSet, position.freq),
-          originalAnchorTime: harmonicSet.anchorTime
-        }
+  get sets() {
+    return this.instance.state.harmonics.harmonicSets
+  }
+
+  /**
+   * @returns {SelectedFeatureType} Selection type for a harmonic set
+   */
+  get selectionType() {
+    return 'harmonicSet'
+  }
+
+  /**
+   * DOM naming for harmonic pins. Unchanged from before the pin machinery was
+   * shared, so every existing CSS selector, test and helper keeps working.
+   * @returns {PinSetClassNames} Class and attribute names
+   */
+  get pinNames() {
+    return {
+      idPrefix: 'harmonic',
+      lineClass: 'gram-frame-harmonic-line',
+      miniPinClass: 'gram-frame-harmonic-mini-pin',
+      labelClass: 'gram-frame-harmonic-number',
+      setIdAttribute: 'data-harmonic-set-id',
+      indexAttribute: 'data-harmonic-number'
+    }
+  }
+
+  /**
+   * Frequency of the nth harmonic: the origin is 0 Hz, so it is a plain
+   * multiple of the spacing.
+   * @param {PinSet} set - Harmonic set
+   * @param {number} index - Harmonic number
+   * @returns {number} Frequency in Hz
+   */
+  freqForIndex(set, index) {
+    return index * set.spacing
+  }
+
+  /**
+   * Get the inclusive harmonic-number range of a set that falls within the
+   * currently visible frequency span.
+   *
+   * Harmonic numbers start at 1: there is no zeroth harmonic, and a set never
+   * draws below its own origin.
+   * @param {PinSet} set - Harmonic set
+   * @returns {{minIndex: number, maxIndex: number}} Inclusive harmonic range
+   */
+  visibleIndexRange(set) {
+    const { freqMin, freqMax } = this.visibleFrequencySpan()
+    return {
+      minIndex: Math.max(1, Math.ceil(freqMin / set.spacing)),
+      maxIndex: Math.floor(freqMax / set.spacing)
+    }
+  }
+
+  /**
+   * Find which harmonic number a frequency is nearest.
+   * @param {PinSet} set - Harmonic set
+   * @param {number} freq - Probe frequency
+   * @returns {number} Harmonic number (1, 2, 3, ...)
+   */
+  nearestIndex(set, freq) {
+    return Math.max(1, Math.round(freq / set.spacing))
+  }
+
+  /**
+   * The harmonics table's Ratio column is the cursor frequency over the set's
+   * spacing, so it is stale the moment the pointer moves.
+   * @returns {boolean} True — this table follows the cursor
+   */
+  get panelTracksCursor() {
+    return true
+  }
+
+  /**
+   * @param {number} index - Harmonic number
+   * @returns {string} The harmonic number, as drawn
+   */
+  labelTextFor(index) {
+    return String(index)
+  }
+
+  /**
+   * Mint a new harmonic set at the mousedown position.
+   *
+   * The initial spacing places the cursor on a sensible harmonic — the 10th
+   * when the frequency axis starts above zero, the 5th when it starts at zero —
+   * which is what keeps the first drawn set legible.
+   * @param {DataCoordinates} dataCoords - Data coordinates {freq, time}
+   * @returns {DragTarget|null} A create-kind target, or null if a set cannot be made
+   */
+  createSetTarget(dataCoords) {
+    const { freqMin } = this.instance.state.config
+
+    // Origin > 0 positions the cursor at the 10th harmonic; origin at 0, the 5th.
+    const clickedIndex = freqMin > 0 ? 10 : 5
+    const initialSpacing = Math.max(dataCoords.freq / clickedIndex, MIN_PIN_SPACING)
+
+    // Create the harmonic set immediately, so the drag has something to move
+    const harmonicSet = this.addHarmonicSet(dataCoords.time, initialSpacing)
+    if (!harmonicSet) {
+      return null
+    }
+
+    return {
+      kind: 'create',
+      id: harmonicSet.id,
+      type: 'harmonicSet',
+      position: dataCoords,
+      data: {
+        set: harmonicSet,
+        clickedIndex,
+        originalAnchorTime: dataCoords.time
       }
     }
-    return null
   }
 
   /**
-   * Resolve what a mousedown in harmonics mode starts.
+   * Dragging a harmonic keeps that harmonic under the cursor, which is the same
+   * as scaling the spacing.
+   * @param {PinSet} _set - Harmonic set being dragged
+   * @param {number} clickedIndex - Harmonic number the drag grabbed
+   * @param {DataCoordinates} currentPos - Current pointer position
+   * @returns {Partial<PinSet>} Spacing update
+   */
+  freqUpdatesForDrag(_set, clickedIndex, currentPos) {
+    const spacing = Math.max(currentPos.freq / (clickedIndex || 1), MIN_PIN_SPACING)
+    return { spacing }
+  }
+
+  /**
+   * Nudging a harmonic set's spacing with the arrow keys.
    *
-   * Landing on an existing set moves it; landing anywhere else creates one and
-   * drags it out from there. The new set is minted here, on mousedown, so the
-   * engine has a target id for the whole gesture (contract: drag-engine.md).
-   * @param {DataCoordinates} position - Position of the mousedown
-   * @returns {DragTarget|null} A move- or create-kind target
+   * The 1 Hz floor is inherited from before the pin machinery was shared: a
+   * harmonic set nudged below it draws so many pins that the keypress is
+   * indistinguishable from a hang, and the analyst has no way back.
+   * @param {PinSet} set - Harmonic set being nudged
+   * @param {number} freqDelta - What the keypress is worth in Hz, signed
+   * @returns {Partial<PinSet>} Spacing update
    */
-  resolveHarmonicDrag(position) {
-    const existing = this.findHarmonicSetTarget(position)
-    if (existing) {
-      return existing
-    }
-    return this.createHarmonicSetTarget(position)
+  nudgeFreqUpdates(set, freqDelta) {
+    return { spacing: Math.max(1.0, set.spacing + freqDelta) }
   }
-
-  /**
-   * Start dragging a harmonic set
-   * @param {DragTarget} target - Drag target with id and type
-   * @param {DataCoordinates} position - Start position
-   */
-  onHarmonicSetDragStart(target, position) {
-    void position
-    const harmonicSet = target.data.harmonicSet
-
-    // Auto-select the harmonic set being dragged (consistent with analysis markers)
-    const index = this.instance.state.harmonics.harmonicSets.findIndex(set => set.id === harmonicSet.id)
-    if (index !== -1) {
-      this.instance.interaction.setSelection('harmonicSet', harmonicSet.id, index)
-    }
-    // Drag bookkeeping belongs to the engine (state.drag) — nothing to mirror.
-  }
-
-  /**
-   * Update harmonic set during drag
-   * @param {DragTarget} target - Drag target
-   * @param {DataCoordinates} currentPos - Current position
-   * @param {DataCoordinates} startPos - Start position
-   */
-  onHarmonicSetDragUpdate(target, currentPos, startPos) {
-    // Update cursor position so the readouts follow the drag
-    this.instance.state.cursorPosition = {
-      freq: currentPos.freq,
-      time: currentPos.time,
-      x: 0, y: 0, svgX: 0, svgY: 0, imageX: 0, imageY: 0 // Minimal values for compatibility
-    }
-
-    this.applyHarmonicSetDrag(target, currentPos, startPos)
-  }
-
-  /**
-   * End dragging a harmonic set
-   * @param {Object} _target - Drag target with id and type (unused)
-   * @param {DataCoordinates|null} _position - End position (unused)
-   */
-  onHarmonicSetDragEnd(_target, _position) {
-    // Nothing to unwind: the engine clears the drag record itself.
-  }
-
-  /**
-   * Color palette for harmonic sets
-   * @type {string[]}
-   */
-  static harmonicColors = ['#ff6b6b', '#2ecc71', '#f39c12', '#9b59b6', '#ffc93c', '#ff9ff3', '#45b7d1', '#e67e22']
-
-  /**
-   * Base pixel size (width/height) of a pin's symbol mark. The effective size is
-   * this scaled by the "Large" symbol-size experiment toggle — use
-   * {@link HarmonicsMode#symbolSize} rather than reading this directly.
-   * @type {number}
-   */
-  static SYMBOL_SIZE = 10
-
-  /**
-   * Height of a pin line, as a fraction of the *base* (unzoomed) render height.
-   *
-   * The resulting height is a fixed pixel length, not a span of time: it is
-   * derived from the viewport's base render size (which tracks expand, not zoom)
-   * rather than from the zoomed image element. Pins therefore keep the same
-   * on-screen height at every zoom level, growing/shrinking only when the
-   * component itself is resized.
-   * @type {number}
-   */
-  static PIN_HEIGHT_RATIO = 0.2
-
-  /**
-   * Height (px) of a mini-pin: the stub line drawn under each harmonic of a set
-   * whose full pin is hidden.
-   *
-   * Fixed rather than derived, by design (spec: issue #232). It is half the
-   * height of a "Large" symbol mark (SYMBOL_SIZE * LARGE_SYMBOL_SCALE = 20px),
-   * which is enough to tie each harmonic to the data beneath it without
-   * reinstating the clutter the pin toggle exists to remove.
-   * @type {number}
-   */
-  static MINI_PIN_HEIGHT = 10
-
-  /**
-   * Maximum pin lines rendered per harmonic set. At the 0.1 Hz minimum spacing
-   * a standard 0–20 kHz config has 200,000 visible harmonics; drawing an SVG
-   * line for each — rebuilt on every drag frame — locked the browser (BH-2).
-   * Past this cap the drawn lines are a regular sample of the range; well
-   * beyond typical screen widths, adjacent pins merge on screen anyway, so the
-   * thinning is invisible until the set is already a solid block.
-   * @type {number}
-   */
-  static MAX_PIN_LINES = 1000
-
-  /**
-   * Font size (px) of a pin's number label; also used as its approximate ascent
-   * when clamping the label/symbol stack to the image's top edge.
-   * @type {number}
-   */
-  static LABEL_FONT_SIZE = 12
-
-  /**
-   * Approximate width of one label digit as a fraction of the label font size,
-   * used to size the label's grab region (bold Arial digits are ~0.6 em wide).
-   * @type {number}
-   */
-  static LABEL_CHAR_WIDTH_RATIO = 0.6
-
-  /**
-   * Vertical gap (px) between the pin's number label and its symbol.
-   * @type {number}
-   */
-  static LABEL_GAP = 3
-
-  /**
-   * Minimum padding (px) kept between the top of a pin's label and the top edge
-   * of the spectrogram image.
-   * @type {number}
-   */
-  static STACK_TOP_PAD = 1
 
   /**
    * Get guidance content for harmonics mode
@@ -219,60 +185,6 @@ export class HarmonicsMode extends BaseMode {
   }
 
   /**
-   * Handle mouse move events in harmonics mode
-   * @param {MouseEvent} _event - Mouse event
-   * @param {DataCoordinates} dataCoords - Data coordinates {freq, time}
-   */
-  handleMouseMove(_event, dataCoords) {
-    // Both the move and create drags run through the one handler
-    if (this.dragHandler.isDragging()) {
-      this.dragHandler.handleMouseMove(dataCoords)
-    } else {
-      // Update cursor for hover when not dragging
-      this.dragHandler.updateCursorForHover(dataCoords)
-    }
-    
-    // Update harmonic panel ratio values on mouse movement to reflect current cursor position
-    // This ensures existing harmonic sets show their ratio relative to the current mouse position
-    if (this.instance.state.harmonics.harmonicSets.length > 0) {
-      this.updateHarmonicPanel()
-    }
-  }
-
-  /**
-   * Handle mouse down events in harmonics mode
-   * @param {MouseEvent} event - Mouse event
-   * @param {DataCoordinates} dataCoords - Data coordinates {freq, time}
-   */
-  handleMouseDown(event, dataCoords) {
-    // Only handle left clicks
-    if (event.button !== 0) {
-      return
-    }
-    
-    // The resolver decides whether this moves an existing set or creates one
-    this.dragHandler.startDrag(dataCoords, event)
-  }
-
-  /**
-   * Handle mouse up events in harmonics mode
-   * @param {MouseEvent} _event - Mouse event
-   * @param {DataCoordinates} dataCoords - Data coordinates {freq, time}
-   */
-  handleMouseUp(_event, dataCoords) {
-    // One exit for both kinds; the engine restores the cursor
-    this.dragHandler.endDrag(dataCoords)
-  }
-
-
-
-
-
-
-
-
-
-  /**
    * Create UI elements for harmonics mode
    * @param {HTMLElement} harmonicsContainer - Persistent container for harmonics table
    */
@@ -280,42 +192,39 @@ export class HarmonicsMode extends BaseMode {
     // Initialize uiElements
     this.uiElements = {}
 
-
-    
     // Use the provided persistent harmonics container (already has label)
     this.uiElements.harmonicsContainer = harmonicsContainer
-    
-    // Find the button container created in main.js
+
+    // Find the button container created in MainUI
     const buttonContainer = harmonicsContainer.querySelector('.gram-frame-harmonics-button-container')
-    
+
     // Check if UI already exists to prevent duplicates
     if (buttonContainer && buttonContainer.querySelector('.gram-frame-manual-button')) {
       // Find existing elements and store references
-      this.uiElements.manualButton = buttonContainer.querySelector('.gram-frame-manual-button')
-      this.uiElements.harmonicPanel = harmonicsContainer.querySelector('.gram-frame-harmonic-panel')
+      this.uiElements.manualButton = /** @type {HTMLElement|null} */ (buttonContainer.querySelector('.gram-frame-manual-button'))
+      this.uiElements.harmonicPanel = /** @type {HTMLElement|null} */ (harmonicsContainer.querySelector('.gram-frame-harmonic-panel'))
 
       this.instance.ui.harmonicPanel = this.uiElements.harmonicPanel
       return
     }
-    
+
     // Create Manual button and add to existing container
     this.uiElements.manualButton = this.createManualButton()
     if (buttonContainer) {
       buttonContainer.appendChild(this.uiElements.manualButton)
     }
-    
+
     // Create harmonic management panel in the persistent container
     this.uiElements.harmonicPanel = createHarmonicPanel(harmonicsContainer, this.instance)
-    
-    // Store references on instance for compatibility
 
+    // Store references on instance for compatibility
     this.instance.ui.harmonicPanel = this.uiElements.harmonicPanel
-    
+
     // Central color picker is managed by unified layout
     this.instance.ui.colorPicker = this.instance.ui.colorPicker || null
-    
+
     // Populate panel with existing harmonic sets when UI is created
-    this.updateHarmonicPanel()
+    this.updatePanel()
   }
 
   /**
@@ -332,7 +241,7 @@ export class HarmonicsMode extends BaseMode {
    */
   updateModeSpecificLEDs() {
     // Update harmonic panel to show current rate values
-    this.updateHarmonicPanel()
+    this.updatePanel()
   }
 
   /**
@@ -359,100 +268,29 @@ export class HarmonicsMode extends BaseMode {
    * Destroy mode-specific UI elements when leaving this mode
    */
   destroyUI() {
-
-    // Central color picker is managed by unified layout
-    // Harmonics panel and container are persistent and should not be removed
-    // Only remove non-persistent elements if any
-    
-    // Don't call super.destroyUI() because it removes persistent elements from DOM
-    // Instead, just clear references to non-persistent elements
-    
-
+    // Central color picker is managed by unified layout.
+    // The harmonics panel and container are persistent and must survive a mode
+    // switch, so this deliberately does NOT call super.destroyUI(), which would
+    // remove them from the DOM.
   }
 
   /**
    * Add a new harmonic set
    * @param {number} anchorTime - Time position in seconds
    * @param {number} spacing - Frequency spacing in Hz
-   * @returns {HarmonicSet} The created harmonic set
+   * @returns {PinSet} The created harmonic set
    */
   addHarmonicSet(anchorTime, spacing) {
-    const id = `harmonic-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`
-    
-    // Use selected color from global state, fallback to cycling through predefined colors
-    let color
-    if (this.instance.state.selectedColor) {
-      color = this.instance.state.selectedColor
-    } else {
-      const colorIndex = this.instance.state.harmonics.harmonicSets.length % HarmonicsMode.harmonicColors.length
-      color = HarmonicsMode.harmonicColors[colorIndex]
-    }
-    
-    // Use selected symbol from global state, defaulting to the symbol-less cross
-    const symbol = this.instance.state.selectedSymbol || 'cross'
-
-    // Use the session's pin-visibility preference (on unless the analyst turned
-    // it off via the style panel toggle)
-    const showPin = this.instance.state.showHarmonicPin !== false
-
-    /** @type {HarmonicSet} */
-    const harmonicSet = {
-      id,
-      color,
-      anchorTime,
-      spacing,
-      symbol,
-      showPin,
-      // EXPERIMENT (temporary): symbol size is carried per set, seeded from the
-      // toggle's next-feature default, so sets at both sizes can coexist.
-      largeSymbols: !!this.instance.state.largeSymbols
-    }
-    
-    this.instance.state.harmonics.harmonicSets.push(harmonicSet)
-    markAnnotationsChanged(this.instance)
-    
-    // Auto-select the newly created harmonic set
-    const index = this.instance.state.harmonics.harmonicSets.length - 1
-    this.instance.interaction.setSelection('harmonicSet', harmonicSet.id, index)
-    
-    // Update visual elements
-    if (this.instance.ui.harmonicPanel) {
-      updateHarmonicPanelContent(this.instance.ui.harmonicPanel, this.instance)
-    }
-    
-    // Trigger re-render of persistent features to show the new harmonic set
-    if (this.instance.featureRenderer) {
-      this.instance.featureRenderer.renderAllPersistentFeatures()
-    }
-    
-    dispatch(this.instance, { frame: true })
-    
-    return harmonicSet
+    return this.addSet({ anchorTime, spacing })
   }
 
   /**
    * Update an existing harmonic set
    * @param {string} id - Harmonic set ID
-   * @param {Partial<HarmonicSet>} updates - Properties to update
+   * @param {Partial<PinSet>} updates - Properties to update
    */
   updateHarmonicSet(id, updates) {
-    const setIndex = this.instance.state.harmonics.harmonicSets.findIndex(set => set.id === id)
-    if (setIndex !== -1) {
-      Object.assign(this.instance.state.harmonics.harmonicSets[setIndex], updates)
-      markAnnotationsChanged(this.instance)
-
-      // Update visual elements
-      if (this.instance.ui.harmonicPanel) {
-        updateHarmonicPanelContent(this.instance.ui.harmonicPanel, this.instance)
-      }
-      
-      // Trigger re-render of persistent features to show updated harmonic set
-      if (this.instance.featureRenderer) {
-        this.instance.featureRenderer.renderAllPersistentFeatures()
-      }
-      
-      dispatch(this.instance, { frame: true })
-    }
+    this.updateSet(id, updates)
   }
 
   /**
@@ -460,228 +298,22 @@ export class HarmonicsMode extends BaseMode {
    * @param {string} id - Harmonic set ID
    */
   removeHarmonicSet(id) {
-    const setIndex = this.instance.state.harmonics.harmonicSets.findIndex(set => set.id === id)
-    if (setIndex !== -1) {
-      // Clear selection if removing the selected harmonic set
-      if (this.instance.state.selection.selectedType === 'harmonicSet' && 
-          this.instance.state.selection.selectedId === id) {
-        this.instance.interaction.clearSelection()
-      }
-      
-      this.instance.state.harmonics.harmonicSets.splice(setIndex, 1)
-      markAnnotationsChanged(this.instance)
-
-      // Update visual elements
-      if (this.instance.ui.harmonicPanel) {
-        updateHarmonicPanelContent(this.instance.ui.harmonicPanel, this.instance)
-      }
-      
-      // Trigger re-render of persistent features to remove the harmonic set
-      if (this.instance.featureRenderer) {
-        this.instance.featureRenderer.renderAllPersistentFeatures()
-      }
-      
-      dispatch(this.instance, { frame: true })
-    }
+    this.removeSet(id)
   }
 
   /**
    * Find the harmonic set whose drawn geometry contains the given position.
-   *
-   * Hit-testing follows exactly what is drawn — nothing more, nothing less.
-   * Every visible part of a pin grabs it: the line's fixed-pixel span AND the
-   * number label + symbol stacked above it. A set with its pin hidden draws
-   * mini-pins, so its line region shrinks to that stub — the empty span below,
-   * where a full pin would have reached, is blank on screen and blank to the
-   * mouse too.
-   *
-   * Takes the probe position as a parameter rather than reading
-   * `state.cursorPosition`: the stored cursor goes stale during pans (wheel-pan
-   * suppresses mousemove), and a click tested against the pre-pan time missed
-   * the pin and minted a duplicate set on top of it (BH-13).
-   *
-   * Bounded work per set (BH-2): the range is the VISIBLE one (zoom-aware, the
-   * same source the renderer uses), only the harmonic nearest the probe
-   * frequency (±1) is line-tested — no other line can be within frequency
-   * tolerance — and the stack test walks just the thinned labelled subset.
-   * The full-range loop this replaces iterated 200,000 harmonics per hover at
-   * the minimum spacing on a standard config.
-   *
    * @param {DataCoordinates} position - Probe position {freq, time}
-   * @returns {HarmonicSet|null} The harmonic set if found, null otherwise
+   * @returns {PinSet|null} The harmonic set if found, null otherwise
    */
   findHarmonicSetAt(position) {
-    if (!position) return null
-    const { freq, time } = position
-
-    for (const harmonicSet of this.instance.state.harmonics.harmonicSets) {
-      // Check if frequency is close to any harmonic line in this set
-      if (harmonicSet.spacing > 0) {
-        const { minHarmonic, maxHarmonic } = this.getVisibleHarmonicRange(harmonicSet)
-        if (maxHarmonic < minHarmonic) continue
-
-        // Pins are a fixed pixel height, so hit-test vertically in SVG pixels
-        // against the same geometry the renderer draws.
-        const { lineHeight, lineTop } = this.calculateHarmonicLineDimensions(harmonicSet)
-        const stack = this.calculateLabelStackBounds(lineTop, harmonicSet)
-        // Only the thinned subset is labelled, so only those pins carry a stack.
-        const labelled = this.getLabelledHarmonics(minHarmonic, maxHarmonic)
-        // A hidden pin draws mini-pins instead of full lines, so its line grab
-        // region is the mini-pin stub hanging from the stack's underside.
-        const pinDrawn = harmonicSet.showPin !== false
-        const lineFrom = pinDrawn ? lineTop : stack.bottom
-        const lineTo = lineFrom + (pinDrawn ? lineHeight : HarmonicsMode.MINI_PIN_HEIGHT)
-
-        const tolerance = getUniformTolerance(this.getViewport(), this.instance.ui.spectrogramImage)
-        const cursorSVG = dataToSVG(
-          { freq, time },
-          this.getViewport(),
-          this.instance.ui.spectrogramImage
-        )
-
-        // The pin line: frequency tolerance horizontally, the drawn line span
-        // vertically. Only the harmonic(s) nearest the probe frequency can
-        // pass the horizontal test, so only they are checked.
-        if (cursorSVG.y >= lineFrom && cursorSVG.y <= lineTo) {
-          const nearest = Math.round(freq / harmonicSet.spacing)
-          const from = Math.max(minHarmonic, nearest - 1)
-          const to = Math.min(maxHarmonic, nearest + 1)
-          for (let h = from; h <= to; h++) {
-            if (Math.abs(freq - h * harmonicSet.spacing) < tolerance.freq) {
-              return harmonicSet
-            }
-          }
-        }
-
-        // The label/symbol stack above the line: measured in SVG pixels, since
-        // the digits and symbol are a fixed pixel size regardless of zoom.
-        if (cursorSVG.y >= stack.top && cursorSVG.y <= stack.bottom) {
-          for (const h of labelled) {
-            if (Math.abs(cursorSVG.x - this.harmonicLineX(harmonicSet, h)) <= this.labelStackHalfWidth(harmonicSet, h)) {
-              return harmonicSet
-            }
-          }
-        }
-      }
-    }
-    return null
-  }
-
-  /**
-   * Mint a new harmonic set at the mousedown position and return it as a
-   * `create`-kind drag target, so the rest of the gesture is an ordinary drag.
-   *
-   * The initial spacing places the cursor on a sensible harmonic — the 10th
-   * when the frequency axis starts above zero, the 5th when it starts at zero —
-   * which is what keeps the first drawn set legible.
-   * @param {DataCoordinates} dataCoords - Data coordinates {freq, time}
-   * @returns {DragTarget|null} A create-kind target, or null if a set cannot be made
-   */
-  createHarmonicSetTarget(dataCoords) {
-    const { freqMin } = this.instance.state.config
-
-    let initialSpacing
-    let clickedHarmonicNumber
-
-    if (freqMin > 0) {
-      // Origin > 0, position at 10th harmonic
-      clickedHarmonicNumber = 10
-      initialSpacing = dataCoords.freq / clickedHarmonicNumber
-    } else {
-      // Origin at 0, position at 5th harmonic
-      clickedHarmonicNumber = 5
-      initialSpacing = dataCoords.freq / clickedHarmonicNumber
-    }
-
-    // Ensure minimum spacing
-    initialSpacing = Math.max(initialSpacing, 0.1)
-
-    // Create the harmonic set immediately, so the drag has something to move
-    const harmonicSet = this.addHarmonicSet(dataCoords.time, initialSpacing)
-    if (!harmonicSet) {
-      return null
-    }
-
-    return {
-      kind: 'create',
-      id: harmonicSet.id,
-      type: 'harmonicSet',
-      position: dataCoords,
-      data: {
-        harmonicSet,
-        clickedHarmonicNumber,
-        originalAnchorTime: dataCoords.time
-      }
-    }
-  }
-
-  /**
-   * Find which harmonic number was clicked
-   * @param {HarmonicSet} harmonicSet - The harmonic set
-   * @param {number} freq - The clicked frequency
-   * @returns {number} The harmonic number (1, 2, 3, etc.)
-   */
-  findClickedHarmonicNumber(harmonicSet, freq) {
-    const harmonicNumber = Math.round(freq / harmonicSet.spacing)
-    return Math.max(1, harmonicNumber)
-  }
-
-  /**
-   * Apply a harmonic-set drag — the shared step for both the `move` and
-   * `create` kinds, which differ only in how their target was resolved.
-   * @param {DragTarget} target - The drag target from the engine
-   * @param {DataCoordinates} currentPos - Current pointer position
-   * @param {DataCoordinates} startPos - Where the drag began
-   */
-  applyHarmonicSetDrag(target, currentPos, startPos) {
-    if (!target || !currentPos || !startPos) return
-
-    const setId = target.id
-    if (!setId) return
-
-    const harmonicSet = this.instance.state.harmonics.harmonicSets.find(set => set.id === setId)
-    if (!harmonicSet) return
-
-    let newSpacing
-
-    // For both new creation and existing drags, keep the clicked harmonic under the cursor
-    const clickedHarmonicNumber = (target.data && target.data.clickedHarmonicNumber) || 1
-
-    // Calculate spacing so the clicked harmonic stays at cursor position
-    newSpacing = currentPos.freq / clickedHarmonicNumber
-
-    // Ensure minimum spacing
-    newSpacing = Math.max(newSpacing, 0.1)
-
-    // Allow vertical movement for both new creation and existing drags.
-    // Clamped to the configured time range, matching the keyboard-move path:
-    // an unclamped drag could push the anchor off the gram, store it there
-    // unvalidated, and have the set snap back on the first arrow key (BH-25).
-    const originalAnchorTime = target.data && target.data.originalAnchorTime !== undefined
-      ? target.data.originalAnchorTime
-      : harmonicSet.anchorTime
-    const deltaTime = currentPos.time - startPos.time
-    const { timeMin, timeMax } = this.instance.state.config
-    const newAnchorTime = Math.max(timeMin, Math.min(timeMax, originalAnchorTime + deltaTime))
-
-    // Apply updates
-    const updates = {}
-    if (newSpacing > 0) {
-      updates.spacing = newSpacing
-    }
-    updates.anchorTime = newAnchorTime
-
-    this.updateHarmonicSet(setId, updates)
-    
-    // Update harmonic management panel
-    this.updateHarmonicPanel()
+    return this.findSetAt(position)
   }
 
   /**
    * Update harmonic management panel
    */
-  updateHarmonicPanel() {
-
+  updatePanel() {
     if (this.instance.ui.harmonicPanel) {
       updateHarmonicPanelContent(this.instance.ui.harmonicPanel, this.instance)
     }
@@ -696,11 +328,11 @@ export class HarmonicsMode extends BaseMode {
     button.className = 'gram-frame-manual-button'
     button.textContent = '+ Manual'
     button.title = 'Manually add a set of harmonics at a specific spacing'
-    
+
     button.addEventListener('click', () => {
       this.showManualHarmonicModal()
     })
-    
+
     return button
   }
 
@@ -715,9 +347,9 @@ export class HarmonicsMode extends BaseMode {
    * Re-render this mode's persistent panel from current state.
    *
    * The `PanelOwner` capability. `MainUI` used to reach in by name, resolve the
-   * panel element on this mode's behalf, and call `updateHarmonicPanel` through
-   * an `any` cast. Resolving the panel reference belongs here — it is this
-   * mode's own UI element — so it is absorbed rather than left outside
+   * panel element on this mode's behalf, and call the panel update through an
+   * `any` cast. Resolving the panel reference belongs here — it is this mode's
+   * own UI element — so it is absorbed rather than left outside
    * (spec 167, FR-006, AS-4.2).
    */
   refreshPanel() {
@@ -731,385 +363,7 @@ export class HarmonicsMode extends BaseMode {
         this.instance.ui.harmonicPanel = existingPanel
       }
     }
-    this.updateHarmonicPanel()
-  }
-
-  /**
-   * Whether this mode currently owns any persistent feature.
-   *
-   * Half of the `PersistentFeatureProvider` capability. Lived on
-   * `FeatureRenderer` as `hasHarmonicFeatures()` until spec 167 moved it onto
-   * the mode that owns the state it reads.
-   * @returns {boolean} True if at least one harmonic set exists
-   */
-  hasPersistentFeatures() {
-    const harmonics = this.instance.state.harmonics
-    return !!(harmonics && harmonics.harmonicSets && harmonics.harmonicSets.length > 0)
-  }
-
-  /**
-   * Render persistent features for harmonics mode
-   */
-  renderPersistentFeatures() {
-    if (!this.instance.ui.cursorGroup || !this.instance.state.harmonics?.harmonicSets) {
-      return
-    }
-    
-    // Clear existing harmonic lines and their symbol marks. Scope the symbol
-    // cleanup to harmonic pin symbols (which carry data-harmonic-set-id) so it
-    // never removes analysis-marker symbols that share the base symbol class.
-    const existingHarmonics = this.instance.ui.cursorGroup.querySelectorAll(
-      '.gram-frame-harmonic-line, .gram-frame-harmonic-mini-pin'
-    )
-    existingHarmonics.forEach(line => line.remove())
-    const existingSymbols = this.instance.ui.cursorGroup.querySelectorAll('.gram-frame-harmonic-symbol[data-harmonic-set-id]')
-    existingSymbols.forEach(symbol => symbol.remove())
-    
-    // Render all harmonic sets
-    this.instance.state.harmonics.harmonicSets.forEach(harmonicSet => {
-      this.renderHarmonicSet(harmonicSet)
-    })
-  }
-
-  /**
-   * Get the inclusive harmonic-number range of a set that falls within the
-   * currently visible frequency span.
-   *
-   * The visible range comes from `calculateVisibleDataRange` (the same
-   * source the frequency axis uses), so it is viewport-aware: zooming in narrows
-   * the span (fewer harmonics), zooming out / panning widens it. At zoom 1.0 the
-   * visible range equals the full data range.
-   *
-   * Every harmonic in this range is drawn as a pin line (spec 159, FR-001); the
-   * label/symbol subset is a regularly-sampled slice of it (see
-   * {@link getLabelledHarmonics}).
-   *
-   * @param {HarmonicSet} harmonicSet - Harmonic set configuration
-   * @returns {{minHarmonic: number, maxHarmonic: number}} Inclusive harmonic range
-   */
-  getVisibleHarmonicRange(harmonicSet) {
-    const { freqMin, freqMax } = calculateVisibleDataRange(this.instance.state, this.instance.ui.spectrogramImage)
-    const minHarmonic = Math.max(1, Math.ceil(freqMin / harmonicSet.spacing))
-    const maxHarmonic = Math.floor(freqMax / harmonicSet.spacing)
-    return { minHarmonic, maxHarmonic }
-  }
-
-  /**
-   * Get the "major" subset of harmonic numbers that receive a number label and
-   * symbol, thinned to at most the label limit (default 25) by regular sampling.
-   *
-   * Reuses the spec-158 sampling maths, but that limit now governs
-   * labels/symbols only — every pin line is still drawn (spec 159). When the
-   * visible range already fits under the limit the subset is the whole range, so
-   * every drawn pin is labelled (FR-005).
-   *
-   * @param {number} minHarmonic - Lowest visible harmonic number (>= 1)
-   * @param {number} maxHarmonic - Highest visible harmonic number
-   * @returns {number[]} Ascending harmonic numbers to label/symbol (length <= cap)
-   */
-  getLabelledHarmonics(minHarmonic, maxHarmonic) {
-    return sampledHarmonics(minHarmonic, maxHarmonic).harmonics
-  }
-
-  /**
-   * Calculate harmonic line dimensions and positions.
-   *
-   * The height is a fixed pixel length taken from the *base* (unzoomed) render
-   * height, so a pin covers the same number of screen pixels no matter how far
-   * the user has zoomed in — it is not a span of time that stretches with the
-   * image. Only the centre is zoom-aware: the pin stays centred on the set's
-   * anchor time (the original click location), so it tracks the feature while
-   * keeping a constant height.
-   *
-   * @param {HarmonicSet} harmonicSet - Harmonic set configuration
-   * @returns {{lineHeight: number, lineTop: number}} Fixed pixel height and top Y position
-   */
-  calculateHarmonicLineDimensions(harmonicSet) {
-    const { renderHeight } = getRenderDimensions(this.instance.state)
-    const lineHeight = renderHeight * HarmonicsMode.PIN_HEIGHT_RATIO
-    const anchorPoint = { freq: harmonicSet.spacing, time: harmonicSet.anchorTime }
-    const anchorSVG = dataToSVG(anchorPoint, this.getViewport(), this.instance.ui.spectrogramImage)
-    const lineTop = anchorSVG.y - lineHeight / 2
-
-    return { lineHeight, lineTop }
-  }
-
-  /**
-   * Create SVG line element for a harmonic
-   * @param {number} harmonicNumber - Harmonic number
-   * @param {HarmonicSet} harmonicSet - Harmonic set configuration
-   * @param {number} lineX - X position for the line
-   * @param {number} lineTop - Top Y position for the line
-   * @param {number} lineHeight - Height of the line
-   * @returns {SVGLineElement} SVG line element
-   */
-  createHarmonicLine(harmonicNumber, harmonicSet, lineX, lineTop, lineHeight) {
-    const line = document.createElementNS('http://www.w3.org/2000/svg', 'line')
-    line.setAttribute('class', 'gram-frame-harmonic-line')
-    line.setAttribute('data-harmonic-set-id', harmonicSet.id)
-    line.setAttribute('data-harmonic-number', String(harmonicNumber))
-    line.setAttribute('x1', String(lineX))
-    line.setAttribute('y1', String(lineTop))
-    line.setAttribute('x2', String(lineX))
-    line.setAttribute('y2', String(lineTop + lineHeight))
-    line.setAttribute('stroke', harmonicSet.color)
-    line.setAttribute('stroke-width', '2')
-    line.setAttribute('stroke-linecap', 'round')
-    line.setAttribute('opacity', '0.9')
-    return line
-  }
-
-  /**
-   * Create the short stub line drawn under a harmonic when the set's full pin is
-   * hidden.
-   *
-   * Same colour and stroke as a full pin line, so a mini-pin reads as the same
-   * feature at a smaller scale; only its class and height differ. The distinct
-   * class keeps the two apart for cleanup, hit-testing and tests — a hidden-pin
-   * set still draws no `.gram-frame-harmonic-line`.
-   *
-   * @param {number} harmonicNumber - Harmonic number
-   * @param {HarmonicSet} harmonicSet - Harmonic set configuration
-   * @param {number} lineX - X position of the mini-pin
-   * @param {number} top - Top Y position of the mini-pin (the symbol's underside)
-   * @returns {SVGLineElement} SVG line element
-   */
-  createMiniPin(harmonicNumber, harmonicSet, lineX, top) {
-    const miniPin = this.createHarmonicLine(
-      harmonicNumber, harmonicSet, lineX, top, HarmonicsMode.MINI_PIN_HEIGHT
-    )
-    miniPin.setAttribute('class', 'gram-frame-harmonic-mini-pin')
-    return miniPin
-  }
-
-  /**
-   * Create SVG text label for a harmonic number.
-   *
-   * Centred horizontally on the pin's line (`text-anchor: middle` at `lineX`) and
-   * positioned above the pin's symbol (baseline at `labelY`), so the vertical
-   * stack over a pin reads label -> symbol -> line (spec 159, FR-009/FR-010).
-   *
-   * The digits are drawn black inside a white halo rather than in the set's
-   * colour: a single colour is only legible over part of a gram, whereas the
-   * halo reads over both dark and light backgrounds. Set identity is still
-   * carried by the pin's line and symbol colour.
-   *
-   * @param {number} harmonicNumber - Harmonic number
-   * @param {HarmonicSet} harmonicSet - Harmonic set configuration
-   * @param {number} lineX - X position of the pin line (label is centred on it)
-   * @param {number} labelY - Baseline Y position for the label text
-   * @returns {SVGTextElement} SVG text element
-   */
-  createHarmonicLabel(harmonicNumber, harmonicSet, lineX, labelY) {
-    const label = document.createElementNS('http://www.w3.org/2000/svg', 'text')
-    label.setAttribute('class', 'gram-frame-harmonic-number')
-    label.setAttribute('data-harmonic-set-id', harmonicSet.id)
-    label.setAttribute('data-harmonic-number', String(harmonicNumber))
-    label.setAttribute('x', String(lineX)) // centred on the pin line
-    label.setAttribute('y', String(labelY)) // above the symbol
-    label.setAttribute('text-anchor', 'middle')
-    applyTextHalo(/** @type {SVGTextElement} */ (label))
-    label.setAttribute('font-size', String(HarmonicsMode.LABEL_FONT_SIZE))
-    label.setAttribute('font-weight', 'bold')
-    label.setAttribute('font-family', 'Arial, sans-serif')
-    label.textContent = String(harmonicNumber)
-    return label
-  }
-
-  /**
-   * Effective pixel size of a set's symbol marks: the base size scaled by that
-   * set's own large-symbol flag, so sets at both sizes can share a gram. The
-   * whole label/symbol stack layout derives from this, so the label spacing and
-   * top-edge clamping follow the set's chosen size.
-   * @param {HarmonicSet} harmonicSet - Harmonic set configuration
-   * @returns {number} Symbol diameter in px
-   */
-  symbolSize(harmonicSet) {
-    return HarmonicsMode.SYMBOL_SIZE * resolveSymbolScale(harmonicSet)
-  }
-
-  /**
-   * Create the filled symbol mark drawn between a pin's number label and the top
-   * of its line.
-   *
-   * The vertical position (`symbolCy`) is computed once per set by
-   * {@link calculateLabelStackPositions} so the whole label/symbol stack shares a
-   * consistent, on-screen layout.
-   *
-   * @param {HarmonicSet} harmonicSet - Harmonic set configuration
-   * @param {number} lineX - X position of the pin line (symbol is centred on it)
-   * @param {number} symbolCy - Centre Y position for the symbol
-   * @returns {SVGElement|null} SVG symbol element, or null for the `cross` (symbol-less) style
-   */
-  createHarmonicSymbol(harmonicSet, lineX, symbolCy) {
-    const symbol = createSymbolMark(
-      harmonicSet.symbol, lineX, symbolCy, this.symbolSize(harmonicSet), harmonicSet.color
-    )
-    // `cross` sets draw no symbol shape (the pin keeps its line and label).
-    if (!symbol) {
-      return null
-    }
-    symbol.setAttribute('data-harmonic-set-id', harmonicSet.id)
-    return symbol
-  }
-
-  /**
-   * Compute the shared vertical layout of a pin's label/symbol stack.
-   *
-   * Ideal (top-to-bottom): label baseline, then symbol, then the pin line top,
-   * so the symbol caps the line and the label sits above the symbol. When the
-   * stack's top would clip above the spectrogram's top edge, the whole stack
-   * (label + symbol) is nudged down by the overflow so it stays legible
-   * (spec 159, FR-011).
-   *
-   * @param {number} lineTop - Top Y position of the pin lines (SVG coords)
-   * @param {number} imageTop - Top edge of the spectrogram image in SVG coords
-   * @param {HarmonicSet} harmonicSet - Harmonic set being laid out (its symbol size drives the stack)
-   * @returns {{symbolCy: number, labelY: number}} Symbol centre and label baseline Y
-   */
-  calculateLabelStackPositions(lineTop, imageTop, harmonicSet) {
-    const r = this.symbolSize(harmonicSet) / 2
-    const gap = HarmonicsMode.LABEL_GAP
-    const fontSize = HarmonicsMode.LABEL_FONT_SIZE
-
-    // Symbol caps the line; label baseline sits just above the symbol.
-    let symbolCy = lineTop - r
-    let labelY = symbolCy - r - gap
-
-    // Keep the top of the label (approx one ascent above its baseline) on-screen.
-    const labelTop = labelY - fontSize
-    const minTop = imageTop + HarmonicsMode.STACK_TOP_PAD
-    if (labelTop < minTop) {
-      const shift = minTop - labelTop
-      symbolCy += shift
-      labelY += shift
-    }
-
-    return { symbolCy, labelY }
-  }
-
-  /**
-   * Vertical extent (SVG coords) of a pin's label/symbol stack, for hit-testing.
-   *
-   * Derived from the same {@link calculateLabelStackPositions} layout the
-   * renderer uses, so the grab region tracks the drawn stack — including the
-   * downward nudge applied near the image's top edge. The bottom is clamped to
-   * the pin line's top so the stack region and the line region always meet with
-   * no dead gap between them.
-   *
-   * @param {number} lineTop - Top Y position of the pin lines (SVG coords)
-   * @param {HarmonicSet} harmonicSet - Harmonic set being hit-tested
-   * @returns {{top: number, bottom: number}} Top and bottom Y of the stack region
-   */
-  calculateLabelStackBounds(lineTop, harmonicSet) {
-    const imageTop = getImageBounds(this.getViewport(), this.instance.ui.spectrogramImage).top
-    const { symbolCy, labelY } = this.calculateLabelStackPositions(lineTop, imageTop, harmonicSet)
-    const r = this.symbolSize(harmonicSet) / 2
-
-    return {
-      // One ascent above the label's baseline is the top of the digits.
-      top: labelY - HarmonicsMode.LABEL_FONT_SIZE,
-      bottom: Math.max(lineTop, symbolCy + r)
-    }
-  }
-
-  /**
-   * Half-width (SVG px) of a pin's label/symbol stack, for hit-testing.
-   *
-   * The wider of the symbol mark and the number label, so both are grabbable:
-   * a `cross` set has no symbol but still shows its digits, and a "Large
-   * symbols" set's mark is wider than its digits. Label width is estimated from
-   * the digit count rather than measured, which is ample for a grab region.
-   *
-   * @param {HarmonicSet} harmonicSet - Harmonic set being hit-tested
-   * @param {number} harmonicNumber - Harmonic number whose label is drawn
-   * @returns {number} Half-width in SVG pixels
-   */
-  labelStackHalfWidth(harmonicSet, harmonicNumber) {
-    const digits = String(harmonicNumber).length
-    const labelHalfWidth = digits * HarmonicsMode.LABEL_FONT_SIZE * HarmonicsMode.LABEL_CHAR_WIDTH_RATIO / 2
-
-    return Math.max(this.symbolSize(harmonicSet) / 2, labelHalfWidth)
-  }
-
-  /**
-   * Compute the SVG x-coordinate of a harmonic's vertical pin line.
-   * @param {HarmonicSet} harmonicSet - Harmonic set configuration
-   * @param {number} harmonicNumber - Harmonic number
-   * @returns {number} SVG x-coordinate of the pin line
-   */
-  harmonicLineX(harmonicSet, harmonicNumber) {
-    const harmonicPoint = { freq: harmonicNumber * harmonicSet.spacing, time: harmonicSet.anchorTime }
-    return dataToSVG(harmonicPoint, this.getViewport(), this.instance.ui.spectrogramImage).x
-  }
-
-  /**
-   * Render a single harmonic set as vertical pin lines.
-   *
-   * Spec 159: draw a pin line for EVERY harmonic in the visible span (no pins are
-   * dropped, even if they merge into a solid block), then draw a number label and
-   * symbol only for the thinned "major" subset so the overlay stays readable.
-   * Lines are appended first so the labels/symbols paint on top of them.
-   *
-   * A set with `showPin === false` draws a mini-pin per harmonic instead of a
-   * full-height line: a stub hanging from the symbol's underside, in the set's
-   * colour. Labels and symbols are thinned, so without them a pin-less set gave
-   * no sign of where the harmonics between the labelled ones actually fell
-   * (issue #232); the mini-pins restore that alignment with the data at a
-   * fraction of the ink. The label/symbol geometry is unchanged either way, so
-   * toggling the pin swaps line lengths without moving anything else.
-   *
-   * @param {HarmonicSet} harmonicSet - Harmonic set to render
-   */
-  renderHarmonicSet(harmonicSet) {
-    if (!this.instance.ui.cursorGroup) {
-      return
-    }
-
-    const { minHarmonic, maxHarmonic } = this.getVisibleHarmonicRange(harmonicSet)
-    if (maxHarmonic < minHarmonic) {
-      return
-    }
-
-    const { lineHeight, lineTop } = this.calculateHarmonicLineDimensions(harmonicSet)
-    const imageTop = getImageBounds(this.getViewport(), this.instance.ui.spectrogramImage).top
-    // The label/symbol stack is laid out first: a mini-pin hangs from the
-    // underside of the symbol, so it needs the stack's (possibly clamped)
-    // vertical position.
-    const { symbolCy, labelY } = this.calculateLabelStackPositions(lineTop, imageTop, harmonicSet)
-    const pinDrawn = harmonicSet.showPin !== false
-
-    // Draw a line for every harmonic in the visible span (FR-001) — full height
-    // when the set is pinned, a mini-pin when it is not. Sets restored from
-    // storage without the flag are pinned.
-    // Beyond MAX_PIN_LINES the lines are a regular sample of the span (BH-2):
-    // by then adjacent pins have long merged on screen, and an uncapped loop
-    // rebuilt hundreds of thousands of SVG elements per drag frame.
-    const visibleCount = maxHarmonic - minHarmonic + 1
-    const stride = Math.max(1, Math.ceil(visibleCount / HarmonicsMode.MAX_PIN_LINES))
-    const miniPinTop = symbolCy + this.symbolSize(harmonicSet) / 2
-    for (let harmonicNumber = minHarmonic; harmonicNumber <= maxHarmonic; harmonicNumber += stride) {
-      const lineX = this.harmonicLineX(harmonicSet, harmonicNumber)
-      const line = pinDrawn
-        ? this.createHarmonicLine(harmonicNumber, harmonicSet, lineX, lineTop, lineHeight)
-        : this.createMiniPin(harmonicNumber, harmonicSet, lineX, miniPinTop)
-      this.instance.ui.cursorGroup.appendChild(line)
-    }
-
-    // Draw labels + symbols only on the thinned major subset (FR-002), stacked
-    // above each pin line with a shared, on-screen vertical layout.
-    const labelledHarmonics = this.getLabelledHarmonics(minHarmonic, maxHarmonic)
-
-    labelledHarmonics.forEach(harmonicNumber => {
-      const lineX = this.harmonicLineX(harmonicSet, harmonicNumber)
-      const symbol = this.createHarmonicSymbol(harmonicSet, lineX, symbolCy)
-      const label = this.createHarmonicLabel(harmonicNumber, harmonicSet, lineX, labelY)
-      // `cross` sets have no symbol mark; the number label is still drawn.
-      if (symbol) {
-        this.instance.ui.cursorGroup.appendChild(symbol)
-      }
-      this.instance.ui.cursorGroup.appendChild(label)
-    })
+    this.updatePanel()
   }
 
   /**
@@ -1125,5 +379,4 @@ export class HarmonicsMode extends BaseMode {
       },
     }
   }
-
 }

--- a/src/modes/shared/PinSetMode.js
+++ b/src/modes/shared/PinSetMode.js
@@ -1,0 +1,1008 @@
+/**
+ * The shared "pin set" mode.
+ *
+ * A pin set is a family of equally-spaced vertical pins drawn across the gram
+ * at one anchor time: a numbered line per member, a symbol capping it and a
+ * number label above that. Two modes draw one — Harmonics, whose members sit at
+ * multiples of the spacing (origin fixed at 0 Hz), and Sidebands, whose members
+ * sit either side of a fundamental the analyst places (issue #241).
+ *
+ * Everything those two share lives here: the pin geometry, the label/symbol
+ * stack, the hit test, the render loop, the drag wiring, and set add/update/
+ * remove. What differs is small and declared as the subclass contract below —
+ * where the sets are stored, what frequency a member index maps to, which
+ * indices are visible, what a member's label says, and what a drag means.
+ *
+ * The class is deliberately indexed by a signed integer rather than by
+ * "harmonic number": index `n` means the same thing to both modes (the nth
+ * member out from the set's origin), and only {@link PinSetMode#freqForIndex}
+ * knows where that lands in Hz.
+ */
+
+/// <reference path="../../types.js" />
+
+import { BaseMode } from '../BaseMode.js'
+import { dispatch, markAnnotationsChanged } from '../../core/state.js'
+import {
+  dataToSVG,
+  getImageBounds,
+  calculateVisibleDataRange,
+  getRenderDimensions
+} from '../../utils/coordinates.js'
+import { BaseDragHandler } from './BaseDragHandler.js'
+import { getUniformTolerance } from '../../utils/tolerance.js'
+import { sampledHarmonics } from '../../utils/harmonicSampling.js'
+import { createSymbolMark, resolveSymbolScale } from '../../rendering/symbols.js'
+import { applyTextHalo } from '../../utils/svg.js'
+
+/**
+ * Minimum spacing (Hz) any pin set may be dragged or nudged to.
+ *
+ * Strictly positive: a spacing of zero makes the visible index range infinite
+ * and hangs the render loop (BH-1/BH-16, the same reason storage refuses it).
+ * @type {number}
+ */
+export const MIN_PIN_SPACING = 0.1
+
+/**
+ * Pin-set mode base class.
+ */
+export class PinSetMode extends BaseMode {
+  /**
+   * Base pixel size (width/height) of a pin's symbol mark. The effective size is
+   * this scaled by the "Large" symbol-size experiment toggle — use
+   * {@link PinSetMode#symbolSize} rather than reading this directly.
+   * @type {number}
+   */
+  static SYMBOL_SIZE = 10
+
+  /**
+   * Height of a pin line, as a fraction of the *base* (unzoomed) render height.
+   *
+   * The resulting height is a fixed pixel length, not a span of time: it is
+   * derived from the viewport's base render size (which tracks expand, not zoom)
+   * rather than from the zoomed image element. Pins therefore keep the same
+   * on-screen height at every zoom level, growing/shrinking only when the
+   * component itself is resized.
+   * @type {number}
+   */
+  static PIN_HEIGHT_RATIO = 0.2
+
+  /**
+   * Height (px) of a mini-pin: the stub line drawn under each member of a set
+   * whose full pin is hidden.
+   *
+   * Fixed rather than derived, by design (spec: issue #232). It is half the
+   * height of a "Large" symbol mark (SYMBOL_SIZE * LARGE_SYMBOL_SCALE = 20px),
+   * which is enough to tie each pin to the data beneath it without reinstating
+   * the clutter the pin toggle exists to remove.
+   * @type {number}
+   */
+  static MINI_PIN_HEIGHT = 10
+
+  /**
+   * Maximum pin lines rendered per set. At the 0.1 Hz minimum spacing a
+   * standard 0–20 kHz config has 200,000 visible members; drawing an SVG line
+   * for each — rebuilt on every drag frame — locked the browser (BH-2). Past
+   * this cap the drawn lines are a regular sample of the range; well beyond
+   * typical screen widths, adjacent pins merge on screen anyway, so the thinning
+   * is invisible until the set is already a solid block.
+   * @type {number}
+   */
+  static MAX_PIN_LINES = 1000
+
+  /**
+   * Font size (px) of a pin's number label; also used as its approximate ascent
+   * when clamping the label/symbol stack to the image's top edge.
+   * @type {number}
+   */
+  static LABEL_FONT_SIZE = 12
+
+  /**
+   * Approximate width of one label character as a fraction of the label font
+   * size, used to size the label's grab region (bold Arial digits are ~0.6 em
+   * wide).
+   * @type {number}
+   */
+  static LABEL_CHAR_WIDTH_RATIO = 0.6
+
+  /**
+   * Vertical gap (px) between the pin's number label and its symbol.
+   * @type {number}
+   */
+  static LABEL_GAP = 3
+
+  /**
+   * Minimum padding (px) kept between the top of a pin's label and the top edge
+   * of the spectrogram image.
+   * @type {number}
+   */
+  static STACK_TOP_PAD = 1
+
+  /**
+   * Wire up the one drag handler both pin-set drags run through.
+   *
+   * Moving an existing set (`move`) and creating one by dragging (`create`)
+   * differ only in how the target is resolved — a create mints its set on
+   * mousedown — and share every subsequent step (spec 166, FR-004).
+   * @param {GramFrame} instance - GramFrame instance
+   * @param {ModeType} modeName - Mode that owns the drag, for the projection
+   */
+  constructor(instance, modeName) {
+    super(instance)
+
+    this.dragHandler = new BaseDragHandler(instance, {
+      // A feature drag always carries a data position. Only the pan drag passes
+      // null, and it runs on its own handler in `core/events.js`.
+      resolveTarget: (position) => this.resolvePinSetDrag(/** @type {DataCoordinates} */ (position)),
+      // Hover only ever *finds* — resolvePinSetDrag mints a new set when the
+      // cursor is over empty gram, which is right for a mousedown and wrong for
+      // a hover (a hover that creates features floods the gram with sets).
+      resolveHoverTarget: (position) => this.findSetTarget(/** @type {DataCoordinates} */ (position)),
+      onDragStart: (target) => this.onSetDragStart(target),
+      onDragMove: (target, currentPos, startPos) => this.onSetDragUpdate(
+        target,
+        /** @type {DataCoordinates} */ (currentPos),
+        /** @type {DataCoordinates} */ (startPos)
+      ),
+      onDragEnd: () => this.onSetDragEnd(),
+      onDragCancel: () => this.onSetDragEnd(),
+      updateCursor: (style) => this.updateCursorStyle(style)
+    }, modeName)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Subclass contract. Every member below is abstract: the base class calls it
+  // and cannot answer it, so a subclass that forgets one fails loudly rather
+  // than drawing nothing.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * The sets this mode owns, live (mutated in place by add/remove).
+   * @returns {PinSet[]} This mode's sets
+   */
+  get sets() {
+    throw new Error(`${this.constructor.name} must implement the "sets" getter`)
+  }
+
+  /**
+   * Selection type used for this mode's sets, as `state.selection.selectedType`.
+   * @returns {SelectedFeatureType} Selection type
+   */
+  get selectionType() {
+    throw new Error(`${this.constructor.name} must implement the "selectionType" getter`)
+  }
+
+  /**
+   * Prefix for generated set ids, and the DOM naming stem for this mode's pins.
+   * @returns {PinSetClassNames} Class and attribute names for the drawn pins
+   */
+  get pinNames() {
+    throw new Error(`${this.constructor.name} must implement the "pinNames" getter`)
+  }
+
+  /**
+   * Frequency (Hz, in the raw configured scale) of a set member.
+   * @param {PinSet} _set - The set
+   * @param {number} _index - Member index
+   * @returns {number} Frequency of that member
+   */
+  freqForIndex(_set, _index) {
+    throw new Error(`${this.constructor.name} must implement freqForIndex()`)
+  }
+
+  /**
+   * Inclusive member-index range of a set within the currently visible span.
+   * @param {PinSet} _set - The set
+   * @returns {{minIndex: number, maxIndex: number}} Inclusive index range
+   */
+  visibleIndexRange(_set) {
+    throw new Error(`${this.constructor.name} must implement visibleIndexRange()`)
+  }
+
+  /**
+   * Member index nearest a probe frequency — the only member (±1) that can be
+   * within frequency tolerance of it.
+   * @param {PinSet} _set - The set
+   * @param {number} _freq - Probe frequency
+   * @returns {number} Nearest member index
+   */
+  nearestIndex(_set, _freq) {
+    throw new Error(`${this.constructor.name} must implement nearestIndex()`)
+  }
+
+  /**
+   * Text of a member's number label.
+   * @param {number} _index - Member index
+   * @returns {string} Label text
+   */
+  labelTextFor(_index) {
+    throw new Error(`${this.constructor.name} must implement labelTextFor()`)
+  }
+
+  /**
+   * Mint a new set at the mousedown position and return it as a `create`-kind
+   * drag target, so the rest of the gesture is an ordinary drag.
+   * @param {DataCoordinates} _dataCoords - Position of the mousedown
+   * @returns {DragTarget|null} A create-kind target, or null if none can be made
+   */
+  createSetTarget(_dataCoords) {
+    throw new Error(`${this.constructor.name} must implement createSetTarget()`)
+  }
+
+  /**
+   * The frequency-axis half of a drag: what changes when the pointer moves
+   * horizontally. The time-axis half (the anchor) is shared and handled here.
+   * @param {PinSet} _set - The set being dragged
+   * @param {number} _clickedIndex - Member index the drag grabbed
+   * @param {DataCoordinates} _currentPos - Current pointer position
+   * @returns {Partial<PinSet>} Updates to apply
+   */
+  freqUpdatesForDrag(_set, _clickedIndex, _currentPos) {
+    throw new Error(`${this.constructor.name} must implement freqUpdatesForDrag()`)
+  }
+
+  /**
+   * Whether this mode's table shows anything derived from the cursor position,
+   * and so has to be re-rendered as the pointer moves.
+   *
+   * Not abstract: false is the answer for a table of plain feature properties,
+   * and a mode says otherwise only when it has a reason to.
+   * @returns {boolean} True if the table follows the cursor
+   */
+  get panelTracksCursor() {
+    return false
+  }
+
+  /**
+   * Re-render this mode's table from current state.
+   */
+  updatePanel() {
+    throw new Error(`${this.constructor.name} must implement updatePanel()`)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pointer handling
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Handle mouse move events
+   * @param {MouseEvent} _event - Mouse event
+   * @param {DataCoordinates} dataCoords - Data coordinates {freq, time}
+   */
+  handleMouseMove(_event, dataCoords) {
+    // Both the move and create drags run through the one handler
+    if (this.dragHandler && this.dragHandler.isDragging()) {
+      this.dragHandler.handleMouseMove(dataCoords)
+    } else if (this.dragHandler) {
+      // Update cursor for hover when not dragging
+      this.dragHandler.updateCursorForHover(dataCoords)
+    }
+
+    // Refresh the table on mouse movement only for a mode whose table shows
+    // something derived from the cursor (the harmonics panel's ratio). Without
+    // the guard every pointer move re-diffs a table that cannot have changed.
+    if (this.panelTracksCursor && this.sets.length > 0) {
+      this.updatePanel()
+    }
+  }
+
+  /**
+   * Handle mouse down events
+   * @param {MouseEvent} event - Mouse event
+   * @param {DataCoordinates} dataCoords - Data coordinates {freq, time}
+   */
+  handleMouseDown(event, dataCoords) {
+    // Only handle left clicks
+    if (event.button !== 0) {
+      return
+    }
+
+    // The resolver decides whether this moves an existing set or creates one
+    if (this.dragHandler) {
+      this.dragHandler.startDrag(dataCoords, event)
+    }
+  }
+
+  /**
+   * Handle mouse up events
+   * @param {MouseEvent} _event - Mouse event
+   * @param {DataCoordinates} dataCoords - Data coordinates {freq, time}
+   */
+  handleMouseUp(_event, dataCoords) {
+    // One exit for both kinds; the engine restores the cursor
+    if (this.dragHandler) {
+      this.dragHandler.endDrag(dataCoords)
+    }
+  }
+
+  /**
+   * Find the set under a position and describe it as a `move` drag target.
+   * @param {DataCoordinates} position - Position to check
+   * @returns {DragTarget|null} Drag target if found, null otherwise
+   */
+  findSetTarget(position) {
+    const set = this.findSetAt(position)
+    if (set) {
+      return {
+        kind: 'move',
+        id: set.id,
+        type: this.selectionType,
+        position: position,
+        data: {
+          set,
+          clickedIndex: this.nearestIndex(set, position.freq),
+          originalAnchorTime: set.anchorTime
+        }
+      }
+    }
+    return null
+  }
+
+  /**
+   * Resolve what a mousedown starts.
+   *
+   * Landing on an existing set moves it; landing anywhere else creates one and
+   * drags it out from there. The new set is minted here, on mousedown, so the
+   * engine has a target id for the whole gesture (contract: drag-engine.md).
+   * @param {DataCoordinates} position - Position of the mousedown
+   * @returns {DragTarget|null} A move- or create-kind target
+   */
+  resolvePinSetDrag(position) {
+    return this.findSetTarget(position) || this.createSetTarget(position)
+  }
+
+  /**
+   * Start dragging a set: select it, as clicking its table row would.
+   * @param {DragTarget} target - Drag target with id and type
+   */
+  onSetDragStart(target) {
+    const index = this.sets.findIndex(set => set.id === target.id)
+    if (index !== -1) {
+      this.instance.interaction.setSelection(this.selectionType, /** @type {string} */ (target.id), index)
+    }
+    // Drag bookkeeping belongs to the engine (state.drag) — nothing to mirror.
+  }
+
+  /**
+   * Update a set during a drag.
+   * @param {DragTarget} target - Drag target
+   * @param {DataCoordinates} currentPos - Current position
+   * @param {DataCoordinates} startPos - Position the drag started from
+   */
+  onSetDragUpdate(target, currentPos, startPos) {
+    // Update cursor position so the readouts follow the drag
+    this.instance.state.cursorPosition = {
+      freq: currentPos.freq,
+      time: currentPos.time,
+      x: 0, y: 0, svgX: 0, svgY: 0, imageX: 0, imageY: 0 // Minimal values for compatibility
+    }
+
+    this.applySetDrag(target, currentPos, startPos)
+  }
+
+  /**
+   * End (or cancel) a set drag.
+   */
+  onSetDragEnd() {
+    // Nothing to unwind: the engine clears the drag record itself.
+  }
+
+  /**
+   * Apply a set drag — the shared step for both the `move` and `create` kinds,
+   * which differ only in how their target was resolved.
+   * @param {DragTarget} target - The drag target from the engine
+   * @param {DataCoordinates} currentPos - Current pointer position
+   * @param {DataCoordinates} startPos - Where the drag began
+   */
+  applySetDrag(target, currentPos, startPos) {
+    if (!target || !currentPos || !startPos) return
+
+    const setId = target.id
+    if (!setId) return
+
+    const set = this.sets.find(candidate => candidate.id === setId)
+    if (!set) return
+
+    // Keep the grabbed member under the cursor, whatever it costs the geometry.
+    const clickedIndex = target.data && target.data.clickedIndex !== undefined
+      ? target.data.clickedIndex
+      : 1
+    /** @type {Record<string, any>} */
+    const updates = { ...this.freqUpdatesForDrag(set, clickedIndex, currentPos) }
+
+    // Vertical movement is shared: it moves the whole set's anchor time.
+    // Clamped to the configured time range, matching the keyboard-move path:
+    // an unclamped drag could push the anchor off the gram, store it there
+    // unvalidated, and have the set snap back on the first arrow key (BH-25).
+    const originalAnchorTime = target.data && target.data.originalAnchorTime !== undefined
+      ? target.data.originalAnchorTime
+      : set.anchorTime
+    const deltaTime = currentPos.time - startPos.time
+    const { timeMin, timeMax } = this.instance.state.config
+    updates.anchorTime = Math.max(timeMin, Math.min(timeMax, originalAnchorTime + deltaTime))
+
+    this.updateSet(setId, updates)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Set lifecycle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Add a set, seeded with this session's style choices, and select it.
+   *
+   * The subclass supplies only the geometry (`anchorTime`, `spacing`, and for
+   * sidebands the fundamental); colour, symbol, pin visibility and symbol size
+   * come from the style panel and are the same for every pin set.
+   * @param {Partial<PinSet>} geometry - Geometry fields for the new set
+   * @returns {PinSet} The created set
+   */
+  addSet(geometry) {
+    const id = `${this.pinNames.idPrefix}-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`
+
+    // Use selected color from global state, fallback to cycling through predefined colors
+    const palette = PinSetMode.SET_COLORS
+    const color = this.instance.state.selectedColor
+      || palette[this.sets.length % palette.length]
+
+    /** @type {PinSet} */
+    const set = /** @type {PinSet} */ ({
+      id,
+      color,
+      // Use selected symbol from global state, defaulting to the symbol-less cross
+      symbol: this.instance.state.selectedSymbol || 'cross',
+      // Use the session's pin-visibility preference (on unless the analyst
+      // turned it off via the style panel toggle)
+      showPin: this.instance.state.showHarmonicPin !== false,
+      // EXPERIMENT (temporary): symbol size is carried per set, seeded from the
+      // toggle's next-feature default, so sets at both sizes can coexist.
+      largeSymbols: !!this.instance.state.largeSymbols,
+      ...geometry
+    })
+
+    this.sets.push(set)
+    markAnnotationsChanged(this.instance)
+
+    // Auto-select the newly created set
+    this.instance.interaction.setSelection(this.selectionType, set.id, this.sets.length - 1)
+
+    this.updatePanel()
+
+    // Trigger re-render of persistent features to show the new set
+    if (this.instance.featureRenderer) {
+      this.instance.featureRenderer.renderAllPersistentFeatures()
+    }
+
+    dispatch(this.instance, { frame: true })
+
+    return set
+  }
+
+  /**
+   * Update an existing set.
+   * @param {string} id - Set ID
+   * @param {Partial<PinSet>} updates - Properties to update
+   */
+  updateSet(id, updates) {
+    const setIndex = this.sets.findIndex(set => set.id === id)
+    if (setIndex === -1) {
+      return
+    }
+
+    Object.assign(this.sets[setIndex], updates)
+    markAnnotationsChanged(this.instance)
+
+    this.updatePanel()
+
+    // Trigger re-render of persistent features to show the updated set
+    if (this.instance.featureRenderer) {
+      this.instance.featureRenderer.renderAllPersistentFeatures()
+    }
+
+    dispatch(this.instance, { frame: true })
+  }
+
+  /**
+   * Remove a set.
+   * @param {string} id - Set ID
+   */
+  removeSet(id) {
+    const setIndex = this.sets.findIndex(set => set.id === id)
+    if (setIndex === -1) {
+      return
+    }
+
+    // Clear selection if removing the selected set
+    const { selection } = this.instance.state
+    if (selection.selectedType === this.selectionType && selection.selectedId === id) {
+      this.instance.interaction.clearSelection()
+    }
+
+    this.sets.splice(setIndex, 1)
+    markAnnotationsChanged(this.instance)
+
+    this.updatePanel()
+
+    if (this.instance.featureRenderer) {
+      this.instance.featureRenderer.renderAllPersistentFeatures()
+    }
+
+    // Default tier, not frame tier: a deletion is a one-off, and listeners
+    // (storage among them) should see it on the next microtask rather than
+    // waiting for a frame that only a continuous gesture needs.
+    dispatch(this.instance)
+  }
+
+  /**
+   * The frequency-axis half of a keyboard nudge: what an arrow key worth of
+   * horizontal movement changes.
+   *
+   * The default adjusts the spacing, which is what both pin-set modes want. A
+   * mode overrides it to change the floor, or to nudge something else.
+   * @param {PinSet} set - The set being nudged
+   * @param {number} freqDelta - What the keypress is worth in Hz, signed
+   * @returns {Partial<PinSet>} Updates to apply
+   */
+  nudgeFreqUpdates(set, freqDelta) {
+    return { spacing: Math.max(MIN_PIN_SPACING, set.spacing + freqDelta) }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Hit testing
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Find the set whose drawn geometry contains the given position.
+   *
+   * Hit-testing follows exactly what is drawn — nothing more, nothing less.
+   * Every visible part of a pin grabs it: the line's fixed-pixel span AND the
+   * number label + symbol stacked above it. A set with its pin hidden draws
+   * mini-pins, so its line region shrinks to that stub — the empty span below,
+   * where a full pin would have reached, is blank on screen and blank to the
+   * mouse too.
+   *
+   * Takes the probe position as a parameter rather than reading
+   * `state.cursorPosition`: the stored cursor goes stale during pans (wheel-pan
+   * suppresses mousemove), and a click tested against the pre-pan time missed
+   * the pin and minted a duplicate set on top of it (BH-13).
+   *
+   * Bounded work per set (BH-2): the range is the VISIBLE one (zoom-aware, the
+   * same source the renderer uses), only the member nearest the probe frequency
+   * (±1) is line-tested — no other line can be within frequency tolerance — and
+   * the stack test walks just the thinned labelled subset.
+   *
+   * @param {DataCoordinates} position - Probe position {freq, time}
+   * @returns {PinSet|null} The set if found, null otherwise
+   */
+  findSetAt(position) {
+    if (!position) return null
+    const { freq, time } = position
+
+    for (const set of this.sets) {
+      if (!(set.spacing > 0)) continue
+
+      const { minIndex, maxIndex } = this.visibleIndexRange(set)
+      if (maxIndex < minIndex) continue
+
+      // Pins are a fixed pixel height, so hit-test vertically in SVG pixels
+      // against the same geometry the renderer draws.
+      const { lineHeight, lineTop } = this.pinLineDimensions(set)
+      const stack = this.labelStackBounds(lineTop, set)
+      // Only the thinned subset is labelled, so only those pins carry a stack.
+      const labelled = this.labelledIndices(minIndex, maxIndex)
+      // A hidden pin draws mini-pins instead of full lines, so its line grab
+      // region is the mini-pin stub hanging from the stack's underside.
+      const pinDrawn = set.showPin !== false
+      const lineFrom = pinDrawn ? lineTop : stack.bottom
+      const lineTo = lineFrom + (pinDrawn ? lineHeight : PinSetMode.MINI_PIN_HEIGHT)
+
+      const tolerance = getUniformTolerance(this.getViewport(), this.instance.ui.spectrogramImage)
+      const cursorSVG = dataToSVG(
+        { freq, time },
+        this.getViewport(),
+        this.instance.ui.spectrogramImage
+      )
+
+      // The pin line: frequency tolerance horizontally, the drawn line span
+      // vertically. Only the member(s) nearest the probe frequency can pass the
+      // horizontal test, so only they are checked.
+      if (cursorSVG.y >= lineFrom && cursorSVG.y <= lineTo) {
+        const nearest = this.nearestIndex(set, freq)
+        const from = Math.max(minIndex, nearest - 1)
+        const to = Math.min(maxIndex, nearest + 1)
+        for (let index = from; index <= to; index++) {
+          if (Math.abs(freq - this.freqForIndex(set, index)) < tolerance.freq) {
+            return set
+          }
+        }
+      }
+
+      // The label/symbol stack above the line: measured in SVG pixels, since
+      // the characters and symbol are a fixed pixel size regardless of zoom.
+      if (cursorSVG.y >= stack.top && cursorSVG.y <= stack.bottom) {
+        for (const index of labelled) {
+          if (Math.abs(cursorSVG.x - this.pinX(set, index)) <= this.labelStackHalfWidth(set, index)) {
+            return set
+          }
+        }
+      }
+    }
+    return null
+  }
+
+  // ---------------------------------------------------------------------------
+  // Geometry
+  // ---------------------------------------------------------------------------
+
+  /**
+   * The visible frequency span, as the frequency axis reports it.
+   *
+   * Viewport-aware: zooming in narrows the span (fewer pins), zooming out /
+   * panning widens it. At zoom 1.0 it equals the full data range.
+   * @returns {{freqMin: number, freqMax: number}} Visible frequency span
+   */
+  visibleFrequencySpan() {
+    const { freqMin, freqMax } = calculateVisibleDataRange(
+      this.instance.state, this.instance.ui.spectrogramImage
+    )
+    return { freqMin, freqMax }
+  }
+
+  /**
+   * The "major" subset of member indices that receive a number label and symbol,
+   * thinned to at most the label limit (default 25) by regular sampling.
+   *
+   * Every pin line is still drawn (spec 159); this limit governs labels and
+   * symbols only. When the visible range already fits under the limit the subset
+   * is the whole range, so every drawn pin is labelled (FR-005).
+   * @param {number} minIndex - Lowest visible member index
+   * @param {number} maxIndex - Highest visible member index
+   * @returns {number[]} Ascending member indices to label/symbol
+   */
+  labelledIndices(minIndex, maxIndex) {
+    return sampledHarmonics(minIndex, maxIndex).harmonics
+  }
+
+  /**
+   * Calculate pin line dimensions and positions.
+   *
+   * The height is a fixed pixel length taken from the *base* (unzoomed) render
+   * height, so a pin covers the same number of screen pixels no matter how far
+   * the user has zoomed in — it is not a span of time that stretches with the
+   * image. Only the centre is zoom-aware: the pin stays centred on the set's
+   * anchor time (the original click location), so it tracks the feature while
+   * keeping a constant height.
+   *
+   * @param {PinSet} set - The set being drawn
+   * @returns {{lineHeight: number, lineTop: number}} Fixed pixel height and top Y position
+   */
+  pinLineDimensions(set) {
+    const { renderHeight } = getRenderDimensions(this.instance.state)
+    const lineHeight = renderHeight * PinSetMode.PIN_HEIGHT_RATIO
+    // Only the y component is read; the frequency merely has to be a number.
+    const anchorPoint = { freq: this.freqForIndex(set, 1), time: set.anchorTime }
+    const anchorSVG = dataToSVG(anchorPoint, this.getViewport(), this.instance.ui.spectrogramImage)
+    const lineTop = anchorSVG.y - lineHeight / 2
+
+    return { lineHeight, lineTop }
+  }
+
+  /**
+   * Compute the SVG x-coordinate of a member's vertical pin line.
+   * @param {PinSet} set - The set
+   * @param {number} index - Member index
+   * @returns {number} SVG x-coordinate of the pin line
+   */
+  pinX(set, index) {
+    const point = { freq: this.freqForIndex(set, index), time: set.anchorTime }
+    return dataToSVG(point, this.getViewport(), this.instance.ui.spectrogramImage).x
+  }
+
+  /**
+   * Effective pixel size of a set's symbol marks: the base size scaled by that
+   * set's own large-symbol flag, so sets at both sizes can share a gram. The
+   * whole label/symbol stack layout derives from this, so the label spacing and
+   * top-edge clamping follow the set's chosen size.
+   * @param {PinSet} set - The set
+   * @returns {number} Symbol diameter in px
+   */
+  symbolSize(set) {
+    return PinSetMode.SYMBOL_SIZE * resolveSymbolScale(set)
+  }
+
+  /**
+   * Compute the shared vertical layout of a pin's label/symbol stack.
+   *
+   * Ideal (top-to-bottom): label baseline, then symbol, then the pin line top,
+   * so the symbol caps the line and the label sits above the symbol. When the
+   * stack's top would clip above the spectrogram's top edge, the whole stack
+   * (label + symbol) is nudged down by the overflow so it stays legible
+   * (spec 159, FR-011).
+   *
+   * @param {number} lineTop - Top Y position of the pin lines (SVG coords)
+   * @param {number} imageTop - Top edge of the spectrogram image in SVG coords
+   * @param {PinSet} set - Set being laid out (its symbol size drives the stack)
+   * @returns {{symbolCy: number, labelY: number}} Symbol centre and label baseline Y
+   */
+  labelStackPositions(lineTop, imageTop, set) {
+    const r = this.symbolSize(set) / 2
+    const gap = PinSetMode.LABEL_GAP
+    const fontSize = PinSetMode.LABEL_FONT_SIZE
+
+    // Symbol caps the line; label baseline sits just above the symbol.
+    let symbolCy = lineTop - r
+    let labelY = symbolCy - r - gap
+
+    // Keep the top of the label (approx one ascent above its baseline) on-screen.
+    const labelTop = labelY - fontSize
+    const minTop = imageTop + PinSetMode.STACK_TOP_PAD
+    if (labelTop < minTop) {
+      const shift = minTop - labelTop
+      symbolCy += shift
+      labelY += shift
+    }
+
+    return { symbolCy, labelY }
+  }
+
+  /**
+   * Vertical extent (SVG coords) of a pin's label/symbol stack, for hit-testing.
+   *
+   * Derived from the same {@link PinSetMode#labelStackPositions} layout the
+   * renderer uses, so the grab region tracks the drawn stack — including the
+   * downward nudge applied near the image's top edge. The bottom is clamped to
+   * the pin line's top so the stack region and the line region always meet with
+   * no dead gap between them.
+   *
+   * @param {number} lineTop - Top Y position of the pin lines (SVG coords)
+   * @param {PinSet} set - Set being hit-tested
+   * @returns {{top: number, bottom: number}} Top and bottom Y of the stack region
+   */
+  labelStackBounds(lineTop, set) {
+    const imageTop = getImageBounds(this.getViewport(), this.instance.ui.spectrogramImage).top
+    const { symbolCy, labelY } = this.labelStackPositions(lineTop, imageTop, set)
+    const r = this.symbolSize(set) / 2
+
+    return {
+      // One ascent above the label's baseline is the top of the characters.
+      top: labelY - PinSetMode.LABEL_FONT_SIZE,
+      bottom: Math.max(lineTop, symbolCy + r)
+    }
+  }
+
+  /**
+   * Half-width (SVG px) of a pin's label/symbol stack, for hit-testing.
+   *
+   * The wider of the symbol mark and the number label, so both are grabbable:
+   * a `cross` set has no symbol but still shows its label, and a "Large
+   * symbols" set's mark is wider than its text. Label width is estimated from
+   * the character count rather than measured, which is ample for a grab region.
+   *
+   * @param {PinSet} set - Set being hit-tested
+   * @param {number} index - Member index whose label is drawn
+   * @returns {number} Half-width in SVG pixels
+   */
+  labelStackHalfWidth(set, index) {
+    const characters = this.labelTextFor(index).length
+    const labelHalfWidth = characters * PinSetMode.LABEL_FONT_SIZE * PinSetMode.LABEL_CHAR_WIDTH_RATIO / 2
+
+    return Math.max(this.symbolSize(set) / 2, labelHalfWidth)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Rendering
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Create the SVG line element for one pin.
+   * @param {number} index - Member index
+   * @param {PinSet} set - The set
+   * @param {number} lineX - X position for the line
+   * @param {number} lineTop - Top Y position for the line
+   * @param {number} lineHeight - Height of the line
+   * @returns {SVGLineElement} SVG line element
+   */
+  createPinLine(index, set, lineX, lineTop, lineHeight) {
+    const names = this.pinNames
+    const line = document.createElementNS('http://www.w3.org/2000/svg', 'line')
+    line.setAttribute('class', names.lineClass)
+    line.setAttribute(names.setIdAttribute, set.id)
+    line.setAttribute(names.indexAttribute, String(index))
+    line.setAttribute('x1', String(lineX))
+    line.setAttribute('y1', String(lineTop))
+    line.setAttribute('x2', String(lineX))
+    line.setAttribute('y2', String(lineTop + lineHeight))
+    line.setAttribute('stroke', set.color)
+    line.setAttribute('stroke-width', '2')
+    line.setAttribute('stroke-linecap', 'round')
+    line.setAttribute('opacity', '0.9')
+    return line
+  }
+
+  /**
+   * Create the short stub line drawn under a member when the set's full pin is
+   * hidden.
+   *
+   * Same colour and stroke as a full pin line, so a mini-pin reads as the same
+   * feature at a smaller scale; only its class and height differ. The distinct
+   * class keeps the two apart for cleanup, hit-testing and tests — a hidden-pin
+   * set still draws no full pin line.
+   *
+   * @param {number} index - Member index
+   * @param {PinSet} set - The set
+   * @param {number} lineX - X position of the mini-pin
+   * @param {number} top - Top Y position of the mini-pin (the symbol's underside)
+   * @returns {SVGLineElement} SVG line element
+   */
+  createMiniPin(index, set, lineX, top) {
+    const miniPin = this.createPinLine(index, set, lineX, top, PinSetMode.MINI_PIN_HEIGHT)
+    miniPin.setAttribute('class', this.pinNames.miniPinClass)
+    return miniPin
+  }
+
+  /**
+   * Create the SVG text label for a member.
+   *
+   * Centred horizontally on the pin's line (`text-anchor: middle` at `lineX`) and
+   * positioned above the pin's symbol (baseline at `labelY`), so the vertical
+   * stack over a pin reads label -> symbol -> line (spec 159, FR-009/FR-010).
+   *
+   * The characters are drawn black inside a white halo rather than in the set's
+   * colour: a single colour is only legible over part of a gram, whereas the
+   * halo reads over both dark and light backgrounds. Set identity is still
+   * carried by the pin's line and symbol colour.
+   *
+   * @param {number} index - Member index
+   * @param {PinSet} set - The set
+   * @param {number} lineX - X position of the pin line (label is centred on it)
+   * @param {number} labelY - Baseline Y position for the label text
+   * @returns {SVGTextElement} SVG text element
+   */
+  createPinLabel(index, set, lineX, labelY) {
+    const names = this.pinNames
+    const label = document.createElementNS('http://www.w3.org/2000/svg', 'text')
+    label.setAttribute('class', names.labelClass)
+    label.setAttribute(names.setIdAttribute, set.id)
+    label.setAttribute(names.indexAttribute, String(index))
+    label.setAttribute('x', String(lineX)) // centred on the pin line
+    label.setAttribute('y', String(labelY)) // above the symbol
+    label.setAttribute('text-anchor', 'middle')
+    applyTextHalo(/** @type {SVGTextElement} */ (label))
+    label.setAttribute('font-size', String(PinSetMode.LABEL_FONT_SIZE))
+    label.setAttribute('font-weight', 'bold')
+    label.setAttribute('font-family', 'Arial, sans-serif')
+    label.textContent = this.labelTextFor(index)
+    return label
+  }
+
+  /**
+   * Create the filled symbol mark drawn between a pin's number label and the top
+   * of its line.
+   *
+   * The vertical position (`symbolCy`) is computed once per set by
+   * {@link PinSetMode#labelStackPositions} so the whole label/symbol stack
+   * shares a consistent, on-screen layout.
+   *
+   * @param {PinSet} set - The set
+   * @param {number} lineX - X position of the pin line (symbol is centred on it)
+   * @param {number} symbolCy - Centre Y position for the symbol
+   * @returns {SVGElement|null} SVG symbol element, or null for the `cross` (symbol-less) style
+   */
+  createPinSymbol(set, lineX, symbolCy) {
+    const symbol = createSymbolMark(set.symbol, lineX, symbolCy, this.symbolSize(set), set.color)
+    // `cross` sets draw no symbol shape (the pin keeps its line and label).
+    if (!symbol) {
+      return null
+    }
+    symbol.setAttribute(this.pinNames.setIdAttribute, set.id)
+    return symbol
+  }
+
+  /**
+   * Whether this mode currently owns any persistent feature.
+   *
+   * Half of the `PersistentFeatureProvider` capability.
+   * @returns {boolean} True if at least one set exists
+   */
+  hasPersistentFeatures() {
+    return this.sets.length > 0
+  }
+
+  /**
+   * Render every set this mode owns.
+   */
+  renderPersistentFeatures() {
+    if (!this.instance.ui.cursorGroup) {
+      return
+    }
+
+    const names = this.pinNames
+    // Clear existing pin lines and their symbol marks. Scope the symbol cleanup
+    // to this mode's pin symbols (which carry its set-id attribute) so it never
+    // removes another mode's symbols, which share the base symbol class.
+    const existingLines = this.instance.ui.cursorGroup.querySelectorAll(
+      `.${names.lineClass}, .${names.miniPinClass}`
+    )
+    existingLines.forEach(line => line.remove())
+    const existingSymbols = this.instance.ui.cursorGroup.querySelectorAll(
+      `.gram-frame-harmonic-symbol[${names.setIdAttribute}]`
+    )
+    existingSymbols.forEach(symbol => symbol.remove())
+
+    this.sets.forEach(set => this.renderSet(set))
+  }
+
+  /**
+   * Render a single set as vertical pin lines.
+   *
+   * Spec 159: draw a pin line for EVERY member in the visible span (no pins are
+   * dropped, even if they merge into a solid block), then draw a number label
+   * and symbol only for the thinned "major" subset so the overlay stays
+   * readable. Lines are appended first so the labels/symbols paint on top.
+   *
+   * A set with `showPin === false` draws a mini-pin per member instead of a
+   * full-height line: a stub hanging from the symbol's underside, in the set's
+   * colour. Labels and symbols are thinned, so without them a pin-less set gave
+   * no sign of where the members between the labelled ones actually fell
+   * (issue #232); the mini-pins restore that alignment with the data at a
+   * fraction of the ink. The label/symbol geometry is unchanged either way, so
+   * toggling the pin swaps line lengths without moving anything else.
+   *
+   * @param {PinSet} set - Set to render
+   */
+  renderSet(set) {
+    if (!this.instance.ui.cursorGroup) {
+      return
+    }
+
+    const { minIndex, maxIndex } = this.visibleIndexRange(set)
+    if (maxIndex < minIndex) {
+      return
+    }
+
+    const { lineHeight, lineTop } = this.pinLineDimensions(set)
+    const imageTop = getImageBounds(this.getViewport(), this.instance.ui.spectrogramImage).top
+    // The label/symbol stack is laid out first: a mini-pin hangs from the
+    // underside of the symbol, so it needs the stack's (possibly clamped)
+    // vertical position.
+    const { symbolCy, labelY } = this.labelStackPositions(lineTop, imageTop, set)
+    const pinDrawn = set.showPin !== false
+
+    // Draw a line for every member in the visible span (FR-001) — full height
+    // when the set is pinned, a mini-pin when it is not. Sets restored from
+    // storage without the flag are pinned.
+    // Beyond MAX_PIN_LINES the lines are a regular sample of the span (BH-2):
+    // by then adjacent pins have long merged on screen, and an uncapped loop
+    // rebuilt hundreds of thousands of SVG elements per drag frame.
+    const visibleCount = maxIndex - minIndex + 1
+    const stride = Math.max(1, Math.ceil(visibleCount / PinSetMode.MAX_PIN_LINES))
+    const miniPinTop = symbolCy + this.symbolSize(set) / 2
+    for (let index = minIndex; index <= maxIndex; index += stride) {
+      const lineX = this.pinX(set, index)
+      const line = pinDrawn
+        ? this.createPinLine(index, set, lineX, lineTop, lineHeight)
+        : this.createMiniPin(index, set, lineX, miniPinTop)
+      this.instance.ui.cursorGroup.appendChild(line)
+    }
+
+    // Draw labels + symbols only on the thinned major subset (FR-002), stacked
+    // above each pin line with a shared, on-screen vertical layout.
+    this.labelledIndices(minIndex, maxIndex).forEach(index => {
+      const lineX = this.pinX(set, index)
+      const symbol = this.createPinSymbol(set, lineX, symbolCy)
+      const label = this.createPinLabel(index, set, lineX, labelY)
+      // `cross` sets have no symbol mark; the number label is still drawn.
+      if (symbol) {
+        this.instance.ui.cursorGroup.appendChild(symbol)
+      }
+      this.instance.ui.cursorGroup.appendChild(label)
+    })
+  }
+
+  /**
+   * Colour palette used when the style panel offers no explicit choice.
+   * @type {string[]}
+   */
+  static SET_COLORS = ['#ff6b6b', '#2ecc71', '#f39c12', '#9b59b6', '#ffc93c', '#ff9ff3', '#45b7d1', '#e67e22']
+}

--- a/src/modes/sideband/SidebandMode.js
+++ b/src/modes/sideband/SidebandMode.js
@@ -1,0 +1,311 @@
+import { PinSetMode, MIN_PIN_SPACING } from '../shared/PinSetMode.js'
+import { updateSidebandPanelContent, createSidebandPanel } from '../../components/SidebandPanel.js'
+
+/**
+ * Sidebands mode implementation (issue #241).
+ *
+ * A sideband set is a {@link PinSetMode} set whose origin the analyst places:
+ * member `n` sits at `fundamentalFreq + n × spacing`, and `n` runs negative as
+ * well as positive, so the pins spread both sides of the fundamental. That one
+ * difference — where index 0 lands — is the whole of what separates this mode
+ * from Harmonics; the pins, labels, hit test, drag and persistence are the
+ * shared pin-set machinery.
+ *
+ * Clicking empty gram sets the fundamental at the click and shows a spread of
+ * sidebands either side of it. Dragging the fundamental (member 0) moves the
+ * origin; dragging any other member sets the spacing, keeping the grabbed
+ * sideband under the cursor.
+ */
+export class SidebandMode extends PinSetMode {
+  /**
+   * Number of sidebands a newly placed set spreads across the frequency axis.
+   *
+   * The seed spacing is the axis span divided by this, so a set dropped in the
+   * middle of the gram shows about this many members — an equal count each side
+   * when the fundamental is central, and more on the roomier side when it is
+   * not. It is only a starting point: the analyst drags a sideband onto the
+   * data immediately afterwards, which is what actually sets the spacing.
+   * @type {number}
+   */
+  static INITIAL_SIDEBAND_COUNT = 8
+
+  /**
+   * Initialize SidebandMode
+   * @param {GramFrame} instance - GramFrame instance
+   */
+  constructor(instance) {
+    super(instance, 'sideband')
+  }
+
+  /**
+   * The sideband sets, live.
+   * @returns {PinSet[]} This mode's sets
+   */
+  get sets() {
+    return this.instance.state.sidebands.sidebandSets
+  }
+
+  /**
+   * @returns {SelectedFeatureType} Selection type for a sideband set
+   */
+  get selectionType() {
+    return 'sidebandSet'
+  }
+
+  /**
+   * DOM naming for sideband pins: its own stem, so a selector, a cleanup pass
+   * or a test can never confuse a sideband with a harmonic.
+   * @returns {PinSetClassNames} Class and attribute names
+   */
+  get pinNames() {
+    return {
+      idPrefix: 'sideband',
+      lineClass: 'gram-frame-sideband-line',
+      miniPinClass: 'gram-frame-sideband-mini-pin',
+      labelClass: 'gram-frame-sideband-number',
+      setIdAttribute: 'data-sideband-set-id',
+      indexAttribute: 'data-sideband-index'
+    }
+  }
+
+  /**
+   * Frequency of sideband `index`, counted out from the fundamental. Negative
+   * indices fall below it, positive ones above; index 0 is the fundamental.
+   * @param {PinSet} set - Sideband set
+   * @param {number} index - Sideband index
+   * @returns {number} Frequency in Hz
+   */
+  freqForIndex(set, index) {
+    return this.fundamentalOf(set) + index * set.spacing
+  }
+
+  /**
+   * The inclusive sideband-index range within the currently visible frequency
+   * span. Unlike a harmonic set this is not clamped at zero: sidebands below the
+   * fundamental are as real as those above it.
+   * @param {PinSet} set - Sideband set
+   * @returns {{minIndex: number, maxIndex: number}} Inclusive index range
+   */
+  visibleIndexRange(set) {
+    const { freqMin, freqMax } = this.visibleFrequencySpan()
+    const fundamental = this.fundamentalOf(set)
+    return {
+      minIndex: Math.ceil((freqMin - fundamental) / set.spacing),
+      maxIndex: Math.floor((freqMax - fundamental) / set.spacing)
+    }
+  }
+
+  /**
+   * Which sideband a probe frequency is nearest.
+   * @param {PinSet} set - Sideband set
+   * @param {number} freq - Probe frequency
+   * @returns {number} Nearest sideband index
+   */
+  nearestIndex(set, freq) {
+    return Math.round((freq - this.fundamentalOf(set)) / set.spacing)
+  }
+
+  /**
+   * Label a sideband by its signed offset from the fundamental, so the origin
+   * is identifiable at a glance: `0` on the fundamental, `+1`/`-1` either side.
+   * @param {number} index - Sideband index
+   * @returns {string} Label text
+   */
+  labelTextFor(index) {
+    return index > 0 ? `+${index}` : String(index)
+  }
+
+  /**
+   * The set's fundamental, tolerating a record that somehow lacks one.
+   * @param {PinSet} set - Sideband set
+   * @returns {number} Fundamental frequency in Hz
+   */
+  fundamentalOf(set) {
+    return set.fundamentalFreq || 0
+  }
+
+  /**
+   * Mint a new sideband set at the mousedown position.
+   *
+   * The click sets the fundamental. The seed spacing spreads roughly
+   * {@link SidebandMode.INITIAL_SIDEBAND_COUNT} members across the frequency
+   * axis, which puts an equal number either side of a centred fundamental and
+   * more on the roomier side of an off-centre one — exactly as the analyst
+   * placed it. The drag that follows then sets the real spacing.
+   * @param {DataCoordinates} dataCoords - Data coordinates {freq, time}
+   * @returns {DragTarget|null} A create-kind target, or null if a set cannot be made
+   */
+  createSetTarget(dataCoords) {
+    const { freqMin, freqMax } = this.instance.state.config
+    const span = Math.abs(freqMax - freqMin)
+    const initialSpacing = Math.max(span / SidebandMode.INITIAL_SIDEBAND_COUNT, MIN_PIN_SPACING)
+
+    const sidebandSet = this.addSidebandSet(dataCoords.time, dataCoords.freq, initialSpacing)
+    if (!sidebandSet) {
+      return null
+    }
+
+    return {
+      kind: 'create',
+      id: sidebandSet.id,
+      type: 'sidebandSet',
+      position: dataCoords,
+      data: {
+        set: sidebandSet,
+        // The click landed on the fundamental, so the drag that follows moves
+        // the origin — which is how the analyst places it precisely.
+        clickedIndex: 0,
+        originalAnchorTime: dataCoords.time
+      }
+    }
+  }
+
+  /**
+   * What a horizontal drag means for a sideband set.
+   *
+   * Grabbing the fundamental moves the whole set along the frequency axis;
+   * grabbing any other sideband holds it under the cursor, which sets the
+   * spacing. Dragging a sideband past the fundamental would invert the spacing,
+   * so it is floored at the shared minimum rather than allowed to go negative.
+   * @param {PinSet} set - The set being dragged
+   * @param {number} clickedIndex - Sideband index the drag grabbed
+   * @param {DataCoordinates} currentPos - Current pointer position
+   * @returns {Partial<PinSet>} Updates to apply
+   */
+  freqUpdatesForDrag(set, clickedIndex, currentPos) {
+    if (clickedIndex === 0) {
+      const { freqMin, freqMax } = this.instance.state.config
+      const lower = Math.min(freqMin, freqMax)
+      const upper = Math.max(freqMin, freqMax)
+      return { fundamentalFreq: Math.max(lower, Math.min(upper, currentPos.freq)) }
+    }
+
+    const spacing = (currentPos.freq - this.fundamentalOf(set)) / clickedIndex
+    return { spacing: Math.max(spacing, MIN_PIN_SPACING) }
+  }
+
+  /**
+   * Add a new sideband set
+   * @param {number} anchorTime - Time position in seconds
+   * @param {number} fundamentalFreq - Fundamental frequency in Hz
+   * @param {number} spacing - Frequency spacing between adjacent sidebands in Hz
+   * @returns {PinSet} The created sideband set
+   */
+  addSidebandSet(anchorTime, fundamentalFreq, spacing) {
+    return this.addSet({ anchorTime, fundamentalFreq, spacing })
+  }
+
+  /**
+   * Update an existing sideband set
+   * @param {string} id - Sideband set ID
+   * @param {Partial<PinSet>} updates - Properties to update
+   */
+  updateSidebandSet(id, updates) {
+    this.updateSet(id, updates)
+  }
+
+  /**
+   * Remove a sideband set
+   * @param {string} id - Sideband set ID
+   */
+  removeSidebandSet(id) {
+    this.removeSet(id)
+  }
+
+  /**
+   * Find the sideband set whose drawn geometry contains the given position.
+   * @param {DataCoordinates} position - Probe position {freq, time}
+   * @returns {PinSet|null} The sideband set if found, null otherwise
+   */
+  findSidebandSetAt(position) {
+    return this.findSetAt(position)
+  }
+
+  /**
+   * Get guidance content for sidebands mode
+   * @returns {Object} Structured guidance content
+   */
+  getGuidanceText() {
+    return {
+      title: 'Sidebands Mode',
+      items: [
+        'Click & drag to place a sideband set at that frequency',
+        'Drag the 0 line to move the fundamental',
+        'Drag any other line to adjust sideband spacing',
+        'Click table row + arrow keys (Shift for larger steps)'
+      ]
+    }
+  }
+
+  /**
+   * Create UI elements for sidebands mode
+   * @param {HTMLElement} sidebandsContainer - Persistent container for the sidebands table
+   */
+  createUI(sidebandsContainer) {
+    this.uiElements = {}
+    this.uiElements.sidebandsContainer = sidebandsContainer
+
+    // Check if the panel already exists (a mode switch rebuilds this mode's UI
+    // against the same persistent container) to prevent duplicates.
+    const existingPanel = /** @type {HTMLElement|null} */ (
+      sidebandsContainer.querySelector('.gram-frame-sideband-panel')
+    )
+    this.uiElements.sidebandPanel = existingPanel || createSidebandPanel(sidebandsContainer, this.instance)
+    this.instance.ui.sidebandPanel = this.uiElements.sidebandPanel
+
+    // Populate the panel with any sets restored from storage
+    this.updatePanel()
+  }
+
+  /**
+   * Destroy mode-specific UI elements when leaving this mode.
+   *
+   * The panel and its container are persistent — the sidebands table stays
+   * visible in every mode, as the markers and harmonics tables do — so this
+   * deliberately does NOT call `super.destroyUI()`.
+   */
+  destroyUI() {
+    // Nothing to remove.
+  }
+
+  /**
+   * Update the sidebands table
+   */
+  updatePanel() {
+    if (this.instance.ui.sidebandPanel) {
+      updateSidebandPanelContent(this.instance.ui.sidebandPanel, this.instance)
+    }
+  }
+
+  /**
+   * Re-render this mode's persistent panel from current state.
+   *
+   * The `PanelOwner` capability.
+   * @see {@link module:modes/capabilities}
+   */
+  refreshPanel() {
+    // The panel may have been created by a previous instance of this mode's UI,
+    // so re-resolve it when the reference is missing.
+    if (!this.instance.ui.sidebandPanel && this.instance.ui.sidebandsContainer) {
+      const existingPanel = /** @type {HTMLElement|null} */ (
+        this.instance.ui.sidebandsContainer.querySelector('.gram-frame-sideband-panel')
+      )
+      if (existingPanel) {
+        this.instance.ui.sidebandPanel = existingPanel
+      }
+    }
+    this.updatePanel()
+  }
+
+  /**
+   * Get initial state for sidebands mode
+   * @returns {SidebandsInitialState} Sidebands-specific initial state
+   */
+  static getInitialState() {
+    return {
+      sidebands: {
+        sidebandSets: []
+      }
+    }
+  }
+}

--- a/src/types.js
+++ b/src/types.js
@@ -613,7 +613,8 @@
  * @property {HTMLDivElement} unifiedLayoutContainer - Main layout container
  * @property {HTMLDivElement} leftColumn - Readout column
  * @property {HTMLDivElement} middleColumn - Markers column
- * @property {HTMLDivElement} rightColumn - Harmonics and sidebands column
+ * @property {HTMLDivElement} rightColumn - Harmonics column
+ * @property {HTMLDivElement} sidebandsColumn - Sidebands column
  * @property {HTMLDivElement} modeColumn - Mode buttons column
  * @property {HTMLDivElement} guidanceColumn - Guidance text column
  * @property {HTMLDivElement} controlsColumn - Controls column

--- a/src/types.js
+++ b/src/types.js
@@ -118,6 +118,59 @@
  * @property {HarmonicSet[]} harmonicSets - Array of harmonic sets with persistent overlays
  */
 
+/**
+ * A sideband set: equally-spaced pins either side of a fundamental frequency the
+ * analyst places. Unlike a harmonic set its origin is not 0 Hz — member `n` sits
+ * at `fundamentalFreq + n * spacing`, for negative as well as positive `n`
+ * (issue #241).
+ * @typedef {Object} SidebandSet
+ * @property {string} id - Unique identifier for the sideband set
+ * @property {string} color - Display colour for the sideband lines
+ * @property {number} anchorTime - Time position (Y-axis) in seconds
+ * @property {number} fundamentalFreq - Frequency of the fundamental (member 0) in Hz
+ * @property {number} spacing - Frequency spacing between adjacent sidebands in Hz
+ * @property {SymbolType} symbol - Filled shape drawn at the top of each pin and shown in the sidebands table
+ * @property {boolean} [showPin] - Whether the vertical pin lines are drawn; absent (legacy/restored) means shown
+ * @property {boolean} [largeSymbols] - EXPERIMENT (temporary): draw this set's pin symbols at the large size; not persisted
+ */
+
+/**
+ * Sidebands mode state
+ * @typedef {Object} SidebandsState
+ * @property {SidebandSet[]} sidebandSets - Array of sideband sets with persistent overlays
+ */
+
+/**
+ * What every pin-set family has in common, and all `PinSetMode` needs to draw
+ * one. `HarmonicSet` matches it exactly; `SidebandSet` adds its fundamental.
+ * @typedef {Object} PinSet
+ * @property {string} id - Unique identifier
+ * @property {string} color - Display colour
+ * @property {number} anchorTime - Time position (Y-axis) in seconds
+ * @property {number} spacing - Frequency spacing between adjacent members in Hz
+ * @property {SymbolType} symbol - Filled shape drawn at the top of each pin
+ * @property {boolean} [showPin] - Whether the vertical pin lines are drawn
+ * @property {boolean} [largeSymbols] - EXPERIMENT (temporary): large symbol marks
+ * @property {number} [fundamentalFreq] - Origin frequency; sideband sets only
+ */
+
+/**
+ * The DOM naming a pin-set mode draws under: one stem per mode, so two modes'
+ * pins never collide in a selector, a cleanup pass or a test.
+ * @typedef {Object} PinSetClassNames
+ * @property {string} idPrefix - Prefix for generated set ids
+ * @property {string} lineClass - Class on a full-height pin line
+ * @property {string} miniPinClass - Class on a mini-pin stub
+ * @property {string} labelClass - Class on a pin's number label
+ * @property {string} setIdAttribute - Attribute carrying the owning set's id
+ * @property {string} indexAttribute - Attribute carrying the member index
+ */
+
+/**
+ * What `state.selection.selectedType` may name.
+ * @typedef {'marker'|'harmonicSet'|'sidebandSet'} SelectedFeatureType
+ */
+
 
 
 
@@ -222,7 +275,7 @@
 
 /**
  * Analysis mode type
- * @typedef {'analysis'|'harmonics'|'doppler'|'pan'} ModeType
+ * @typedef {'analysis'|'harmonics'|'sideband'|'doppler'|'pan'} ModeType
  */
 
 /**
@@ -286,6 +339,7 @@
  * @property {Array<CursorPosition>} cursors - Array of cursor positions (future use)
  * @property {number} annotationRevision - Bumped by every annotation mutation; lets the storage listener skip pure cursor moves
  * @property {HarmonicsState} harmonics - Harmonics mode state
+ * @property {SidebandsState} sidebands - Sidebands mode state
  * @property {DopplerState} doppler - Doppler mode state
  * @property {AnalysisState} analysis - Analysis mode state
  * @property {DragProjection} drag - Read-only projection of the active drag
@@ -327,6 +381,7 @@
  * @property {StoredGramFingerprint} [gram] - Which gram this record belongs to; ABSENT in legacy records (restores without the identity check)
  * @property {StoredAnalysisData} analysis - Stored analysis mode annotations
  * @property {StoredHarmonicsData} harmonics - Stored harmonics mode annotations
+ * @property {StoredSidebandsData} [sidebands] - Stored sidebands mode annotations; ABSENT in records written before sidebands existed
  * @property {StoredDopplerData} doppler - Stored doppler mode annotations
  */
 
@@ -374,6 +429,24 @@
  * @property {number} spacing - Frequency spacing between harmonics in Hz
  * @property {SymbolType} [symbol] - Persisted symbol; ABSENT in legacy (pre-feature) records
  * @property {boolean} [showPin] - Persisted pin visibility; ABSENT in records saved before the pin toggle (restores as shown)
+ */
+
+/**
+ * Stored sidebands data
+ * @typedef {Object} StoredSidebandsData
+ * @property {Array<StoredSidebandSet>} sidebandSets - All sideband sets
+ */
+
+/**
+ * Stored sideband set (persisted subset of SidebandSet)
+ * @typedef {Object} StoredSidebandSet
+ * @property {string} id - Unique identifier
+ * @property {string} color - Display colour (hex)
+ * @property {number} anchorTime - Y-axis position in seconds
+ * @property {number} fundamentalFreq - Fundamental (member 0) frequency in Hz
+ * @property {number} spacing - Frequency spacing between adjacent sidebands in Hz
+ * @property {SymbolType} [symbol] - Persisted symbol; defaults to `cross` on restore
+ * @property {boolean} [showPin] - Persisted pin visibility; absent restores as shown
  */
 
 /**
@@ -458,6 +531,7 @@
  * @property {function(boolean): boolean} applyPinToSelectedFeature - Show/hide pin lines
  * @property {function(boolean): boolean} applyLargeSymbolsToSelectedFeature - Resize symbols
  * @property {function(string): void} removeHarmonicSet - Delete a harmonic set by id
+ * @property {function(string): void} removeSidebandSet - Delete a sideband set by id
  * @property {function(): void} syncStyleControls - Sync the controls to the selection
  * @property {{setValue: function(SymbolType): void, setTint: function(string): void}|null} _symbolControl - Symbol drop-down handle
  * @property {{setValue: function(boolean): void, setEnabled: function(boolean): void}|null} _pinControl - Pin toggle handle
@@ -508,7 +582,9 @@
  * @property {HTMLElement} speedLED - Speed readout
  * @property {HTMLDivElement} markersContainer - Markers table container
  * @property {HTMLDivElement} harmonicsContainer - Harmonics panel container
+ * @property {HTMLDivElement} sidebandsContainer - Sidebands panel container
  * @property {HTMLElement|null} harmonicPanel - Harmonics panel, mounted by HarmonicsMode
+ * @property {HTMLElement|null} sidebandPanel - Sidebands panel, mounted by SidebandMode
  * @property {SVGImageElement} spectrogramImage - The spectrogram image element
  * @property {HTMLButtonElement|null} expandToggleButton - Expand toggle; absent for portrait images
  * @property {HTMLDivElement} modesContainer - Mode buttons container
@@ -521,6 +597,7 @@
  * The selection and restyle functions bound by `setupAllEventListeners`.
  * @typedef {Object} SelectionControls
  * @property {function(string): void} removeHarmonicSet - Delete a harmonic set by id
+ * @property {function(string): void} removeSidebandSet - Delete a sideband set by id
  * @property {function(string, string, number): void} setSelection - Select a feature
  * @property {function(): void} clearSelection - Clear the selection
  * @property {function(): void} updateSelectionVisuals - Re-render selection styling
@@ -536,12 +613,13 @@
  * @property {HTMLDivElement} unifiedLayoutContainer - Main layout container
  * @property {HTMLDivElement} leftColumn - Readout column
  * @property {HTMLDivElement} middleColumn - Markers column
- * @property {HTMLDivElement} rightColumn - Harmonics column
+ * @property {HTMLDivElement} rightColumn - Harmonics and sidebands column
  * @property {HTMLDivElement} modeColumn - Mode buttons column
  * @property {HTMLDivElement} guidanceColumn - Guidance text column
  * @property {HTMLDivElement} controlsColumn - Controls column
  * @property {HTMLDivElement} markersContainer - Markers table container
  * @property {HTMLDivElement} harmonicsContainer - Harmonics panel container
+ * @property {HTMLDivElement} sidebandsContainer - Sidebands panel container
  * @property {HTMLElement} timeLED - Time readout
  * @property {HTMLElement} freqLED - Frequency readout
  * @property {HTMLElement} speedLED - Speed readout
@@ -593,6 +671,12 @@
  * Harmonics mode initial state object
  * @typedef {Object} HarmonicsInitialState
  * @property {HarmonicsState} harmonics - Harmonics state
+ */
+
+/**
+ * Sidebands mode initial state object
+ * @typedef {Object} SidebandsInitialState
+ * @property {SidebandsState} sidebands - Sidebands state
  */
 
 /**

--- a/src/utils/calculations.js
+++ b/src/utils/calculations.js
@@ -27,6 +27,7 @@ export function getModeDisplayName(mode) {
   const displayNames = {
     'analysis': 'Cross Cursor',
     'harmonics': 'Harmonics', 
+    'sideband': 'Sidebands',
     'doppler': 'Doppler',
     'pan': 'Pan'
   }

--- a/tests/harmonic-pin-sampling.spec.js
+++ b/tests/harmonic-pin-sampling.spec.js
@@ -220,16 +220,16 @@ test.describe('Harmonic Pin Sampling (feature 158)', () => {
         const harmonics = instance.modes['harmonics']
         // Probe within the pin's vertical range (anchorTime = 30)
         const found = harmonics.findHarmonicSetAt({ freq, time: 30 })
-        const target = harmonics.findHarmonicSetTarget({ freq, time: 30 })
+        const target = harmonics.findSetTarget({ freq, time: 30 })
 
         // Simulate a spacing adjustment via the drag seam (data coordinates),
         // exactly as the event layer would drive it.
         let spacingChanged = false
         if (target) {
           const original = instance.state.harmonics.harmonicSets.find((s) => s.id === id).spacing
-          harmonics.onHarmonicSetDragStart(target, { freq, time: 30 })
-          harmonics.onHarmonicSetDragUpdate(target, { freq: freq + 5, time: 30 }, { freq, time: 30 })
-          harmonics.onHarmonicSetDragEnd(target, { freq: freq + 5, time: 30 })
+          harmonics.onSetDragStart(target)
+          harmonics.onSetDragUpdate(target, { freq: freq + 5, time: 30 }, { freq, time: 30 })
+          harmonics.onSetDragEnd()
           const updated = instance.state.harmonics.harmonicSets.find((s) => s.id === id).spacing
           spacingChanged = updated !== original
         }

--- a/tests/helpers/gram-frame-page.js
+++ b/tests/helpers/gram-frame-page.js
@@ -814,6 +814,56 @@ class GramFramePage {
   }
 
   /**
+   * Programmatically add a sideband set via the test instance API.
+   * @param {number} anchorTime - Time position in seconds
+   * @param {number} fundamentalFreq - Fundamental (member 0) frequency in Hz
+   * @param {number} spacing - Frequency spacing between adjacent sidebands in Hz
+   * @returns {Promise<string>} The created sideband set's id
+   */
+  async addSidebandSet(anchorTime, fundamentalFreq, spacing) {
+    const id = await this.page.evaluate(([time, fundamental, space]) => {
+      // @ts-ignore - test-only global
+      const instances = window.GramFrame.__test__getInstances()
+      const set = instances[0].modes['sideband'].addSidebandSet(time, fundamental, space)
+      return set.id
+    }, [anchorTime, fundamentalFreq, spacing])
+    await this.waitForState(
+      (state) => (state.sidebands?.sidebandSets ?? []).some((s) => s.id === id),
+      { message: `sideband set ${id} to appear in state` }
+    )
+    return id
+  }
+
+  /**
+   * Wait until the sidebands state holds exactly `n` sideband sets.
+   * @param {number} n - Expected sideband set count
+   * @param {number|{timeout?: number}} [opts={}] - Timeout in ms, or options
+   * @returns {Promise<void>}
+   */
+  async waitForSidebandSetCount(n, opts = {}) {
+    await this.waitForState(
+      (state) => (state.sidebands?.sidebandSets?.length ?? 0) === n,
+      { ...opts, message: `${n} sideband set(s)` }
+    )
+  }
+
+  /**
+   * Read the `data-sideband-index` of each rendered sideband pin line, in
+   * document order, optionally scoped to one set.
+   * @param {string} [setId] - Restrict to one sideband set
+   * @returns {Promise<number[]>} Sideband indices in order
+   */
+  async getSidebandIndices(setId) {
+    const selector = setId
+      ? `.gram-frame-sideband-line[data-sideband-set-id="${setId}"]`
+      : '.gram-frame-sideband-line'
+    return this.page.evaluate((sel) => {
+      const lines = Array.from(document.querySelectorAll(sel))
+      return lines.map((line) => Number(line.getAttribute('data-sideband-index')))
+    }, selector)
+  }
+
+  /**
    * Programmatically set the zoom level/centre via the test instance API.
    * @param {number} level - Zoom level (1.0 = no zoom)
    * @param {number} [centerX=0.5] - Normalised horizontal centre (0-1)

--- a/tests/sideband-mode.spec.js
+++ b/tests/sideband-mode.spec.js
@@ -6,9 +6,10 @@ import { test, expect } from './helpers/fixtures.js'
  * A sideband set is a harmonic set whose origin the analyst places: pins spread
  * both sides of a fundamental rather than marching up from 0 Hz. These tests
  * cover what makes it a distinct mode — where the pins land, what a drag on the
- * fundamental does versus a drag on a sideband, which table the right column
- * shows — and that the shared pin-set machinery it rides on (cross-mode
- * rendering, selection, deletion, persistence) reaches it too.
+ * fundamental does versus a drag on a sideband, its own always-visible table —
+ * and that the shared pin-set machinery it rides on (cross-mode rendering,
+ * selection, deletion, persistence) reaches it too. The last three guard the
+ * control row itself: a fourth table went into a row that was already full.
  *
  * The debug gram spans 0-60 s and 0-100 Hz, so a set placed by clicking gets a
  * seed spacing of 100 / 8 = 12.5 Hz.
@@ -152,17 +153,48 @@ test.describe('Sidebands mode', () => {
     expect(updated.spacing).toBeCloseTo(10, 5)
   })
 
-  test('the right column shows the sidebands table in this mode, harmonics otherwise', async ({ gramFramePage }) => {
+  test('its table is visible in every mode, alongside the harmonics one', async ({ gramFramePage }) => {
     const page = gramFramePage.page
     const sidebands = page.locator('.gram-frame-sidebands-persistent-container')
     const harmonics = page.locator('.gram-frame-harmonics-persistent-container')
 
-    await expect(sidebands).toBeVisible()
-    await expect(harmonics).toBeHidden()
+    for (const mode of ['Sidebands', 'Harmonics', 'Pan', 'Cross Cursor', 'Doppler']) {
+      await gramFramePage.clickMode(mode)
+      await expect(sidebands, `sidebands table in ${mode} mode`).toBeVisible()
+      await expect(harmonics, `harmonics table in ${mode} mode`).toBeVisible()
+    }
+  })
 
-    await gramFramePage.clickMode('Harmonics')
-    await expect(harmonics).toBeVisible()
-    await expect(sidebands).toBeHidden()
+  test('adding the fourth table left the spectrogram where it was', async ({ gramFramePage }) => {
+    // The control row is a constant height in every mode, so switching mode no
+    // longer moves the gram up or down the page — and the height it settled on
+    // is the smallest it used to take, not the largest.
+    const tops = []
+    for (const mode of ['Pan', 'Cross Cursor', 'Harmonics', 'Sidebands', 'Doppler']) {
+      await gramFramePage.clickMode(mode)
+      tops.push(await gramFramePage.page.evaluate(
+        () => Math.round(document.querySelector('.gram-frame-svg').getBoundingClientRect().top)
+      ))
+    }
+    expect(new Set(tops).size, `svg top per mode: ${tops.join(', ')}`).toBe(1)
+  })
+
+  test('the whole control row fits the component, with nothing cut off', async ({ gramFramePage }) => {
+    // Every column is at or near its minimum now that four tables share the row,
+    // so this is the guard against the next thing added to it silently pushing
+    // the sidebands table off the end.
+    const fits = await gramFramePage.page.evaluate(() => {
+      const layout = document.querySelector('.gram-frame-unified-layout')
+      const probe = document.createElement('div')
+      probe.style.cssText = 'position:absolute;visibility:hidden;left:-9999px;width:min-content'
+      probe.appendChild(layout.cloneNode(true))
+      document.body.appendChild(probe)
+      const minContent = Math.round(probe.firstChild.getBoundingClientRect().width)
+      probe.remove()
+      return { minContent, available: Math.round(layout.getBoundingClientRect().width) }
+    })
+    expect(fits.minContent, `row needs ${fits.minContent}px, has ${fits.available}px`)
+      .toBeLessThanOrEqual(fits.available)
   })
 
   test('a set appears in the table and can be deleted from it', async ({ gramFramePage }) => {

--- a/tests/sideband-mode.spec.js
+++ b/tests/sideband-mode.spec.js
@@ -1,0 +1,233 @@
+import { test, expect } from './helpers/fixtures.js'
+
+/**
+ * @fileoverview Sidebands mode (issue #241).
+ *
+ * A sideband set is a harmonic set whose origin the analyst places: pins spread
+ * both sides of a fundamental rather than marching up from 0 Hz. These tests
+ * cover what makes it a distinct mode — where the pins land, what a drag on the
+ * fundamental does versus a drag on a sideband, which table the right column
+ * shows — and that the shared pin-set machinery it rides on (cross-mode
+ * rendering, selection, deletion, persistence) reaches it too.
+ *
+ * The debug gram spans 0-60 s and 0-100 Hz, so a set placed by clicking gets a
+ * seed spacing of 100 / 8 = 12.5 Hz.
+ */
+
+/** Seed spacing for a set placed on the debug gram: the axis span over 8. */
+const SEED_SPACING = 12.5
+
+/**
+ * Place a sideband set by clicking the gram at a fraction across the image,
+ * exactly as an analyst would.
+ * @param {import('./helpers/gram-frame-page.js').GramFramePage} gfp - Page object
+ * @param {number} fracX - Horizontal position, 0-1 across the image
+ * @param {number} fracY - Vertical position, 0-1 down the image
+ * @returns {Promise<any>} The created set, from broadcast state
+ */
+async function placeSetByClicking(gfp, fracX, fracY) {
+  const point = await gfp.imageSVGPoint(fracX, fracY)
+  await gfp.clickSVG(point.x, point.y)
+  await gfp.waitForSidebandSetCount(1)
+  const state = await gfp.getState()
+  return state.sidebands.sidebandSets[0]
+}
+
+test.describe('Sidebands mode', () => {
+  test.beforeEach(async ({ gramFramePage }) => {
+    await gramFramePage.clickMode('Sidebands')
+  })
+
+  test('sits between Harmonics and Doppler in the mode buttons', async ({ gramFramePage }) => {
+    const order = await gramFramePage.page.evaluate(() =>
+      Array.from(document.querySelectorAll('.gram-frame-mode-btn')).map((b) => b.getAttribute('data-mode'))
+    )
+    expect(order).toEqual(['pan', 'analysis', 'harmonics', 'sideband', 'doppler'])
+  })
+
+  test('a click sets the fundamental at that frequency', async ({ gramFramePage }) => {
+    const set = await placeSetByClicking(gramFramePage, 0.5, 0.5)
+
+    // The debug gram spans 0-100 Hz, so the middle of the image is ~50 Hz.
+    expect(set.fundamentalFreq).toBeGreaterThan(45)
+    expect(set.fundamentalFreq).toBeLessThan(55)
+    expect(set.spacing).toBeCloseTo(SEED_SPACING, 5)
+  })
+
+  test('pins spread both sides of the fundamental, about eight of them', async ({ gramFramePage }) => {
+    const set = await placeSetByClicking(gramFramePage, 0.5, 0.5)
+    const indices = await gramFramePage.getSidebandIndices(set.id)
+
+    expect(indices).toContain(0)
+    expect(indices.filter((n) => n < 0).length).toBeGreaterThan(0)
+    expect(indices.filter((n) => n > 0).length).toBeGreaterThan(0)
+    // Eight steps across the axis puts 7-9 pins in view wherever it is placed.
+    expect(indices.length).toBeGreaterThanOrEqual(7)
+    expect(indices.length).toBeLessThanOrEqual(9)
+
+    // Each pin's frequency is the fundamental plus n spacings — that is what
+    // "equally distributed either side" means.
+    const positions = await gramFramePage.page.evaluate((id) => {
+      const lines = Array.from(
+        document.querySelectorAll(`.gram-frame-sideband-line[data-sideband-set-id="${id}"]`)
+      )
+      return lines.map((line) => ({
+        index: Number(line.getAttribute('data-sideband-index')),
+        x: Number(line.getAttribute('x1'))
+      }))
+    }, set.id)
+
+    const byIndex = new Map(positions.map((p) => [p.index, p.x]))
+    const step = byIndex.get(1) - byIndex.get(0)
+    expect(step).toBeGreaterThan(0)
+    expect(byIndex.get(0) - byIndex.get(-1)).toBeCloseTo(step, 3)
+  })
+
+  test('an off-centre fundamental gets more pins on the roomier side', async ({ gramFramePage }) => {
+    const set = await placeSetByClicking(gramFramePage, 0.25, 0.5)
+    const indices = await gramFramePage.getSidebandIndices(set.id)
+
+    const below = indices.filter((n) => n < 0).length
+    const above = indices.filter((n) => n > 0).length
+    expect(above).toBeGreaterThan(below)
+  })
+
+  test('every pin carries a signed label, with 0 on the fundamental', async ({ gramFramePage }) => {
+    const set = await placeSetByClicking(gramFramePage, 0.5, 0.5)
+
+    const labels = await gramFramePage.page.evaluate((id) => {
+      const texts = Array.from(
+        document.querySelectorAll(`.gram-frame-sideband-number[data-sideband-set-id="${id}"]`)
+      )
+      return texts.map((t) => ({ index: Number(t.getAttribute('data-sideband-index')), text: t.textContent }))
+    }, set.id)
+
+    expect(labels.length).toBeGreaterThan(0)
+    for (const label of labels) {
+      const expected = label.index > 0 ? `+${label.index}` : String(label.index)
+      expect(label.text).toBe(expected)
+    }
+    expect(labels.some((l) => l.text === '0')).toBe(true)
+  })
+
+  test('dragging a sideband sets the spacing and leaves the fundamental alone', async ({ gramFramePage }) => {
+    const setId = await gramFramePage.addSidebandSet(30, 50, 10)
+
+    // Grab the +1 sideband (60 Hz) and pull it out to 70 Hz: the spacing
+    // becomes 20 Hz, the fundamental does not move.
+    const updated = await gramFramePage.page.evaluate((id) => {
+      // @ts-ignore - test-only global
+      const instance = window.GramFrame.__test__getInstances()[0]
+      const sideband = instance.modes['sideband']
+      const target = sideband.findSetTarget({ freq: 60, time: 30 })
+      if (!target) return null
+      sideband.onSetDragStart(target)
+      sideband.onSetDragUpdate(target, { freq: 70, time: 30 }, { freq: 60, time: 30 })
+      sideband.onSetDragEnd()
+      return instance.state.sidebands.sidebandSets.find((s) => s.id === id)
+    }, setId)
+
+    expect(updated).not.toBeNull()
+    expect(updated.spacing).toBeCloseTo(20, 5)
+    expect(updated.fundamentalFreq).toBeCloseTo(50, 5)
+  })
+
+  test('dragging the fundamental moves the origin and leaves the spacing alone', async ({ gramFramePage }) => {
+    const setId = await gramFramePage.addSidebandSet(30, 50, 10)
+
+    const updated = await gramFramePage.page.evaluate((id) => {
+      // @ts-ignore - test-only global
+      const instance = window.GramFrame.__test__getInstances()[0]
+      const sideband = instance.modes['sideband']
+      const target = sideband.findSetTarget({ freq: 50, time: 30 })
+      if (!target) return null
+      sideband.onSetDragStart(target)
+      sideband.onSetDragUpdate(target, { freq: 65, time: 30 }, { freq: 50, time: 30 })
+      sideband.onSetDragEnd()
+      return instance.state.sidebands.sidebandSets.find((s) => s.id === id)
+    }, setId)
+
+    expect(updated).not.toBeNull()
+    expect(updated.fundamentalFreq).toBeCloseTo(65, 5)
+    expect(updated.spacing).toBeCloseTo(10, 5)
+  })
+
+  test('the right column shows the sidebands table in this mode, harmonics otherwise', async ({ gramFramePage }) => {
+    const page = gramFramePage.page
+    const sidebands = page.locator('.gram-frame-sidebands-persistent-container')
+    const harmonics = page.locator('.gram-frame-harmonics-persistent-container')
+
+    await expect(sidebands).toBeVisible()
+    await expect(harmonics).toBeHidden()
+
+    await gramFramePage.clickMode('Harmonics')
+    await expect(harmonics).toBeVisible()
+    await expect(sidebands).toBeHidden()
+  })
+
+  test('a set appears in the table and can be deleted from it', async ({ gramFramePage }) => {
+    const setId = await gramFramePage.addSidebandSet(30, 40, 8)
+    const row = gramFramePage.page.locator(`tr[data-sideband-id="${setId}"]`)
+
+    await expect(row).toBeVisible()
+    await expect(row.locator('.gram-frame-sideband-freq')).toHaveText('40.00')
+    await expect(row.locator('.gram-frame-sideband-spacing')).toHaveText('8.00')
+
+    await row.locator('.gram-frame-sideband-delete').click()
+    await gramFramePage.waitForSidebandSetCount(0)
+    await expect(gramFramePage.page.locator('.gram-frame-sideband-line')).toHaveCount(0)
+  })
+
+  test('its pins stay drawn after switching to another mode', async ({ gramFramePage }) => {
+    const setId = await gramFramePage.addSidebandSet(30, 50, 10)
+    expect((await gramFramePage.getSidebandIndices(setId)).length).toBeGreaterThan(0)
+
+    await gramFramePage.clickMode('Doppler')
+    expect((await gramFramePage.getSidebandIndices(setId)).length).toBeGreaterThan(0)
+  })
+
+  test('arrow keys nudge the spacing of the selected set', async ({ gramFramePage }) => {
+    const setId = await gramFramePage.addSidebandSet(30, 50, 10)
+    // Creation selects the set, which also gives the instance keyboard focus.
+    const before = await gramFramePage.getState()
+    expect(before.selection.selectedType).toBe('sidebandSet')
+    expect(before.selection.selectedId).toBe(setId)
+
+    await gramFramePage.page.keyboard.press('ArrowRight')
+    await gramFramePage.waitForState(
+      (state) => state.sidebands.sidebandSets[0].spacing > 10,
+      { message: 'the spacing to grow' }
+    )
+  })
+
+  test('a set survives a reload on a trainer page', async ({ page }) => {
+    await page.goto('/debug-trainer.html')
+    await page.locator('.gram-frame-container').first().waitFor()
+
+    const { GramFramePage } = await import('./helpers/gram-frame-page.js')
+    const gfp = new GramFramePage(page)
+    await gfp.clearStorage()
+    await page.reload()
+    await page.locator('.gram-frame-container').first().waitFor()
+
+    await gfp.clickMode('Sidebands')
+    const setId = await gfp.addSidebandSet(25, 40, 7.5)
+    // The save runs off a state notification, so wait for the write itself.
+    await page.waitForFunction(() => {
+      const raw = localStorage.getItem(`gramframe::${window.location.pathname}`)
+      return !!raw && raw.includes('sidebandSets')
+    })
+
+    await page.reload()
+    await page.locator('.gram-frame-container').first().waitFor()
+    await gfp.waitForSidebandSetCount(1)
+
+    const state = await gfp.getState()
+    const restored = state.sidebands.sidebandSets[0]
+    expect(restored.id).toBe(setId)
+    expect(restored.fundamentalFreq).toBeCloseTo(40, 5)
+    expect(restored.spacing).toBeCloseTo(7.5, 5)
+    // And it is drawn, not merely stored.
+    expect((await gfp.getSidebandIndices(setId)).length).toBeGreaterThan(0)
+  })
+})

--- a/tests/unit/mode-display-name.test.js
+++ b/tests/unit/mode-display-name.test.js
@@ -12,6 +12,7 @@ describe('getModeDisplayName', () => {
   test('maps every built-in mode', () => {
     expect(getModeDisplayName('analysis')).toBe('Cross Cursor')
     expect(getModeDisplayName('harmonics')).toBe('Harmonics')
+    expect(getModeDisplayName('sideband')).toBe('Sidebands')
     expect(getModeDisplayName('doppler')).toBe('Doppler')
     expect(getModeDisplayName('pan')).toBe('Pan')
   })

--- a/tests/unit/mode-registration.test.js
+++ b/tests/unit/mode-registration.test.js
@@ -92,7 +92,7 @@ const FROZEN_INITIAL_STATE = {
     selectedIndex: null
   },
   // --- contributed by the modes, in registration order --------------------
-  // Pan contributes no slice, which is why there are three and not four.
+  // Pan contributes no slice, which is why there are four and not five.
   analysis: {
     markers: []
   },
@@ -100,6 +100,12 @@ const FROZEN_INITIAL_STATE = {
     baseFrequency: null,
     harmonicData: [],
     harmonicSets: []
+  },
+  // Added when Sidebands mode landed (issue #241) — the one edit this frozen
+  // constant takes: a new mode's slice appears here, in registration order,
+  // and nothing else about the shape moves.
+  sidebands: {
+    sidebandSets: []
   },
   doppler: {
     fPlus: null,
@@ -165,12 +171,13 @@ describe('core/state.js stands alone (AS-2.2)', () => {
     expect(withoutVolatileKeys(core)).toEqual(
       Object.fromEntries(
         Object.entries(FROZEN_INITIAL_STATE)
-          .filter(([key]) => !['analysis', 'harmonics', 'doppler'].includes(key))
+          .filter(([key]) => !['analysis', 'harmonics', 'sidebands', 'doppler'].includes(key))
       )
     )
     // ...and no mode slice appears, because no mode was asked for one.
     expect(core.analysis).toBeUndefined()
     expect(core.harmonics).toBeUndefined()
+    expect(core.sidebands).toBeUndefined()
     expect(core.doppler).toBeUndefined()
   })
 

--- a/tests/unit/storage-validation.test.js
+++ b/tests/unit/storage-validation.test.js
@@ -28,6 +28,11 @@ const validRecord = () => ({
       { id: 'h1', color: '#2ecc71', anchorTime: 30, spacing: 12.5, symbol: 'cross', showPin: true }
     ]
   },
+  sidebands: {
+    sidebandSets: [
+      { id: 's1', color: '#45b7d1', anchorTime: 25, fundamentalFreq: 400, spacing: 12.5, symbol: 'cross', showPin: true }
+    ]
+  },
   doppler: {
     fPlus: { time: 40, freq: 900 },
     fMinus: { time: 20, freq: 880 },
@@ -42,6 +47,7 @@ describe('sanitizeStoredAnnotations (BH-1, BH-16)', () => {
     expect(dropped).toBe(0)
     expect(annotations.analysis.markers).toHaveLength(1)
     expect(annotations.harmonics.harmonicSets).toHaveLength(1)
+    expect(annotations.sidebands.sidebandSets).toHaveLength(1)
     expect(annotations.doppler.fPlus).toEqual({ time: 40, freq: 900 })
   })
 
@@ -145,6 +151,54 @@ describe('sanitizeStoredAnnotations (BH-1, BH-16)', () => {
   })
 })
 
+describe('sanitizeStoredAnnotations: sideband sets (issue #241)', () => {
+  it('discards a sideband set whose spacing is not strictly positive', () => {
+    for (const spacing of [0, -5, NaN, Infinity, '12k']) {
+      const rec = validRecord()
+      // @ts-ignore deliberate corruption
+      rec.sidebands.sidebandSets[0].spacing = spacing
+      const { annotations, dropped } = sanitizeStoredAnnotations(rec)
+      expect(annotations.sidebands.sidebandSets).toHaveLength(0)
+      expect(dropped).toBe(1)
+    }
+  })
+
+  it('discards a sideband set with no fundamental — its pins would have no origin', () => {
+    const rec = validRecord()
+    // @ts-ignore deliberate corruption
+    delete rec.sidebands.sidebandSets[0].fundamentalFreq
+    const { annotations, dropped } = sanitizeStoredAnnotations(rec)
+    expect(annotations.sidebands.sidebandSets).toHaveLength(0)
+    expect(dropped).toBe(1)
+  })
+
+  it('keeps a fundamental of 0 — the origin may legitimately sit at 0 Hz', () => {
+    const rec = validRecord()
+    rec.sidebands.sidebandSets[0].fundamentalFreq = 0
+    const { annotations, dropped } = sanitizeStoredAnnotations(rec)
+    expect(annotations.sidebands.sidebandSets).toHaveLength(1)
+    expect(dropped).toBe(0)
+  })
+
+  it('restores a legacy record that predates sidebands as having none', () => {
+    const rec = validRecord()
+    // @ts-ignore the section simply does not exist in older records
+    delete rec.sidebands
+    const { annotations, dropped } = sanitizeStoredAnnotations(rec)
+    expect(annotations.sidebands.sidebandSets).toEqual([])
+    expect(dropped).toBe(0)
+  })
+
+  it('counts a non-array sidebandSets as one dropped entry', () => {
+    const rec = validRecord()
+    // @ts-ignore deliberate corruption
+    rec.sidebands.sidebandSets = { id: 's1' }
+    const { annotations, dropped } = sanitizeStoredAnnotations(rec)
+    expect(annotations.sidebands.sidebandSets).toEqual([])
+    expect(dropped).toBe(1)
+  })
+})
+
 describe('buildGramFingerprint (BH-6, BH-23)', () => {
   it('uses the image URL basename and the four config ranges', () => {
     const state = /** @type {any} */ ({
@@ -193,7 +247,18 @@ describe('hasPersistableAnnotations covers fZero (BH-32)', () => {
     const state = /** @type {any} */ ({
       analysis: { markers: [] },
       harmonics: { harmonicSets: [] },
+      sidebands: { sidebandSets: [] },
       doppler: { fPlus: null, fMinus: null, fZero: { time: 1, freq: 2 } }
+    })
+    expect(hasPersistableAnnotations(state)).toBe(true)
+  })
+
+  it('a sideband set alone is persistable', () => {
+    const state = /** @type {any} */ ({
+      analysis: { markers: [] },
+      harmonics: { harmonicSets: [] },
+      sidebands: { sidebandSets: [{ id: 's1' }] },
+      doppler: { fPlus: null, fMinus: null, fZero: null }
     })
     expect(hasPersistableAnnotations(state)).toBe(true)
   })
@@ -202,6 +267,7 @@ describe('hasPersistableAnnotations covers fZero (BH-32)', () => {
     const state = /** @type {any} */ ({
       analysis: { markers: [] },
       harmonics: { harmonicSets: [] },
+      sidebands: { sidebandSets: [] },
       doppler: { fPlus: null, fMinus: null, fZero: null }
     })
     expect(hasPersistableAnnotations(state)).toBe(false)


### PR DESCRIPTION
Closes #241.

## What it does

A **Sidebands** mode, between Harmonics and Doppler. A sideband set is a harmonic set with its origin freed: pins spread equally each side of a fundamental the analyst places, rather than marching up from 0 Hz.

- **Click** sets the fundamental at that frequency and shows about eight sidebands spread across the axis — an equal count each side when the fundamental sits mid-axis, more on the roomier side when it does not (seed spacing = axis span / 8).
- **Drag the `0` line** to move the fundamental; **drag any other line** to set the spacing, holding the grabbed sideband under the cursor. A vertical drag moves the anchor time, as in Harmonics.
- Pins are labelled by signed offset — `0`, `+1`, `-1` … — and are drawn with the same pins, symbols, colours, dense-set sampling and **Tall Pins** toggle as harmonic sets.
- Sets are listed in a **Sidebands** table, selectable, nudgeable with the arrow keys, restyleable in place, and deletable.
- Sideband sets persist alongside markers, harmonic sets and doppler curves, and stay drawn in every mode.

## How it's built

Rather than a second copy of the harmonics renderer, the pin machinery is extracted into `src/modes/shared/PinSetMode.js`: pin geometry, the label/symbol stack, hit testing, the render loop, drag wiring and set add/update/remove. Harmonics and Sidebands each supply only where their sets live and what frequency a member index maps to (`freqForIndex`, `visibleIndexRange`, `nearestIndex`, `labelTextFor`, and what a drag means).

`HarmonicsMode.js` goes from 1054 lines to 373; its DOM (classes, `data-` attributes), behaviour and public seams are unchanged.

Alongside:

- **Persistence** — sidebands are written as an ADDITIVE storage section, so `SCHEMA_VERSION` does not move and existing records still restore. A stored set with a non-positive spacing or no fundamental is refused on load, like its harmonic counterpart.
- **A `PinSetOwner` capability** — `keyboardControl` and the pin toggle now find the mode that owns a selection type instead of reading `state.harmonics` directly, so selection, arrow-key nudging, restyling and deletion reach sidebands with no name-based branch. This removes the duplicated harmonic-set removal and move code (`instance.state` reach-ins: 170 → 160, baseline lowered).

## Layout

The markers, harmonics and sidebands tables are **all three permanently visible**, each in its own column — the sidebands table is not tied to its mode any more than the markers table is.

Two changes made room for the fourth column without the spectrogram moving:

- **The guidance panel fills its column and scrolls**, the same absolutely-positioned mechanism the tables beside it already use, instead of setting the control row's height. It was the guidance text that made a fourth table expensive: squeezed narrower, it wrapped to nearly twice the height and pushed the row — and the gram under it — ~80px down the page. The row is now as tall as the readouts and mode buttons need in every mode, so the gram sits at a **constant** height rather than moving as the analyst switches mode (it previously shifted ~40px between modes).
- **The mode buttons are tightened** (gap 8→4px, button padding 8→5px, command buttons 36→32px tall) so five rows occupy what four did.

The local debug pages pinned the component to 1020px, which is narrower than the row now wants (~1090px); they are widened to 1200px. Published material is laid out by OxygenXML, not by these pages.

## Testing

- `tests/sideband-mode.spec.js` — 14 new tests: button order, click-to-place, the spread and its equal spacing, the off-centre bias, signed labels, both drag meanings, both tables visible in every mode, the gram staying put across modes, the control row fitting with nothing cut off, delete from the table, cross-mode rendering, arrow-key nudging, and a trainer-page reload round trip.
- `tests/unit/storage-validation.test.js` — sideband record validation (bad spacing, missing fundamental, a legitimate 0 Hz fundamental, legacy records, non-array section).
- `tests/unit/mode-registration.test.js` — the frozen initial state takes the `sidebands` slice, in registration order.
- `yarn test` 322 passed, `yarn test:unit` 131 passed, `yarn typecheck`, `yarn lint`, `yarn hygiene` all clean. The WebKit smoke lane runs in CI (that browser is not installed in this environment) and passed there.

Docs updated: `docs/Gram-Modes.md` (a Sidebands section), `docs/Data-and-State-Guide.md`, `docs/HTML-Integration-Guide.md`, `README.md`, `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCjedbWsDgQyEEAefDGe39