### PR TITLE
Release v0.1.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spectro-component",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Bumps `package.json` to 0.1.17 so the tag and the injected bundle version match. No code changes.

## What's in v0.1.17 (18 commits since v0.1.16, 7 August)

- **Sidebands mode (#241)** — a pin set whose origin the analyst places, members spread each side of the fundamental and labelled by signed offset. Its panel sits beside the harmonics table so both stay visible.
- **Doppler markers are grabbable (#240)** — with cursor feedback on hover.
- **On-gram labels** — drawn on a white rounded plate instead of a halo (#243), and dropped below an upward-pointing triangle so the apex still points at its data (#242).
- **Control row height** — Style heading dropped, doppler LED inlined, panel headings aligned, marker rows halved, table rows pinned against resizing, and a newly added row kept in view.
- **Housekeeping** — lint backlog cleared and the warning ratchet closed at zero; a note that Codespaces opens in Edge, not Chrome, on this machine.

## Verification

CI's full lane — hygiene ratchets, lint, typecheck, unit tests, build, Playwright and the WebKit smoke test — passed on main at d09c086, the commit this release tags. The release workflow re-runs typecheck, the standalone build and the full Playwright suite when the tag is pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)